### PR TITLE
add a GET API to retrieve history of module health check result

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5,13 +5,11 @@ import "github.com/swaggo/swag"
 const docTemplate = `{
     "openapi": "3.0.0",
     "info": {
-        "description": "{{escape .Description}}",
-        "title": "{{.Title}}",
+        "description": "",
+        "title": "Cube COS API",
         "contact": {},
-        "version": "{{.Version}}"
+        "version": "1.0.0"
     },
-    "host": "{{.Host}}",
-    "basePath": "{{.BasePath}}",
     "paths": {
         "/api/v1/logout": {
             "post": {
@@ -29,12 +27,6 @@ const docTemplate = `{
         "/api/v1/datacenters": {
             "get": {
                 "description": "Retrieve the list of data centers",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "Data Centers"
                 ],
@@ -335,7 +327,7 @@ const docTemplate = `{
                 "tags": [
                     "Health"
                 ],
-                "summary": "Retrieve the list of health",
+                "summary": "Retrieve the overall health status of all modules",
                 "parameters": [
                     {
                         "in": "path",
@@ -530,10 +522,102 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Repair the health for all modules",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "test-data-center"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "The Request of the all modules repair is accepted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "the request of all modules repair is accepted and repairing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "the repair process is already running"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to request repair"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/healths/{module}/repair": {
-            "post": {
+        "/api/v1/datacenters/{dataCenter}/healths/{module}": {
+            "patch": {
                 "tags": [
                     "Health"
                 ],
@@ -623,6 +707,243 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch health checks: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/healths/{module}/history": {
+            "get": {
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Retrieve the health history of module",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "test-data-center"
+                    },
+                    {
+                        "in": "path",
+                        "name": "module",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the module to retrieve health history, it could be 'ceph_osd', 'nova', and so on.",
+                        "example": "'ceph_osd', 'nova', and so on."
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageNum",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The page number of the health history chunking to fetch (default is 1).",
+                        "example": 1
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The size per page of the health history to return (default is unlimit).",
+                        "example": 10
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the health history of module successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "health": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "category": {
+                                                            "type": "string"
+                                                        },
+                                                        "service": {
+                                                            "type": "string"
+                                                        },
+                                                        "module": {
+                                                            "type": "string"
+                                                        },
+                                                        "history": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "time": {
+                                                                        "type": "string",
+                                                                        "format": "date-time"
+                                                                    },
+                                                                    "status": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "error": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "nodes": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"                                                                            },
+                                                                            "details": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "log": {
+                                                                                "type": "string",
+                                                                                "format": "uri"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "page": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "total": {
+                                                            "type": "integer"
+                                                        },
+                                                        "number": {
+                                                            "type": "integer"
+                                                        },
+                                                        "size": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Multiple historical records",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "health": {
+                                                    "category": "cloud computing",
+                                                    "service": "compute",
+                                                    "module": "nova",
+                                                    "history": [
+                                                        {
+                                                            "time": "2025-02-01T03:00:00Z",
+                                                            "status": "ok"
+                                                        },
+                                                        {
+                                                            "time": "2025-02-01T02:55:00Z",
+                                                            "status": "ok"
+                                                        },
+                                                        {
+                                                            "time": "2025-02-01T02:50:00Z",
+                                                            "status": "ng",
+                                                            "error": {
+                                                                "type": "service down",
+                                                                "nodes": [
+                                                                    "example-node-0"
+                                                                ],
+                                                                "description": "nova has 1 node down",
+                                                                "details": "{ ... best effort error summary / direction ...}",
+                                                                "log": "http://datacenter1:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                            }
+                                                        },
+                                                        {
+                                                            "time": "2025-02-01T02:45:00Z",
+                                                            "status": "ok"
+                                                        }
+                                                    ]
+                                                },
+                                                "page": {
+                                                    "total": 10,
+                                                    "number": 1,
+                                                    "size": 2
+                                                }
+                                            },
+                                            "msg": "retrieve health history of module successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to retrieve health history"
                                         },
                                         "status": {
                                             "type": "string",
@@ -754,7 +1075,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the summary of data center successfully",
+                        "description": "Retrieve the summary of data center successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -810,7 +1131,7 @@ const docTemplate = `{
                                                                             "example": 31
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.75
                                                                         },
                                                                         "freeCores": {
@@ -818,7 +1139,7 @@ const docTemplate = `{
                                                                             "example": 49
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.25
                                                                         }
                                                                     }
@@ -835,7 +1156,7 @@ const docTemplate = `{
                                                                             "example": 98255
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.2
                                                                         },
                                                                         "freeMiB": {
@@ -843,7 +1164,7 @@ const docTemplate = `{
                                                                             "example": 159116
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.8
                                                                         }
                                                                     }
@@ -860,7 +1181,7 @@ const docTemplate = `{
                                                                             "example": 51200
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         },
                                                                         "freeMiB": {
@@ -868,7 +1189,7 @@ const docTemplate = `{
                                                                             "example": 51200
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         }
                                                                     }
@@ -932,11 +1253,11 @@ const docTemplate = `{
                                                                             "example": 49
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.75
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.25
                                                                         }
                                                                     }
@@ -957,11 +1278,11 @@ const docTemplate = `{
                                                                             "example": 159116
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 38.2
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 61.8
                                                                         }
                                                                     }
@@ -982,11 +1303,11 @@ const docTemplate = `{
                                                                             "example": 51200
                                                                         },
                                                                         "usedPercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         },
                                                                         "freePercent": {
-                                                                            "type": "float",
+                                                                            "type": "number",
                                                                             "example": 50
                                                                         }
                                                                     }
@@ -1117,7 +1438,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the summary of data center successfully",
+                        "description": "Retrieve the summary of data center successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1346,7 +1667,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the cpu usage of hosts successfully",
+                        "description": "Retrieve the cpu usage of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1372,11 +1693,11 @@ const docTemplate = `{
                                                     "example": 49
                                                 },
                                                 "usedPercent": {
-                                                    "type": "float",
+                                                    "type": "number",
                                                     "example": 38.75
                                                 },
                                                 "freePercent": {
-                                                    "type": "float",
+                                                    "type": "number",
                                                     "example": 61.25
                                                 }
                                             }
@@ -1481,60 +1802,101 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage bandwidth time series of hosts successfully",
+                        "description": "Retrieve the storage bandwidth time series of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "code": {
-                                            "type": "integer",
-                                            "example": 200
-                                        },
-                                        "data": {
+                                    "oneOf": [
+                                        {
                                             "type": "object",
                                             "properties": {
-                                                "read": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "time": {
-                                                                "type": "string",
-                                                                "example": "2025-01-01T01:00:00Z"
-                                                            },
-                                                            "bytes": {
-                                                                "type": "float",
-                                                                "example": 682.6666
+                                                "code": {
+                                                    "type": "integer",
+                                                    "example": 200
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "read": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "time": {
+                                                                        "type": "string",
+                                                                        "example": "2025-01-01T01:00:00Z"
+                                                                    },
+                                                                    "bytes": {
+                                                                        "type": "number",
+                                                                        "example": 682.6666
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "write": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "time": {
+                                                                        "type": "string",
+                                                                        "example": "2025-01-01T01:00:00Z"
+                                                                    },
+                                                                    "bytes": {
+                                                                        "type": "number",
+                                                                        "example": 4.5
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     }
                                                 },
-                                                "write": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "time": {
-                                                                "type": "string",
-                                                                "example": "2025-01-01T01:00:00Z"
-                                                            },
-                                                            "bytes": {
-                                                                "type": "float",
-                                                                "example": 4.5
-                                                            }
-                                                        }
-                                                    }
+                                                "msg": {
+                                                    "type": "string",
+                                                    "example": "fetch metrics successfully"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "ok"
                                                 }
                                             }
                                         },
-                                        "msg": {
-                                            "type": "string",
-                                            "example": "fetch metrics successfully"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "example": "ok"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "ok"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "read": [
+                                                    {
+                                                        "time": "2025-01-01T01:00:00Z",
+                                                        "bytes": 682.6666
+                                                    }
+                                                ],
+                                                "write": [
+                                                    {
+                                                        "time": "2025-01-01T01:00:00Z",
+                                                        "bytes": 4.5
+                                                    }
+                                                ]
+                                            },
+                                            "msg": "fetch metrics successfully",
+                                            "status": "ok"
+                                        }
+                                    },
+                                    "example2": {
+                                        "value": {
+                                            "status": "ok"
                                         }
                                     }
                                 }
