### PR TITLE
[#28] feat(conf): make the opts which read from file can be overrode by flag args

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"flag"
-
 	_ "github.com/bigstack-oss/cube-cos-api/api"
 	"github.com/bigstack-oss/cube-cos-api/internal/config"
 	"github.com/bigstack-oss/cube-cos-api/internal/runtime"
@@ -10,17 +8,8 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
-var (
-	conf string
-)
-
-func init() {
-	flag.StringVar(&conf, "conf", "", "")
-	flag.Parse()
-}
-
 func main() {
-	err := config.InitServerOpts(conf)
+	err := config.ReadAndOverrideOpts()
 	if err != nil {
 		log.Errorf("failed to load config: %s", err.Error())
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"flag"
+
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/influx"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/keycloak"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/log"
@@ -16,8 +18,54 @@ import (
 )
 
 var (
-	Opts Options
+	confile string
+	Opts    Options
 )
+
+func init() {
+	flag.StringVar(&confile, "conf", "/etc/cube-cos-api/cube-cos-api.yaml", "")
+	flag.StringVar(&Opts.Spec.Listen.Address.Local, "listen.address.local", Opts.Spec.Listen.Address.Local, "")
+	flag.StringVar(&Opts.Spec.Listen.Address.Advertise, "listen.address.advertise", Opts.Spec.Listen.Address.Advertise, "")
+	flag.IntVar(&Opts.Spec.Listen.Port, "listen.port", Opts.Spec.Listen.Port, "")
+	flag.StringVar(&Opts.Spec.Identity.OsPolicy, "identity.osPolicy", Opts.Spec.Identity.OsPolicy, "")
+	flag.StringVar(&Opts.Spec.Identity.LogoutRedirect, "identity.logoutRedirect", Opts.Spec.Identity.LogoutRedirect, "")
+	flag.StringVar(&Opts.Spec.Identity.Keycloak.Host, "identity.keycloak.host", Opts.Spec.Identity.Keycloak.Host, "")
+	flag.StringVar(&Opts.Spec.Identity.Keycloak.Realm, "identity.keycloak.realm", Opts.Spec.Identity.Keycloak.Realm, "")
+	flag.StringVar(&Opts.Spec.Identity.Keycloak.Auth.Username, "identity.keycloak.auth.username", Opts.Spec.Identity.Keycloak.Auth.Username, "")
+	flag.StringVar(&Opts.Spec.Identity.Keycloak.Auth.Password, "identity.keycloak.auth.password", Opts.Spec.Identity.Keycloak.Auth.Password, "")
+	flag.BoolVar(&Opts.Spec.Identity.Keycloak.TlsInsecureSkipVerify, "identity.keycloak.tlsInsecureSkipVerify", Opts.Spec.Identity.Keycloak.TlsInsecureSkipVerify, "")
+	flag.StringVar(&Opts.Spec.Identity.Saml.IdentityProvider.MetadataPath, "identity.saml.identityProvider.metadataPath", Opts.Spec.Identity.Saml.IdentityProvider.MetadataPath, "")
+	flag.StringVar(&Opts.Spec.Identity.Saml.IdentityProvider.Host.Scheme, "identity.saml.identityProvider.host.scheme", Opts.Spec.Identity.Saml.IdentityProvider.Host.Scheme, "")
+	flag.IntVar(&Opts.Spec.Identity.Saml.IdentityProvider.Host.Port, "identity.saml.identityProvider.host.port", Opts.Spec.Identity.Saml.IdentityProvider.Host.Port, "")
+	flag.BoolVar(&Opts.Spec.Identity.Saml.IdentityProvider.TlsInsecureSkipVerify, "identity.saml.identityProvider.tlsInsecureSkipVerify", Opts.Spec.Identity.Saml.IdentityProvider.TlsInsecureSkipVerify, "")
+	flag.StringVar(&Opts.Spec.Identity.Saml.ServiceProvider.MetadataPath, "identity.saml.serviceProvider.metadataPath", Opts.Spec.Identity.Saml.ServiceProvider.MetadataPath, "")
+	flag.StringVar(&Opts.Spec.Identity.Saml.ServiceProvider.Host.Scheme, "identity.saml.serviceProvider.host.scheme", Opts.Spec.Identity.Saml.ServiceProvider.Host.Scheme, "")
+	flag.IntVar(&Opts.Spec.Identity.Saml.ServiceProvider.Host.Port, "identity.saml.serviceProvider.host.port", Opts.Spec.Identity.Saml.ServiceProvider.Host.Port, "")
+	flag.BoolVar(&Opts.Spec.Identity.Saml.ServiceProvider.TlsInsecureSkipVerify, "identity.saml.serviceProvider.tlsInsecureSkipVerify", Opts.Spec.Identity.Saml.ServiceProvider.TlsInsecureSkipVerify, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.K3s.Auth, "resourceControl.k3s.auth", Opts.Spec.ResourceControl.K3s.Auth, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.ConfFile, "resourceControl.openstack.confFile", Opts.Spec.ResourceControl.Openstack.ConfFile, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.Auth.Type, "resourceControl.openstack.auth.type", Opts.Spec.ResourceControl.Openstack.Auth.Type, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.Auth.Url, "resourceControl.openstack.auth.url", Opts.Spec.ResourceControl.Openstack.Auth.Url, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.Auth.Username, "resourceControl.openstack.auth.username", Opts.Spec.ResourceControl.Openstack.Auth.Username, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.Auth.Password, "resourceControl.openstack.auth.password", Opts.Spec.ResourceControl.Openstack.Auth.Password, "")
+	flag.BoolVar(&Opts.Spec.ResourceControl.Openstack.Auth.EnableAutoRenew, "resourceControl.openstack.auth.enableAutoRenew", Opts.Spec.ResourceControl.Openstack.Auth.EnableAutoRenew, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.Auth.Project.Name, "resourceControl.openstack.auth.project.name", Opts.Spec.ResourceControl.Openstack.Auth.Project.Name, "")
+	flag.StringVar(&Opts.Spec.ResourceControl.Openstack.Auth.Project.Domain.Name, "resourceControl.openstack.auth.project.domain.name", Opts.Spec.ResourceControl.Openstack.Auth.Project.Domain.Name, "")
+	flag.StringVar(&Opts.Spec.Store.InfluxDB.Url, "store.influxdb.url", Opts.Spec.Store.InfluxDB.Url, "")
+	flag.StringVar(&Opts.Spec.Store.MongoDB.Uri, "store.mongodb.uri", Opts.Spec.Store.MongoDB.Uri, "")
+	flag.StringVar(&Opts.Spec.Store.MongoDB.Database, "store.mongodb.database", Opts.Spec.Store.MongoDB.Database, "")
+	flag.StringVar(&Opts.Spec.Store.MongoDB.ReplicaSet, "store.mongodb.replicaSet", Opts.Spec.Store.MongoDB.ReplicaSet, "")
+	flag.BoolVar(&Opts.Spec.Store.MongoDB.Auth.Enable, "store.mongodb.auth.enable", Opts.Spec.Store.MongoDB.Auth.Enable, "")
+	flag.StringVar(&Opts.Spec.Store.MongoDB.Auth.Username, "store.mongodb.auth.username", Opts.Spec.Store.MongoDB.Auth.Username, "")
+	flag.StringVar(&Opts.Spec.Store.MongoDB.Auth.Password, "store.mongodb.auth.password", Opts.Spec.Store.MongoDB.Auth.Password, "")
+	flag.IntVar(&Opts.Spec.Observability.Log.Level, "observability.log.level", Opts.Spec.Observability.Log.Level, "")
+	flag.StringVar(&Opts.Spec.Observability.Log.File, "observability.log.file", Opts.Spec.Observability.Log.File, "")
+	flag.IntVar(&Opts.Spec.Observability.Log.Rotation.Backups, "observability.log.rotation.backups", Opts.Spec.Observability.Log.Rotation.Backups, "")
+	flag.IntVar(&Opts.Spec.Observability.Log.Rotation.Size, "observability.log.rotation.size", Opts.Spec.Observability.Log.Rotation.Size, "")
+	flag.IntVar(&Opts.Spec.Observability.Log.Rotation.TTL, "observability.log.rotation.ttl", Opts.Spec.Observability.Log.Rotation.TTL, "")
+	flag.BoolVar(&Opts.Spec.Observability.Log.Rotation.Compress, "observability.log.rotation.compress", Opts.Spec.Observability.Log.Rotation.Compress, "")
+	flag.Parse()
+}
 
 type Options struct {
 	Kind     string `json:"kind" yaml:"kind"`
@@ -83,13 +131,33 @@ func (o *Options) String() (string, error) {
 	return string(b), nil
 }
 
-func InitServerOpts(filePath string) error {
+func ReadAndOverrideOpts() error {
+	err := parseOptsFromFile()
+	if err != nil {
+		return err
+	}
+
+	overrideOptsFromFlagArgs()
+	return nil
+}
+
+func newConfiger() (config.Config, error) {
+	return config.NewConfig(
+		config.WithReader(
+			json.NewReader(
+				reader.WithEncoder(yaml.NewEncoder()),
+			),
+		),
+	)
+}
+
+func parseOptsFromFile() error {
 	conf, err := newConfiger()
 	if err != nil {
 		return err
 	}
 
-	src := file.NewSource(file.WithPath(filePath))
+	src := file.NewSource(file.WithPath(confile))
 	err = conf.Load(src)
 	if err != nil {
 		return err
@@ -103,12 +171,6 @@ func InitServerOpts(filePath string) error {
 	return nil
 }
 
-func newConfiger() (config.Config, error) {
-	return config.NewConfig(
-		config.WithReader(
-			json.NewReader(
-				reader.WithEncoder(yaml.NewEncoder()),
-			),
-		),
-	)
+func overrideOptsFromFlagArgs() {
+	flag.Parse()
 }


### PR DESCRIPTION
<br/>

### ▎Main Changes

<br/>

make the opts which read from file can be overrode by flag args.

this could increase the flexibility for the deployment of hex_config and troubleshooting.

<br/>

📔 notice: 

same as the most of related design, the priority of value overriding is flag set values > file values

<br/>

---

<br/>

### ▎Test Results

<br/>

1). make sure the service still works well without specifying any args, and all values are matched with the specified file

![Screenshot 2025-01-29 at 8 13 28 PM](https://github.com/user-attachments/assets/fc8944c3-77b3-4853-945a-8db01cf261e8)

<br/>

2). try to start service with 2 args `-observability.log.level 999` and `-listen.port 8002`, and make sure both args have been overrode the values from file successfully

![Screenshot 2025-01-29 at 8 06 03 PM](https://github.com/user-attachments/assets/89a5791c-8e73-495d-b993-0b2279fb9195)
![Screenshot 2025-01-29 at 8 06 18 PM](https://github.com/user-attachments/assets/6f5e8679-fe2c-4174-a973-9f80480abe45)


