### PR TITLE
[Extra] feat(summary): support server side streaming by http chunked transfer

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1048,6 +1048,16 @@ const docTemplate = `{
                         },
                         "description": "The name of the data center to operate",
                         "example": "test-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The flag to watch the summary data center in real-time (default is false).",
+                        "example": true
                     }
                 ],
                 "responses": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -1044,6 +1044,16 @@
                         },
                         "description": "The name of the data center to operate",
                         "example": "test-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The flag to watch the summary data center in real-time (default is false).",
+                        "example": true
                     }
                 ],
                 "responses": {

--- a/internal/api/v1/summary/handlers.go
+++ b/internal/api/v1/summary/handlers.go
@@ -20,35 +20,29 @@ var (
 	}
 )
 
+func init() {
+	go onDemandStreamSummary()
+}
+
 func getSummary(c *gin.Context) {
-	vmStatusOverview, err := cubecos.GetVmStatusOverview()
+	summary, err := cubecos.GetDataCenterSummary()
 	if err != nil {
-		log.Errorf("request(%s): failed to get vm status overview: %v", api.GetReqId(c), err)
+		log.Errorf("request(%s): failed to fetch data center summary: %v", api.GetReqId(c), err)
 		api.SetInternalServerError(c, err)
 		return
 	}
 
-	resourceMetrics, err := cubecos.GetResourceMetrics()
+	watch, err := parseWatch(c)
 	if err != nil {
-		log.Errorf("request(%s): failed to get resource metrics: %v", api.GetReqId(c), err)
-		api.SetInternalServerError(c, err)
+		log.Errorf("request(%s): failed to parse watch query: %v", api.GetReqId(c), err)
+		api.SetBadRequest(c, err)
 		return
 	}
 
-	roleOverview, err := cubecos.GetRoleOverview()
-	if err != nil {
-		log.Errorf("request(%s): failed to get role overview: %v", api.GetReqId(c), err)
-		api.SetInternalServerError(c, err)
+	if !watch {
+		api.SetStatusOk(c, "fetch summary successfully", summary)
 		return
 	}
 
-	api.SetStatusOk(
-		c,
-		"fetch summary successfully",
-		cubecos.Summary{
-			Vm:      *vmStatusOverview,
-			Role:    *roleOverview,
-			Metrics: *resourceMetrics,
-		},
-	)
+	watchSummary(c, summary)
 }

--- a/internal/api/v1/summary/request.go
+++ b/internal/api/v1/summary/request.go
@@ -1,0 +1,18 @@
+package summary
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+func parseWatch(c *gin.Context) (bool, error) {
+	rawParam := c.DefaultQuery("watch", "false")
+	watch, err := strconv.ParseBool(rawParam)
+	if err != nil {
+		return false, errors.New("watch parameter is invalid, it should be true or false if provided")
+	}
+
+	return watch, nil
+}

--- a/internal/api/v1/summary/watch.go
+++ b/internal/api/v1/summary/watch.go
@@ -1,0 +1,127 @@
+package summary
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/wait"
+	"github.com/gin-gonic/gin"
+	json "github.com/json-iterator/go"
+	log "go-micro.dev/v5/logger"
+)
+
+type watcher chan cubecos.Summary
+
+var (
+	stream = struct {
+		sync.Mutex
+		Watchers []watcher
+	}{}
+)
+
+func onDemandStreamSummary() {
+	for {
+		wait.Seconds(2)
+		if len(stream.Watchers) == 0 {
+			continue
+		}
+
+		summary, err := cubecos.GetDataCenterSummary()
+		if err != nil {
+			log.Errorf("summary: failed to fetch data center summary: %v", err)
+			continue
+		}
+
+		stream.Lock()
+		for _, w := range stream.Watchers {
+			select {
+			case w <- *summary:
+			default:
+			}
+		}
+
+		stream.Unlock()
+	}
+}
+
+func watchSummary(c *gin.Context, summary *cubecos.Summary) {
+	setChunkedTransfer(c)
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		api.SetBadRequest(c, errors.New("http chunked transfer is not supported"))
+		return
+	}
+
+	watcher := make(watcher)
+	addWatcher(watcher)
+	defer removeWatcher(watcher)
+
+	sendFirstSummary(c, flusher, summary)
+	streamingSummary(c, flusher, watcher)
+}
+
+func setChunkedTransfer(c *gin.Context) {
+	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	c.Writer.Header().Set("Transfer-Encoding", "chunked")
+}
+
+func addWatcher(w watcher) {
+	stream.Lock()
+	stream.Watchers = append(stream.Watchers, w)
+	stream.Unlock()
+}
+
+func removeWatcher(watcherToRemove watcher) {
+	stream.Lock()
+	defer stream.Unlock()
+
+	for i, watcher := range stream.Watchers {
+		if watcher != watcherToRemove {
+			continue
+		}
+
+		stream.Watchers = append(
+			stream.Watchers[:i],
+			stream.Watchers[i+1:]...,
+		)
+		return
+	}
+}
+
+func sendFirstSummary(c *gin.Context, flusher http.Flusher, summary *cubecos.Summary) {
+	c.Writer.Write(streamingResp(summary))
+	c.Writer.Write([]byte("\n"))
+	flusher.Flush()
+}
+
+func streamingSummary(c *gin.Context, flusher http.Flusher, watcher watcher) {
+	ctx := c.Request.Context()
+	for {
+		select {
+		case summary := <-watcher:
+			c.Writer.Write(streamingResp(&summary))
+			c.Writer.Write([]byte("\n"))
+			flusher.Flush()
+		case <-ctx.Done():
+			api.SetStatusOk(c, "summary watching is stopped successfully", nil)
+			return
+		}
+	}
+}
+
+func streamingResp(summary *cubecos.Summary) []byte {
+	b, err := json.Marshal(gin.H{
+		"code":   http.StatusOK,
+		"status": "ok",
+		"msg":    "fetch data center summary successfully",
+		"data":   *summary,
+	})
+	if err != nil {
+		return []byte{}
+	}
+
+	return b
+}

--- a/internal/cubecos/cluster.go
+++ b/internal/cubecos/cluster.go
@@ -43,3 +43,26 @@ func GetDataCenterName() (string, error) {
 
 	return ReadHexTuning(CubeSysController)
 }
+
+func GetDataCenterSummary() (*Summary, error) {
+	resourceMetrics, err := GetResourceMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	roleOverview, err := GetRoleOverview()
+	if err != nil {
+		return nil, err
+	}
+
+	vmStatusOverview, err := GetVmStatusOverview()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Summary{
+		Metrics: *resourceMetrics,
+		Role:    *roleOverview,
+		Vm:      *vmStatusOverview,
+	}, nil
+}

--- a/internal/cubecos/statistic.go
+++ b/internal/cubecos/statistic.go
@@ -1,6 +1,8 @@
 package cubecos
 
 import (
+	json "github.com/json-iterator/go"
+
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 )
 
@@ -26,4 +28,13 @@ type Role struct {
 	Compute          int `json:"compute"`
 	Storage          int `json:"storage"`
 	Others           int `json:"others"`
+}
+
+func (s *Summary) Bytes() []byte {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return []byte{}
+	}
+
+	return b
 }

--- a/internal/operators/v1/healths/healths.go
+++ b/internal/operators/v1/healths/healths.go
@@ -1,11 +1,10 @@
 package healths
 
 import (
-	"time"
-
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/bigstack-oss/cube-cos-api/internal/service"
+	"github.com/bigstack-oss/cube-cos-api/internal/wait"
 	log "go-micro.dev/v5/logger"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -56,6 +55,6 @@ func (o *Operator) Stop() {
 
 func (o *Operator) waitForLastTask() {
 	for ReqQueue.Len() >= 1 {
-		time.Sleep(time.Second * 1)
+		wait.Seconds(1)
 	}
 }

--- a/internal/operators/v1/tunings/tuning.go
+++ b/internal/operators/v1/tunings/tuning.go
@@ -1,11 +1,10 @@
 package tunings
 
 import (
-	"time"
-
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/bigstack-oss/cube-cos-api/internal/service"
+	"github.com/bigstack-oss/cube-cos-api/internal/wait"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -52,6 +51,6 @@ func (o *Operator) Stop() {
 
 func (o *Operator) waitForLastTask() {
 	for ReqQueue.Len() >= 1 {
-		time.Sleep(time.Second * 1)
+		wait.Seconds(1)
 	}
 }

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -1,0 +1,7 @@
+package wait
+
+import "time"
+
+func Seconds(s time.Duration) {
+	time.Sleep(s * time.Second)
+}


### PR DESCRIPTION
<br/>

### ▎Main Changes

<br/>

Support `watch` query toggle to do the http streaming in the Summary GET API.

The behavior is

- can be enabled by `summary?watch=true` like how k8s operate the `list-watch`
- if `watch` is not specified, the it will be just like the normal GET
- if FE called by `watch=true`, then they don't need to care about the `polling` or `refresh interval` anymore, all of update will be controlled by API, they just need to receive the data.
- this is not the `duplex` like websocket, but it's enough for most of cases in our UI update, also more easier to develop and less dependency if comparing to the `duplex` technique

<br/>

📔 have to POC/check with FE and based on their comment to remove this feature or apply it to other GET/LIST APIs

<br/>

---

<br/>

### ▎Test Results

<br/>

1). make sure the summary data will be updated to client continuously when `watch=true` is specified

https://github.com/user-attachments/assets/424d069b-9682-4da3-8d4e-f33b092d9439

<br/>

2). make sure the original GET behavior without specifying the `watch` is not impacted

<img width="864" alt="Screenshot 2025-01-30 at 10 48 30 PM" src="https://github.com/user-attachments/assets/4414de50-c8f1-4430-a4d8-427408ba5dd7" />

<br/>

<br/>

3). make sure the request will be blocked if `watch` has an invalid value

![Screenshot 2025-01-30 at 10 57 21 PM](https://github.com/user-attachments/assets/0a103d0c-d76e-4801-9242-b6aaf1cfca0b)

<br/>

4). make sure the API doc has been updated with the corresponding changes

<img width="1431" alt="Screenshot 2025-01-30 at 11 17 08 PM" src="https://github.com/user-attachments/assets/d1d9b517-02ff-4c59-9a06-abe936ce0d23" />