@@ -1628,7 +1990,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage iops time series of hosts successfully",
+                        "description": "Retrieve the storage iops time series of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1651,7 +2013,7 @@ const docTemplate = `{
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ops": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 1.0833
                                                             }
                                                         }
@@ -1667,7 +2029,7 @@ const docTemplate = `{
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ops": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 5.8166
                                                             }
                                                         }
@@ -1775,7 +2137,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage latency time series of hosts successfully",
+                        "description": "Retrieve the storage latency time series of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1798,7 +2160,7 @@ const docTemplate = `{
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ms": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 10736.9833
                                                             }
                                                         }
@@ -1814,7 +2176,7 @@ const docTemplate = `{
                                                                 "example": "2025-01-01T01:00:00Z"
                                                             },
                                                             "ms": {
-                                                                "type": "float",
+                                                                "type": "number",
                                                                 "example": 1615349.9
                                                             }
                                                         }
@@ -1902,7 +2264,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage usage rank of hosts successfully",
+                        "description": "Retrieve the storage usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1926,11 +2288,11 @@ const docTemplate = `{
                                                         "example": "test-data-center"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 24.6699
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 75.3301
                                                     }
                                                 }
@@ -2016,7 +2378,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the cpu usage rank of hosts successfully",
+                        "description": "Retrieve the cpu usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2040,11 +2402,11 @@ const docTemplate = `{
                                                         "example": "test-data-center"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 10.5263
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 89.4737
                                                     }
                                                 }
