### PR TITLE
fix(openstack): support auto auth renewal for openstack access

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -96,7 +96,7 @@ const docTemplate = `{
                                 },
                                 "msg": {
                                     "type": "string",
-                                    "example": "failed to fetch events: internal server error"
+                                    "example": "failed to fetch data centers: internal server error"
                                 },
                                 "status": {
                                     "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -92,7 +92,7 @@
                                 },
                                 "msg": {
                                     "type": "string",
-                                    "example": "failed to fetch events: internal server error"
+                                    "example": "failed to fetch data centers: internal server error"
                                 },
                                 "status": {
                                     "type": "string",

--- a/configs/cube-cos-api.yaml
+++ b/configs/cube-cos-api.yaml
@@ -42,6 +42,7 @@ spec:
         url: "http://10.32.10.113:5000/v3"
         username: "admin_cli"
         password: "dk7LPiAZHTiC1mce"
+        enableAutoRenew: true
         project:
           name: "admin"
           domain:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bigstack-oss/cube-cos-api
 go 1.22.2
 
 require (
-	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250120173251-736764286959
+	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250121124706-d8117847670b
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/crewjam/saml v0.4.14
 	github.com/gin-gonic/gin v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250120165326-1c2791f8253
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250120165326-1c2791f82532/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250120173251-736764286959 h1:BmOytbUp+TWmcal1bneq+SgmC3BO0je0XG2fnVmRhVc=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250120173251-736764286959/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250121124706-d8117847670b h1:1Kmv6abkeSIos/I5ocbH8j+eSmoPo7Y2rBHfTgtiPgI=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250121124706-d8117847670b/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/api/v1/logout/handlers.go
+++ b/internal/api/v1/logout/handlers.go
@@ -13,7 +13,7 @@ var (
 	Handlers = []api.Handler{
 		{
 			Version:              api.V1,
-			Method:               http.MethodGet,
+			Method:               http.MethodPost,
 			Path:                 "/logout",
 			Func:                 logout,
 			IsNotUnderDataCenter: true,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -252,6 +252,7 @@ func newGlobalOpenstackHelper(opts openstack.Options) error {
 	return openstack.NewGlobalHelper(
 		openstack.AuthType(opts.Auth.Type),
 		openstack.AuthUrl(opts.Auth.Url),
+		openstack.EnableAutoRenew(opts.Auth.EnableAutoRenew),
 		openstack.ProjectName(opts.Auth.Project.Name),
 		openstack.ProjectDomainName(opts.Auth.Project.Domain.Name),
 		openstack.Username(opts.Auth.Username),


### PR DESCRIPTION
<br/>

### ▎Main Changes

<br/>

As titled. During testing after placed the cos-api for a few hours, I realized we should enable the auto auth renewal in the openstack helper especially for global helper.


<br/>


---

<br/>

### ▎Test Results

<br/>

Before, after deployed for 1 hr, the inner openstack token in the helper will be expired and can't works anymore.

![Screenshot 2025-01-21 at 8 35 33 PM](https://github.com/user-attachments/assets/e9f1f571-49c9-46f5-a2f5-c156d66ccead)

<br/>

After fixed and test with the same scenario above, has confirmed the openstack involved apis can works well by auto token renewal  

![Screenshot 2025-01-21 at 10 09 52 PM](https://github.com/user-attachments/assets/b7d753e7-ec9c-4b8f-b2e8-428608530af5)




