### PR TITLE
fix the wrong lib lifecycle control by adjusting the operator interface and initiation procedure

### DIFF
--- a/internal/operators/v1/healths/healths.go
+++ b/internal/operators/v1/healths/healths.go
@@ -16,17 +16,17 @@ var (
 
 func init() {
 	ReqQueue = workqueue.New()
-	service.RegisterOperator(module, NewOperator())
-}
-
-func NewOperator() *Operator {
-	return &Operator{}
+	service.RegisterOperator(module, &Operator{})
 }
 
 type Operator struct{}
 
 func (o *Operator) Name() string {
 	return module
+}
+
+func (o *Operator) Init() error {
+	return nil
 }
 
 func (o *Operator) Sync() {

--- a/internal/operators/v1/node/node.go
+++ b/internal/operators/v1/node/node.go
@@ -22,17 +22,16 @@ type Operator struct {
 	isFirstTimeSync bool
 }
 
-func NewOperator() *Operator {
-	ctx, cancel := context.WithCancel(context.Background())
-	return &Operator{
-		ctx:             ctx,
-		cancel:          cancel,
-		isFirstTimeSync: true,
-	}
-}
-
 func (o *Operator) Name() string {
 	return module
+}
+
+func (o *Operator) Init() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	o.ctx = ctx
+	o.cancel = cancel
+	o.isFirstTimeSync = true
+	return nil
 }
 
 func (o *Operator) Sync() {

--- a/internal/operators/v1/tunings/tuning.go
+++ b/internal/operators/v1/tunings/tuning.go
@@ -1,6 +1,8 @@
 package tunings
 
 import (
+	"errors"
+
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
@@ -23,11 +25,20 @@ type Operator struct {
 }
 
 func NewOperator() *Operator {
-	return &Operator{mongo: mongo.GetGlobalHelper()}
+	return &Operator{}
 }
 
 func (o *Operator) Name() string {
 	return module
+}
+
+func (o *Operator) Init() error {
+	o.mongo = mongo.GetGlobalHelper()
+	if o.mongo == nil {
+		return errors.New("mongo helper is not initialized")
+	}
+
+	return nil
 }
 
 func (o *Operator) Sync() {

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -73,7 +73,7 @@ func initNodeIdentities() error {
 }
 
 func initNodePeerSyncer() {
-	service.RegisterOperator(node.Name(), node.NewOperator())
+	service.RegisterOperator(node.Name(), &node.Operator{})
 }
 
 func genMetadata() map[string]string {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -18,6 +18,7 @@ var (
 
 type Operator interface {
 	Name() string
+	Init() error
 	Sync()
 	Stop()
 }
@@ -46,14 +47,20 @@ func WrapGoMicro(server *server.Server) micro.Service {
 
 func runOperators() error {
 	for _, o := range Operators {
-		go run(o.Sync)
+		err := o.Init()
+		if err != nil {
+			log.Errorf("operator: %s init failed: %v: ", o.Name(), err)
+			return err
+		}
+
+		go runInBackground(o.Sync)
 		log.Infof("operator: %s is running", o.Name())
 	}
 
 	return nil
 }
 
-func run(f func()) {
+func runInBackground(f func()) {
 	for {
 		f()
 	}


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

#78 

<br/>

### What this PR does?

This is a great catch by @arasHi87 , sorry that I didn't aware this before.

I fix the wrong lib lifecycle control by adjusting the operator interface and initiation procedure, to make sure the dependency relationship is right in process, so that it can run and shutdown properly without hitting the panic

<br/>

### Test results (optional)

Before: as Arashi mentioned, the process shutdown got panic

![Screenshot 2025-02-05 at 7 13 56 PM](https://github.com/user-attachments/assets/fe573c35-c76f-461c-a14e-d65f2fd5a48b)


<br/>

After: has confirmed no panic will be hit during shutting down (the logs are captured by `journalctl -f -u cube-cos-api`)

📔 another tricky symptom I found is that the systemd seems like won't print out the panic message into /var/log/cube-cos-api/cube-cos-api.log, I'll figure it out

![Screenshot 2025-02-05 at 7 03 49 PM](https://github.com/user-attachments/assets/e1c6a373-94b9-478d-8840-7307e5f8e387)