@@ -2130,7 +2492,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the memory usage rank of hosts successfully",
+                        "description": "Retrieve the memory usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2154,11 +2516,11 @@ const docTemplate = `{
                                                         "example": "test-data-center"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 52.6702
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 47.3298
                                                     }
                                                 }
@@ -2244,7 +2606,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the network ingress rank of hosts successfully",
+                        "description": "Retrieve the network ingress rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2268,7 +2630,7 @@ const docTemplate = `{
                                                         "example": "test-data-center"
                                                     },
                                                     "packets": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 5392.2666
                                                     }
                                                 }
@@ -2354,7 +2716,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the network ingress rank of hosts successfully",
+                        "description": "Retrieve the network ingress rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2378,7 +2740,7 @@ const docTemplate = `{
                                                         "example": "test-data-center"
                                                     },
                                                     "packets": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 1724.5302
                                                     }
                                                 }
@@ -2464,7 +2826,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the cpu usage rank of hosts successfully",
+                        "description": "Retrieve the cpu usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2488,11 +2850,11 @@ const docTemplate = `{
                                                         "example": "test-vm"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 10.5263
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 89.4737
                                                     }
                                                 }
@@ -2578,7 +2940,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the memory usage rank of hosts successfully",
+                        "description": "Retrieve the memory usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2602,11 +2964,11 @@ const docTemplate = `{
                                                         "example": "test-vm"
                                                     },
                                                     "usedPercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 35.0991
                                                     },
                                                     "freePercent": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 64.9009
                                                     }
                                                 }
@@ -2692,7 +3054,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage iops rank of hosts successfully",
+                        "description": "Retrieve the storage iops rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2720,7 +3082,7 @@ const docTemplate = `{
                                                         "example": "sda"
                                                     },
                                                     "usage": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 184266.4594
                                                     }
                                                 }
@@ -2806,7 +3168,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the network ingress or egress rank of hosts successfully",
+                        "description": "Retrieve the network ingress or egress rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2834,7 +3196,7 @@ const docTemplate = `{
                                                         "example": "sda"
                                                     },
                                                     "usage": {
-                                                        "type": "float",
+                                                        "type": "number",
                                                         "example": 45443.764
                                                     }
                                                 }
