### PR TITLE
refactor(registry): use data center name to join and watch the peer nodes instead of role name

### DIFF
--- a/api/docs.json
+++ b/api/docs.json
@@ -1,13 +1,11 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "description": "{{escape .Description}}",
-        "title": "{{.Title}}",
+        "description": "",
+        "title": "Cube COS API",
         "contact": {},
-        "version": "{{.Version}}"
+        "version": "1.0.0"
     },
-    "host": "{{.Host}}",
-    "basePath": "{{.BasePath}}",
     "paths": {
         "/api/v1/logout": {
             "post": {
@@ -25,12 +23,6 @@
         "/api/v1/datacenters": {
             "get": {
                 "description": "Retrieve the list of data centers",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "Data Centers"
                 ],
@@ -806,7 +798,7 @@
                                                                             "example": 31
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.75
                                                                         },
                                                                         "freeCores": {
@@ -814,7 +806,7 @@
                                                                             "example": 49
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.25
                                                                         }
                                                                     }
@@ -831,7 +823,7 @@
                                                                             "example": 98255
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.2
                                                                         },
                                                                         "freeMiB": {
@@ -839,7 +831,7 @@
                                                                             "example": 159116
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.8
                                                                         }
                                                                     }
@@ -856,7 +848,7 @@
                                                                             "example": 51200
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         },
                                                                         "freeMiB": {
@@ -864,7 +856,7 @@
                                                                             "example": 51200
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         }
                                                                     }
@@ -928,11 +920,11 @@
                                                                             "example": 49
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.75
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.25
                                                                         }
                                                                     }
@@ -953,11 +945,11 @@
                                                                             "example": 159116
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.2
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.8
                                                                         }
                                                                     }
@@ -978,11 +970,11 @@
                                                                             "example": 51200
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         }
                                                                     }
@@ -1368,11 +1360,11 @@
                                                     "example": 49
                                                 },
                                                 "usedPercent": {
-                                                    "type": "float",
+                                                    "type": "number",
                                                     "example": 38.75
                                                 },
                                                 "freePercent": {
-                                                    "type": "float",
+                                                    "type": "number",
                                                     "example": 61.25
                                                 }
                                             }
@@ -1500,7 +1492,7 @@
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "bytes": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 682.6666
                                                             }
                                                         }
@@ -1516,7 +1508,7 @@
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "bytes": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 4.5
                                                             }
                                                         }
@@ -1647,7 +1639,7 @@
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ops": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 1.0833
                                                             }
                                                         }
@@ -1663,7 +1655,7 @@
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ops": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 5.8166
                                                             }
                                                         }
@@ -1794,7 +1786,7 @@
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ms": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 10736.9833
                                                             }
                                                         }
@@ -1810,7 +1802,7 @@
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ms": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 1615349.9
                                                             }
                                                         }
@@ -1922,11 +1914,11 @@
                                                         "example": "test-data-center"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 24.6699
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 75.3301
                                                     }
                                                 }
@@ -2036,11 +2028,11 @@
                                                         "example": "test-data-center"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 10.5263
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 89.4737
                                                     }
                                                 }
@@ -2150,11 +2142,11 @@
                                                         "example": "test-data-center"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 52.6702
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 47.3298
                                                     }
                                                 }
@@ -2264,7 +2256,7 @@
                                                         "example": "test-data-center"
                                                     },
                                                     "packets": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 5392.2666
                                                     }
                                                 }
@@ -2374,7 +2366,7 @@
                                                         "example": "test-data-center"
                                                     },
                                                     "packets": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 1724.5302
                                                     }
                                                 }
@@ -2484,11 +2476,11 @@
                                                         "example": "test-vm"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 10.5263
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 89.4737
                                                     }
                                                 }
@@ -2598,11 +2590,11 @@
                                                         "example": "test-vm"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 35.0991
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 64.9009
                                                     }
                                                 }
@@ -2716,7 +2708,7 @@
                                                         "example": "sda"
                                                     },
                                                     "usage": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 184266.4594
                                                     }
                                                 }
@@ -2830,7 +2822,7 @@
                                                         "example": "sda"
                                                     },
                                                     "usage": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 45443.764
                                                     }
                                                 }
@@ -3012,7 +3004,7 @@
                                                                         "type": "object",
                                                                         "properties": {
                                                                             "uptime": {
-                                                                                "type": "int",
+                                                                                "type": "number",
                                                                                 "example": 99.99
                                                                             },
                                                                             "period": {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0
-	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202082555-9061781b157d
+	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/coreos/go-oidc v2.3.0+incompatible
 	github.com/crewjam/saml v0.4.14

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202065107-8db34cdde7b
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202065107-8db34cdde7b7/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202082555-9061781b157d h1:1uKJa7FIV+oaqe1F8e9J3A4B9UHTKWKgEguuVOZf1/8=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202082555-9061781b157d/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af h1:oN/N/CqtbVj+HJdp+TlDcYztEh5aHp3SapFUjOcFBrU=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/operators/v1/node/log-throttling.go
+++ b/internal/operators/v1/node/log-throttling.go
@@ -52,8 +52,8 @@ func logWithThrottling(event *registry.Result) {
 
 	log.Infof(
 		"node resynced: %s %s %s",
-		event.Service.Name,
-		fmt.Sprintf("%s(%s)", event.Service.Metadata["hostname"], event.Service.Nodes[0].Address),
+		event.Service.Nodes[0].Metadata["role"],
+		fmt.Sprintf("%s(%s)", event.Service.Nodes[0].Metadata["hostname"], event.Service.Nodes[0].Address),
 		convertAction(event.Action),
 	)
 }

--- a/internal/operators/v1/node/node.go
+++ b/internal/operators/v1/node/node.go
@@ -36,7 +36,9 @@ func (o *Operator) Name() string {
 }
 
 func (o *Operator) Sync() {
-	watcher, err := registry.Watch()
+	watcher, err := registry.Watch(
+		registry.WatchService(definition.DataCenterName),
+	)
 	if err != nil {
 		log.Errorf("failed to create watcher (%s)", err.Error())
 		return

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -78,6 +78,7 @@ func initNodePeerSyncer() {
 
 func genMetadata() map[string]string {
 	return map[string]string{
+		"role":         definition.CurrentRole,
 		"hostname":     definition.Hostname,
 		"nodeID":       definition.HostID,
 		"isGpuEnabled": fmt.Sprintf("%t", definition.IsGpuEnabled),

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -25,7 +25,7 @@ func newHttpServer() (*server.Server, error) {
 	}
 
 	srv := http.NewServer(
-		server.Name(definition.CurrentRole),
+		server.Name(definition.DataCenterName),
 		server.Metadata(genMetadata()),
 		server.WithLogger(log.DefaultLogger),
 		server.Address(genLocalAddr()),


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

#73 

<br/>

### What this PR does?

Use data center name to join and watch the peer nodes instead of role name.

Otherwise, the service might watch or register on the wrong service group.

<br/>

### Test results (optional)

Before: registered by `role` name will resync the node which not belongs to the same data center.

![Screenshot 2025-02-05 at 3 20 14 AM](https://github.com/user-attachments/assets/17561299-1f7c-4468-8519-fce3e49644b7)

<br/>

After: registered by `data center` name to make sure the synced nodes belong to the current data center

![Screenshot 2025-02-05 at 3 20 26 AM](https://github.com/user-attachments/assets/7386a6eb-40a6-48fd-a739-165dd0e6e9d1)

![Screenshot 2025-02-05 at 3 18 37 AM](https://github.com/user-attachments/assets/107634e7-5ac5-4e60-9ae6-5c72734f1f49)