@@ -3016,7 +3378,7 @@ const docTemplate = `{
                                                                         "type": "object",
                                                                         "properties": {
                                                                             "uptime": {
-                                                                                "type": "int",
+                                                                                "type": "number",
                                                                                 "example": 99.99
                                                                             },
                                                                             "period": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -323,7 +323,7 @@
                 "tags": [
                     "Health"
                 ],
-                "summary": "Retrieve the list of health",
+                "summary": "Retrieve the overall health status of all modules",
                 "parameters": [
                     {
                         "in": "path",
@@ -518,10 +518,102 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Repair the health for all modules",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "test-data-center"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "The Request of the all modules repair is accepted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "the request of all modules repair is accepted and repairing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "the repair process is already running"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to request repair"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/healths/{module}/repair": {
-            "post": {
+        "/api/v1/datacenters/{dataCenter}/healths/{module}": {
+            "patch": {
                 "tags": [
                     "Health"
                 ],
@@ -611,6 +703,243 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch health checks: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/healths/{module}/history": {
+            "get": {
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Retrieve the health history of module",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "test-data-center"
+                    },
+                    {
+                        "in": "path",
+                        "name": "module",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the module to retrieve health history, it could be 'ceph_osd', 'nova', and so on.",
+                        "example": "'ceph_osd', 'nova', and so on."
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageNum",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The page number of the health history chunking to fetch (default is 1).",
+                        "example": 1
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The size per page of the health history to return (default is unlimit).",
+                        "example": 10
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the health history of module successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "health": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "category": {
+                                                            "type": "string"
+                                                        },
+                                                        "service": {
+                                                            "type": "string"
+                                                        },
+                                                        "module": {
+                                                            "type": "string"
+                                                        },
+                                                        "history": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "time": {
+                                                                        "type": "string",
+                                                                        "format": "date-time"
+                                                                    },
+                                                                    "status": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "error": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "nodes": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"                                                                            },
+                                                                            "details": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "log": {
+                                                                                "type": "string",
+                                                                                "format": "uri"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "page": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "total": {
+                                                            "type": "integer"
+                                                        },
+                                                        "number": {
+                                                            "type": "integer"
+                                                        },
+                                                        "size": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Multiple historical records",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "health": {
+                                                    "category": "cloud computing",
+                                                    "service": "compute",
+                                                    "module": "nova",
+                                                    "history": [
+                                                        {
+                                                            "time": "2025-02-01T03:00:00Z",
+                                                            "status": "ok"
+                                                        },
+                                                        {
+                                                            "time": "2025-02-01T02:55:00Z",
+                                                            "status": "ok"
+                                                        },
+                                                        {
+                                                            "time": "2025-02-01T02:50:00Z",
+                                                            "status": "ng",
+                                                            "error": {
+                                                                "type": "service down",
+                                                                "nodes": [
+                                                                    "example-node-0"
+                                                                ],
+                                                                "description": "nova has 1 node down",
+                                                                "details": "{ ... best effort error summary / direction ...}",
+                                                                "log": "http://datacenter1:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                            }
+                                                        },
+                                                        {
+                                                            "time": "2025-02-01T02:45:00Z",
+                                                            "status": "ok"
+                                                        }
+                                                    ]
+                                                },
+                                                "page": {
+                                                    "total": 10,
+                                                    "number": 1,
+                                                    "size": 2
+                                                }
+                                            },
+                                            "msg": "retrieve health history of module successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to retrieve health history"
                                         },
                                         "status": {
                                             "type": "string",
@@ -742,7 +1071,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the summary of data center successfully",
+                        "description": "Retrieve the summary of data center successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1105,7 +1434,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the summary of data center successfully",
+                        "description": "Retrieve the summary of data center successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1334,7 +1663,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the cpu usage of hosts successfully",
+                        "description": "Retrieve the cpu usage of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1469,60 +1798,101 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage bandwidth time series of hosts successfully",
+                        "description": "Retrieve the storage bandwidth time series of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "code": {
-                                            "type": "integer",
-                                            "example": 200
-                                        },
-                                        "data": {
+                                    "oneOf": [
+                                        {
                                             "type": "object",
                                             "properties": {
-                                                "read": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "time": {
-                                                                "type": "string",
-                                                                "example": "2025-01-01T01:00:00Z"
-                                                            },
-                                                            "bytes": {
-                                                                "type": "number",
-                                                                "example": 682.6666
+                                                "code": {
+                                                    "type": "integer",
+                                                    "example": 200
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "read": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "time": {
+                                                                        "type": "string",
+                                                                        "example": "2025-01-01T01:00:00Z"
+                                                                    },
+                                                                    "bytes": {
+                                                                        "type": "number",
+                                                                        "example": 682.6666
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "write": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "time": {
+                                                                        "type": "string",
+                                                                        "example": "2025-01-01T01:00:00Z"
+                                                                    },
+                                                                    "bytes": {
+                                                                        "type": "number",
+                                                                        "example": 4.5
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     }
                                                 },
-                                                "write": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "time": {
-                                                                "type": "string",
-                                                                "example": "2025-01-01T01:00:00Z"
-                                                            },
-                                                            "bytes": {
-                                                                "type": "number",
-                                                                "example": 4.5
-                                                            }
-                                                        }
-                                                    }
+                                                "msg": {
+                                                    "type": "string",
+                                                    "example": "fetch metrics successfully"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "ok"
                                                 }
                                             }
                                         },
-                                        "msg": {
-                                            "type": "string",
-                                            "example": "fetch metrics successfully"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "example": "ok"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "ok"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "read": [
+                                                    {
+                                                        "time": "2025-01-01T01:00:00Z",
+                                                        "bytes": 682.6666
+                                                    }
+                                                ],
+                                                "write": [
+                                                    {
+                                                        "time": "2025-01-01T01:00:00Z",
+                                                        "bytes": 4.5
+                                                    }
+                                                ]
+                                            },
+                                            "msg": "fetch metrics successfully",
+                                            "status": "ok"
+                                        }
+                                    },
+                                    "example2": {
+                                        "value": {
+                                            "status": "ok"
                                         }
                                     }
                                 }
@@ -1616,7 +1986,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage iops time series of hosts successfully",
+                        "description": "Retrieve the storage iops time series of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1763,7 +2133,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage latency time series of hosts successfully",
+                        "description": "Retrieve the storage latency time series of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1890,7 +2260,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage usage rank of hosts successfully",
+                        "description": "Retrieve the storage usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2004,7 +2374,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the cpu usage rank of hosts successfully",
+                        "description": "Retrieve the cpu usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2118,7 +2488,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the memory usage rank of hosts successfully",
+                        "description": "Retrieve the memory usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2232,7 +2602,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the network ingress rank of hosts successfully",
+                        "description": "Retrieve the network ingress rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2342,7 +2712,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the network ingress rank of hosts successfully",
+                        "description": "Retrieve the network ingress rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2452,7 +2822,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the cpu usage rank of hosts successfully",
+                        "description": "Retrieve the cpu usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2566,7 +2936,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the memory usage rank of hosts successfully",
+                        "description": "Retrieve the memory usage rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2680,7 +3050,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the storage iops rank of hosts successfully",
+                        "description": "Retrieve the storage iops rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2794,7 +3164,7 @@
                 ],
                 "responses": {
                     "200": {
-                       "description": "Retrieve the network ingress or egress rank of hosts successfully",
+                        "description": "Retrieve the network ingress or egress rank of hosts successfully",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0
-	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af
+	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250205114656-72189664ae06
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/coreos/go-oidc v2.3.0+incompatible
 	github.com/crewjam/saml v0.4.14

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202082555-9061781b157
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250202082555-9061781b157d/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af h1:oN/N/CqtbVj+HJdp+TlDcYztEh5aHp3SapFUjOcFBrU=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250205114656-72189664ae06 h1:ojNtJyNiaTAVbG8fvu5TFNt4wfkMx9viioMywIG4i48=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250205114656-72189664ae06/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/api/v1/events/handlers.go
+++ b/internal/api/v1/events/handlers.go
@@ -21,7 +21,7 @@ var (
 )
 
 func getEvents(c *gin.Context) {
-	h, err := initHelperByQueryParams(c)
+	h, err := initReqHelper(c)
 	if err != nil {
 		log.Errorf("request(%s): %v", api.GetReqId(c), err)
 		api.SetBadRequest(c, err)

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -22,7 +22,7 @@ type period struct {
 	stop  string
 }
 
-func initHelperByQueryParams(c *gin.Context) (*helper, error) {
+func initReqHelper(c *gin.Context) (*helper, error) {
 	h := &helper{c: c}
 
 	err := h.parseType()
@@ -74,28 +74,28 @@ func (h *helper) parsePeriod() error {
 }
 
 func (h *helper) parsePage() error {
-	pageNum := h.c.DefaultQuery("pageNum", "")
-	pageSize := h.c.DefaultQuery("pageSize", "")
-	if !isPaginationRequired(pageNum, pageSize) {
+	num := h.c.DefaultQuery("pageNum", "")
+	size := h.c.DefaultQuery("pageSize", "")
+	if !isPageRequired(num, size) {
 		return nil
 	}
 
-	if pageNum == "" {
+	if num == "" {
 		return fmt.Errorf("pageNum should be provided if pageSize is provided")
 	}
 
-	if pageSize == "" {
+	if size == "" {
 		return fmt.Errorf("pageSize should greater than 0 if pageNum is provided")
 	}
 
-	intPageNum, err := strconv.Atoi(pageNum)
+	intPageNum, err := strconv.Atoi(num)
 	if err != nil {
-		return fmt.Errorf("pageNum should be an integer: %s", pageNum)
+		return fmt.Errorf("pageNum should be an integer: %s", num)
 	}
 
-	intPageSize, err := strconv.Atoi(pageSize)
+	intPageSize, err := strconv.Atoi(size)
 	if err != nil {
-		return fmt.Errorf("pageSize should be an integer: %s", pageSize)
+		return fmt.Errorf("pageSize should be an integer: %s", size)
 	}
 
 	h.Page = definition.Page{Number: intPageNum, Size: intPageSize}

--- a/internal/api/v1/events/pagination.go
+++ b/internal/api/v1/events/pagination.go
@@ -9,16 +9,16 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
-func isPaginationRequired(page, pageSize string) bool {
+func isPageRequired(page, pageSize string) bool {
 	return page != "" || pageSize != ""
 }
 
-func (h *helper) isPaginationRequired() bool {
+func (h *helper) isPageRequired() bool {
 	return h.Page.Number > 0 || h.Page.Size > 0
 }
 
 func (h *helper) genPageInfo(events []definition.Event) (definition.Page, error) {
-	if !h.isPaginationRequired() {
+	if !h.isPageRequired() {
 		return definition.Page{
 			Total:  1,
 			Number: 1,

--- a/internal/api/v1/events/stmt.go
+++ b/internal/api/v1/events/stmt.go
@@ -43,7 +43,7 @@ func (h *helper) genCountQueryStmt() string {
 }
 
 func (h *helper) genQueryStmt() string {
-	if !h.isPaginationRequired() {
+	if !h.isPageRequired() {
 		return h.genNonPagingQueryStmt()
 	}
 

--- a/internal/api/v1/healths/handlers.go
+++ b/internal/api/v1/healths/handlers.go
@@ -30,6 +30,12 @@ var (
 			Path:    "/healths/:module",
 			Func:    updateHealth,
 		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/healths/:module/history",
+			Func:    getModuleHealthHistory,
+		},
 	}
 )
 
@@ -85,5 +91,31 @@ func updateHealth(c *gin.Context) {
 		c,
 		"repair status updated successfully",
 		nil,
+	)
+}
+
+func getModuleHealthHistory(c *gin.Context) {
+	h, err := initReqHelper(c)
+	if err != nil {
+		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	checkResult := h.genFakeHealthCheckResult()
+	page, err := h.genPageInfo()
+	if err != nil {
+		log.Errorf("request(%s): failed to gen page info: %v", api.GetReqId(c), err)
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"fetch module health history successfully",
+		data{
+			Health: checkResult,
+			Page:   page,
+		},
 	)
 }

--- a/internal/api/v1/healths/helper.go
+++ b/internal/api/v1/healths/helper.go
@@ -1,0 +1,110 @@
+package healths
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+)
+
+type helper struct {
+	c *gin.Context
+	period
+	definition.Page
+}
+
+type period struct {
+	start string
+	stop  string
+}
+
+type data struct {
+	Health          cubecos.HealthCheckResult `json:"health"`
+	definition.Page `json:"page"`
+}
+
+func (p period) StartAsTime() time.Time {
+	t, err := time.Parse(time.RFC3339, p.start)
+	if err != nil {
+		return time.Now()
+	}
+
+	return t
+}
+
+func (p period) StopAsTime() time.Time {
+	t, err := time.Parse(time.RFC3339, p.stop)
+	if err != nil {
+		return time.Now()
+	}
+
+	return t
+}
+
+func initReqHelper(c *gin.Context) (*helper, error) {
+	h := &helper{c: c}
+
+	err := h.parsePeriod()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parsePage()
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *helper) parsePeriod() error {
+	h.period.start = h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
+	start, err := time.Parse(time.RFC3339, h.period.start)
+	if err != nil {
+		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", h.period.start)
+	}
+
+	h.period.stop = h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
+	stop, err := time.Parse(time.RFC3339, h.period.stop)
+	if err != nil {
+		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", h.period.stop)
+	}
+
+	if stop.Before(start) {
+		return fmt.Errorf("'stop' time should be after 'start' time(start: %s, stop: %s)", start, stop)
+	}
+
+	return nil
+}
+
+func (h *helper) parsePage() error {
+	num := h.c.DefaultQuery("pageNum", "")
+	size := h.c.DefaultQuery("pageSize", "")
+	if !isPageRequired(num, size) {
+		return nil
+	}
+
+	if num == "" {
+		return fmt.Errorf("pageNum should be provided if pageSize is provided")
+	}
+
+	if size == "" {
+		return fmt.Errorf("pageSize should greater than 0 if pageNum is provided")
+	}
+
+	var err error
+	h.Page.Number, err = strconv.Atoi(num)
+	if err != nil {
+		return fmt.Errorf("pageNum should be an integer: %s", num)
+	}
+
+	h.Page.Size, err = strconv.Atoi(size)
+	if err != nil {
+		return fmt.Errorf("pageSize should be an integer: %s", size)
+	}
+
+	return nil
+}

--- a/internal/api/v1/healths/pagination.go
+++ b/internal/api/v1/healths/pagination.go
@@ -1,0 +1,19 @@
+package healths
+
+import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+
+func isPageRequired(page, pageSize string) bool {
+	return page != "" || pageSize != ""
+}
+
+func (h *helper) isPageRequired() bool {
+	return h.Page.Number > 0 || h.Page.Size > 0
+}
+
+func (h *helper) genPageInfo() (definition.Page, error) {
+	return definition.Page{
+		Total:  1,
+		Number: 1,
+		Size:   1,
+	}, nil
+}

--- a/internal/api/v1/healths/payload.go
+++ b/internal/api/v1/healths/payload.go
@@ -1,6 +1,9 @@
 package healths
 
 import (
+	"fmt"
+	"time"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
@@ -9,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// M1 TODO: this will be removed once the real data is available in the COS side
 func genFakeHealths() cubecos.Health {
 	return cubecos.Health{
 		Overall: &cubecos.Overall{
@@ -74,6 +78,47 @@ func genFakeHealths() cubecos.Health {
 			},
 		},
 		Fixing: []definition.Service{},
+	}
+}
+
+// M1 TODO: this will be removed once the real data is available in the COS side
+func (h *helper) genFakeHealthCheckResult() cubecos.HealthCheckResult {
+	now := time.Now().UTC()
+	interval := 5 * time.Minute
+	history := []cubecos.HealthCheckPoint{}
+	count := 0
+
+	for t := h.StartAsTime(); !t.After(h.StopAsTime()); t = t.Add(interval) {
+		timestamp := now.Add(-time.Duration(count) * interval).Format(time.RFC3339)
+		status := "ok"
+		checkResult := cubecos.HealthCheckPoint{Time: timestamp, Status: status}
+		if count%5 == 0 {
+			h.setFakeError(&checkResult)
+		}
+
+		history = append(history, checkResult)
+		count++
+	}
+
+	return cubecos.HealthCheckResult{
+		Category: "cloud computing",
+		Service:  "compute",
+		Module:   "nova",
+		History:  history,
+	}
+}
+
+func (h *helper) setFakeError(checkResult *cubecos.HealthCheckPoint) {
+	checkResult.Status = "ng"
+	checkResult.Error = &cubecos.Error{
+		Type:        "service down",
+		Nodes:       []string{definition.DataCenterName},
+		Description: "nova has 1 nodes down",
+		Details:     "{ ... the best efforts of error summary / direction ...} ",
+		Log: fmt.Sprintf(
+			"http://{dataCenter}:8888/log/nova/%s-20250205113459-b3gc.log",
+			definition.DataCenterName,
+		),
 	}
 }
 

--- a/internal/api/v1/healths/stmt.go
+++ b/internal/api/v1/healths/stmt.go
@@ -1,0 +1,19 @@
+package healths
+
+func (h *helper) genCountQueryStmt() string {
+	return "to be replaced"
+
+}
+
+func (h *helper) genQueryStmt() string {
+	return "to be replaced"
+}
+
+func (h *helper) genNonPagingQueryStmt() string {
+	return "to be replaced"
+
+}
+
+func (h *helper) genPagingQueryStmt() string {
+	return "to be replaced"
+}

--- a/internal/api/v1/nodes/pagination.go
+++ b/internal/api/v1/nodes/pagination.go
@@ -12,29 +12,29 @@ import (
 func genPageOptsByQueryParams(c *gin.Context) (definition.Page, error) {
 	var err error
 	page := definition.Page{}
-	pageNum := c.DefaultQuery("pageNum", "")
-	pageSize := c.DefaultQuery("pageSize", "")
+	num := c.DefaultQuery("pageNum", "")
+	size := c.DefaultQuery("pageSize", "")
 
-	if !definition.IsPaginationRequired(pageNum, pageSize) {
+	if !definition.IsPageRequired(num, size) {
 		return page, nil
 	}
 
-	if pageNum == "" {
+	if num == "" {
 		return page, fmt.Errorf("pageNum should be provided if pageSize is provided")
 	}
 
-	if pageSize == "" {
+	if size == "" {
 		return page, fmt.Errorf("pageSize should greater than 0 if pageNum is provided")
 	}
 
-	page.Number, err = strconv.Atoi(pageNum)
+	page.Number, err = strconv.Atoi(num)
 	if err != nil {
-		return page, fmt.Errorf("pageNum should be an integer: %s", pageNum)
+		return page, fmt.Errorf("pageNum should be an integer: %s", num)
 	}
 
-	page.Size, err = strconv.Atoi(pageSize)
+	page.Size, err = strconv.Atoi(size)
 	if err != nil {
-		return page, fmt.Errorf("pageSize should be an integer: %s", pageSize)
+		return page, fmt.Errorf("pageSize should be an integer: %s", size)
 	}
 
 	if page.Number <= 0 {

--- a/internal/cubecos/health.go
+++ b/internal/cubecos/health.go
@@ -20,6 +20,27 @@ type Health struct {
 	Fixing                 []definition.Service `json:"fixing" bson:"fixing"`
 }
 
+type HealthCheckResult struct {
+	Category string             `json:"category"`
+	Service  string             `json:"service"`
+	Module   string             `json:"module"`
+	History  []HealthCheckPoint `json:"history"`
+}
+
+type HealthCheckPoint struct {
+	Time   string `json:"time"`
+	Status string `json:"status"`
+	*Error `json:"error,omitempty"`
+}
+
+type Error struct {
+	Type        string   `json:"type"`
+	Nodes       []string `json:"nodes"`
+	Description string   `json:"description"`
+	Details     string   `json:"details"`
+	Log         string   `json:"log"`
+}
+
 type Overall struct {
 	Status status.Details `json:"status,omitempty" bson:"status"`
 }

--- a/internal/definition/v1/pagination.go
+++ b/internal/definition/v1/pagination.go
@@ -10,6 +10,6 @@ func (p Page) IsRequired() bool {
 	return p.Number > 0 || p.Size > 0
 }
 
-func IsPaginationRequired(pageNum, pageSize string) bool {
+func IsPageRequired(pageNum, pageSize string) bool {
 	return pageNum != "" || pageSize != ""
 }

--- a/internal/operators/v1/node/log-throttling.go
+++ b/internal/operators/v1/node/log-throttling.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/status"
@@ -51,9 +50,10 @@ func logWithThrottling(event *registry.Result) {
 	}
 
 	log.Infof(
-		"node resynced: %s %s %s",
+		"node discovery: node(%s) role(%s) ip(%s) %s",
+		event.Service.Nodes[0].Metadata["hostname"],
 		event.Service.Nodes[0].Metadata["role"],
-		fmt.Sprintf("%s(%s)", event.Service.Nodes[0].Metadata["hostname"], event.Service.Nodes[0].Address),
+		event.Service.Nodes[0].Address,
 		convertAction(event.Action),
 	)
 }


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

#37 

<br/>

### What this PR does?

The 1st iteration of GET API to retrieve the history of module health.

The query of time range and pagination are already included in the implementation.

<br/> 

Please be aware of the things below:

- the response is fake currently until the COS finished the [story - [COS SDK] Health Check - Integrate the health check result with InfluxDB](https://github.com/bigstack-oss/cube-cos/issues/1)

- the response format haven't integrated and reviewed by FE team, so should be adjusted in the 2nd or 3rd iteration along with the COS integration.

<br/>

### Test results (optional)

1). make sure the API will return the sample data which designed in the 1st iteration

<img width="1717" alt="Screenshot 2025-02-06 at 12 05 32 AM" src="https://github.com/user-attachments/assets/da2f985e-635d-4632-a3a5-7bfa9f6767e6" />

<img width="1717" alt="Screenshot 2025-02-06 at 12 05 47 AM" src="https://github.com/user-attachments/assets/3626f180-018d-49ae-adc8-d98140b16605" />

<br/>
<br/>
<br/>

2). make sure the API docs is able to be reviewed on swagger page.

![Screenshot 2025-02-06 at 12 07 03 AM](https://github.com/user-attachments/assets/9bdb5d5d-c2aa-45d1-a96b-f2ea9a676798)

![Screenshot 2025-02-05 at 11 53 45 PM](https://github.com/user-attachments/assets/0c8427f9-53e8-415c-8854-5c8a7b2d6f92)

![Screenshot 2025-02-05 at 11 54 00 PM](https://github.com/user-attachments/assets/48ce4df2-3119-4954-b619-8335034f4a6e)


