### PR TITLE
Add watch(http chunked transfer) for health summary, event listing, and node listing apis

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -122,7 +122,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -173,6 +173,16 @@ const docTemplate = `{
                         },
                         "description": "The size per page of the events to return (default is unlimit).",
                         "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -337,7 +347,17 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -537,7 +557,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     }
                 ],
                 "responses": {
@@ -631,7 +651,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "path",
@@ -735,7 +755,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "path",
@@ -972,7 +992,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     }
                 ],
                 "responses": {
@@ -1070,7 +1090,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -1283,7 +1303,17 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -1586,7 +1616,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "path",
@@ -1835,7 +1865,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -1970,7 +2000,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2158,7 +2188,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2305,7 +2335,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2452,7 +2482,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2494,11 +2524,11 @@ const docTemplate = `{
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -2566,7 +2596,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2608,11 +2638,11 @@ const docTemplate = `{
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -2680,7 +2710,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2722,11 +2752,11 @@ const docTemplate = `{
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -2794,7 +2824,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2836,11 +2866,11 @@ const docTemplate = `{
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "packets": {
                                                         "type": "number",
@@ -2904,7 +2934,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2946,11 +2976,11 @@ const docTemplate = `{
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "packets": {
                                                         "type": "number",
@@ -3014,7 +3044,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3060,7 +3090,7 @@ const docTemplate = `{
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -3128,7 +3158,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3174,7 +3204,7 @@ const docTemplate = `{
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -3242,7 +3272,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3288,7 +3318,7 @@ const docTemplate = `{
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "device": {
                                                         "type": "string",
@@ -3356,7 +3386,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3402,7 +3432,7 @@ const docTemplate = `{
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "device": {
                                                         "type": "string",
@@ -3470,7 +3500,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3491,6 +3521,16 @@ const docTemplate = `{
                         },
                         "description": "The size per page of the events to return (default is unlimit).",
                         "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -3768,7 +3808,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     }
                 ],
                 "requestBody": {
@@ -3782,12 +3822,12 @@ const docTemplate = `{
                                     "name": {
                                         "type": "string",
                                         "description": "the name of user to generate the token",
-                                        "example": "test-name"
+                                        "example": "example-name"
                                     },
                                     "password": {
                                         "type": "string",
                                         "description": "the password of user to generate the token",
-                                        "example": "test-password"
+                                        "example": "example-password"
                                     }
                                 }
                             }

--- a/api/docs.json
+++ b/api/docs.json
@@ -118,7 +118,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -169,6 +169,16 @@
                         },
                         "description": "The size per page of the events to return (default is unlimit).",
                         "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -333,7 +343,17 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -533,7 +553,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     }
                 ],
                 "responses": {
@@ -627,7 +647,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "path",
@@ -731,7 +751,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "path",
@@ -968,7 +988,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     }
                 ],
                 "responses": {
@@ -1066,7 +1086,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -1279,7 +1299,17 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -1582,7 +1612,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "path",
@@ -1831,7 +1861,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -1966,7 +1996,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2154,7 +2184,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2301,7 +2331,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2448,7 +2478,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2490,11 +2520,11 @@
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -2562,7 +2592,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2604,11 +2634,11 @@
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -2676,7 +2706,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2718,11 +2748,11 @@
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -2790,7 +2820,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2832,11 +2862,11 @@
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "packets": {
                                                         "type": "number",
@@ -2900,7 +2930,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -2942,11 +2972,11 @@
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-data-center"
+                                                        "example": "example-data-center"
                                                     },
                                                     "packets": {
                                                         "type": "number",
@@ -3010,7 +3040,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3056,7 +3086,7 @@
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -3124,7 +3154,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3170,7 +3200,7 @@
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "usedPercent": {
                                                         "type": "number",
@@ -3238,7 +3268,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3284,7 +3314,7 @@
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "device": {
                                                         "type": "string",
@@ -3352,7 +3382,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3398,7 +3428,7 @@
                                                     },
                                                     "name": {
                                                         "type": "string",
-                                                        "example": "test-vm"
+                                                        "example": "example-vm"
                                                     },
                                                     "device": {
                                                         "type": "string",
@@ -3466,7 +3496,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -3487,6 +3517,16 @@
                         },
                         "description": "The size per page of the events to return (default is unlimit).",
                         "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
                     }
                 ],
                 "responses": {
@@ -3764,7 +3804,7 @@
                             "type": "string"
                         },
                         "description": "The name of the data center to operate",
-                        "example": "test-data-center"
+                        "example": "example-data-center"
                     }
                 ],
                 "requestBody": {
@@ -3778,12 +3818,12 @@
                                     "name": {
                                         "type": "string",
                                         "description": "the name of user to generate the token",
-                                        "example": "test-name"
+                                        "example": "example-name"
                                     },
                                     "password": {
                                         "type": "string",
                                         "description": "the password of user to generate the token",
-                                        "example": "test-password"
+                                        "example": "example-password"
                                     }
                                 }
                             }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/gin-gonic/gin"
@@ -104,4 +106,14 @@ func GetReqId(c *gin.Context) string {
 	}
 
 	return id.(string)
+}
+
+func ParseWatch(c *gin.Context) (bool, error) {
+	rawParam := c.DefaultQuery("watch", "false")
+	watch, err := strconv.ParseBool(rawParam)
+	if err != nil {
+		return false, errors.New("watch parameter is invalid, it should be true or false if provided")
+	}
+
+	return watch, nil
 }

--- a/internal/api/v1/events/handlers.go
+++ b/internal/api/v1/events/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
-	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
 )
@@ -20,6 +19,10 @@ var (
 	}
 )
 
+func init() {
+	go streamEvents()
+}
+
 func getEvents(c *gin.Context) {
 	h, err := initReqHelper(c)
 	if err != nil {
@@ -28,27 +31,21 @@ func getEvents(c *gin.Context) {
 		return
 	}
 
-	stmt := h.genQueryStmt()
-	events, err := cubecos.GetEvents(stmt)
+	resp, err := h.genEventResp()
 	if err != nil {
-		log.Errorf("request(%s): failed to fetch events: %v", api.GetReqId(c), err)
+		log.Errorf("request(%s): failed to gen event resp: %v", api.GetReqId(c), err)
 		api.SetInternalServerError(c, err)
 		return
 	}
 
-	page, err := h.genPageInfo(events)
-	if err != nil {
-		log.Errorf("request(%s): failed to gen page info: %v", api.GetReqId(c), err)
-		api.SetInternalServerError(c, err)
+	if h.watch {
+		watchEvents(h, resp)
 		return
 	}
 
 	api.SetStatusOk(
 		c,
 		"fetch events successfully",
-		data{
-			Events: events,
-			Page:   page,
-		},
+		resp,
 	)
 }

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -5,9 +5,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
 )
 
 type helper struct {
@@ -15,6 +17,7 @@ type helper struct {
 	eventType string
 	period
 	definition.Page
+	watch bool
 }
 
 type period struct {
@@ -36,6 +39,11 @@ func initReqHelper(c *gin.Context) (*helper, error) {
 	}
 
 	err = h.parsePage()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseWatch()
 	if err != nil {
 		return nil, err
 	}
@@ -100,4 +108,31 @@ func (h *helper) parsePage() error {
 
 	h.Page = definition.Page{Number: intPageNum, Size: intPageSize}
 	return nil
+}
+
+func (h *helper) parseWatch() error {
+	watch, err := api.ParseWatch(h.c)
+	if err != nil {
+		return err
+	}
+
+	h.watch = watch
+	return nil
+}
+
+func (h *helper) genEventResp() (*resp, error) {
+	stmt := h.genQueryStmt()
+	events, err := cubecos.GetEvents(stmt)
+	if err != nil {
+		log.Errorf("request(%s): failed to get events: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	page, err := h.genPageInfo(events)
+	if err != nil {
+		log.Errorf("request(%s): failed to gen page info: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	return &resp{Events: events, Page: page}, nil
 }

--- a/internal/api/v1/events/resp.go
+++ b/internal/api/v1/events/resp.go
@@ -2,7 +2,7 @@ package events
 
 import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 
-type data struct {
+type resp struct {
 	Events          []definition.Event `json:"events"`
 	definition.Page `json:"page"`
 }

--- a/internal/api/v1/events/watch.go
+++ b/internal/api/v1/events/watch.go
@@ -1,20 +1,22 @@
-package metrics
+package events
 
 import (
 	"errors"
 	"net/http"
-	"strconv"
 	"sync"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
-	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/gin-gonic/gin"
 	json "github.com/json-iterator/go"
-	log "go-micro.dev/v5/logger"
 )
 
-type watcher chan cubecos.Summary
+type respChan chan resp
+
+type watcher struct {
+	helper
+	respChan
+}
 
 var (
 	stream = struct {
@@ -23,23 +25,22 @@ var (
 	}{}
 )
 
-func streamSummary() {
+func streamEvents() {
 	for {
 		wait.Seconds(2)
 		if len(stream.Watchers) == 0 {
 			continue
 		}
 
-		summary, err := cubecos.GetDataCenterSummary()
-		if err != nil {
-			log.Errorf("summary: failed to fetch data center summary: %v", err)
-			continue
-		}
-
 		stream.Lock()
 		for _, w := range stream.Watchers {
+			resp, err := w.genEventResp()
+			if err != nil {
+				continue
+			}
+
 			select {
-			case w <- *summary:
+			case w.respChan <- *resp:
 			default:
 			}
 		}
@@ -48,30 +49,20 @@ func streamSummary() {
 	}
 }
 
-func parseWatch(c *gin.Context) (bool, error) {
-	rawParam := c.DefaultQuery("watch", "false")
-	watch, err := strconv.ParseBool(rawParam)
-	if err != nil {
-		return false, errors.New("watch parameter is invalid, it should be true or false if provided")
-	}
-
-	return watch, nil
-}
-
-func watchSummary(c *gin.Context, summary *cubecos.Summary) {
-	setChunkedTransfer(c)
-	flusher, ok := c.Writer.(http.Flusher)
+func watchEvents(h *helper, resp *resp) {
+	setChunkedTransfer(h.c)
+	flusher, ok := h.c.Writer.(http.Flusher)
 	if !ok {
-		api.SetBadRequest(c, errors.New("http chunked transfer is not supported"))
+		api.SetBadRequest(h.c, errors.New("http chunked transfer is not supported"))
 		return
 	}
 
-	watcher := make(watcher)
+	watcher := watcher{helper: *h, respChan: make(respChan)}
 	addWatcher(watcher)
 	defer removeWatcher(watcher)
 
-	sendFirstSummary(c, flusher, summary)
-	streamingSummary(c, flusher, watcher)
+	sendFirstSummary(h.c, flusher, resp)
+	streamingSummary(h.c, flusher, watcher)
 }
 
 func setChunkedTransfer(c *gin.Context) {
@@ -102,8 +93,8 @@ func removeWatcher(watcherToRemove watcher) {
 	}
 }
 
-func sendFirstSummary(c *gin.Context, flusher http.Flusher, summary *cubecos.Summary) {
-	c.Writer.Write(streamingResp(summary))
+func sendFirstSummary(c *gin.Context, flusher http.Flusher, resp *resp) {
+	c.Writer.Write(streamingResp(resp))
 	c.Writer.Write([]byte("\n"))
 	flusher.Flush()
 }
@@ -112,23 +103,23 @@ func streamingSummary(c *gin.Context, flusher http.Flusher, watcher watcher) {
 	ctx := c.Request.Context()
 	for {
 		select {
-		case summary := <-watcher:
-			c.Writer.Write(streamingResp(&summary))
+		case resp := <-watcher.respChan:
+			c.Writer.Write(streamingResp(&resp))
 			c.Writer.Write([]byte("\n"))
 			flusher.Flush()
 		case <-ctx.Done():
-			api.SetStatusOk(c, "summary watching is stopped successfully", nil)
+			api.SetStatusOk(c, "event watching is stopped successfully", nil)
 			return
 		}
 	}
 }
 
-func streamingResp(summary *cubecos.Summary) []byte {
+func streamingResp(resp *resp) []byte {
 	b, err := json.Marshal(gin.H{
 		"code":   http.StatusOK,
 		"status": "ok",
-		"msg":    "fetch data center summary successfully",
-		"data":   *summary,
+		"msg":    "fetch event successfully",
+		"data":   *resp,
 	})
 	if err != nil {
 		return []byte{}

--- a/internal/api/v1/healths/handlers.go
+++ b/internal/api/v1/healths/handlers.go
@@ -16,7 +16,7 @@ var (
 			Version: api.V1,
 			Method:  http.MethodGet,
 			Path:    "/healths",
-			Func:    listHealth,
+			Func:    getHealthSummary,
 		},
 		{
 			Version: api.V1,
@@ -39,13 +39,30 @@ var (
 	}
 )
 
+func init() {
+	go streamHealthSummary()
+}
+
 // TODO M1: the health info will be replaced by the real data around 2025-02-10
 // there're a few implementations to need to be checked with the team.
-func listHealth(c *gin.Context) {
+func getHealthSummary(c *gin.Context) {
+	watch, err := api.ParseWatch(c)
+	if err != nil {
+		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	summary := genFakeHealthSummary()
+	if watch {
+		watchHealthSummary(c, &summary)
+		return
+	}
+
 	api.SetStatusOk(
 		c,
-		"fetch service health successfully",
-		genFakeHealths(),
+		"fetch health summary successfully",
+		summary,
 	)
 }
 

--- a/internal/api/v1/healths/payload.go
+++ b/internal/api/v1/healths/payload.go
@@ -13,7 +13,7 @@ import (
 )
 
 // M1 TODO: this will be removed once the real data is available in the COS side
-func genFakeHealths() cubecos.Health {
+func genFakeHealthSummary() cubecos.Health {
 	return cubecos.Health{
 		Overall: &cubecos.Overall{
 			Status: status.Details{

--- a/internal/api/v1/healths/watch.go
+++ b/internal/api/v1/healths/watch.go
@@ -1,9 +1,8 @@
-package metrics
+package healths
 
 import (
 	"errors"
 	"net/http"
-	"strconv"
 	"sync"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
@@ -11,10 +10,9 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/gin-gonic/gin"
 	json "github.com/json-iterator/go"
-	log "go-micro.dev/v5/logger"
 )
 
-type watcher chan cubecos.Summary
+type watcher chan cubecos.Health
 
 var (
 	stream = struct {
@@ -23,23 +21,18 @@ var (
 	}{}
 )
 
-func streamSummary() {
+func streamHealthSummary() {
 	for {
 		wait.Seconds(2)
 		if len(stream.Watchers) == 0 {
 			continue
 		}
 
-		summary, err := cubecos.GetDataCenterSummary()
-		if err != nil {
-			log.Errorf("summary: failed to fetch data center summary: %v", err)
-			continue
-		}
-
+		summary := genFakeHealthSummary()
 		stream.Lock()
 		for _, w := range stream.Watchers {
 			select {
-			case w <- *summary:
+			case w <- summary:
 			default:
 			}
 		}
@@ -48,17 +41,7 @@ func streamSummary() {
 	}
 }
 
-func parseWatch(c *gin.Context) (bool, error) {
-	rawParam := c.DefaultQuery("watch", "false")
-	watch, err := strconv.ParseBool(rawParam)
-	if err != nil {
-		return false, errors.New("watch parameter is invalid, it should be true or false if provided")
-	}
-
-	return watch, nil
-}
-
-func watchSummary(c *gin.Context, summary *cubecos.Summary) {
+func watchHealthSummary(c *gin.Context, summary *cubecos.Health) {
 	setChunkedTransfer(c)
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
@@ -102,8 +85,8 @@ func removeWatcher(watcherToRemove watcher) {
 	}
 }
 
-func sendFirstSummary(c *gin.Context, flusher http.Flusher, summary *cubecos.Summary) {
-	c.Writer.Write(streamingResp(summary))
+func sendFirstSummary(c *gin.Context, flusher http.Flusher, healthSummary *cubecos.Health) {
+	c.Writer.Write(streamingResp(healthSummary))
 	c.Writer.Write([]byte("\n"))
 	flusher.Flush()
 }
@@ -112,23 +95,23 @@ func streamingSummary(c *gin.Context, flusher http.Flusher, watcher watcher) {
 	ctx := c.Request.Context()
 	for {
 		select {
-		case summary := <-watcher:
-			c.Writer.Write(streamingResp(&summary))
+		case healthSummary := <-watcher:
+			c.Writer.Write(streamingResp(&healthSummary))
 			c.Writer.Write([]byte("\n"))
 			flusher.Flush()
 		case <-ctx.Done():
-			api.SetStatusOk(c, "summary watching is stopped successfully", nil)
+			api.SetStatusOk(c, "health summary watching is stopped successfully", nil)
 			return
 		}
 	}
 }
 
-func streamingResp(summary *cubecos.Summary) []byte {
+func streamingResp(healthSummary *cubecos.Health) []byte {
 	b, err := json.Marshal(gin.H{
 		"code":   http.StatusOK,
 		"status": "ok",
-		"msg":    "fetch data center summary successfully",
-		"data":   *summary,
+		"msg":    "fetch health summary successfully",
+		"data":   *healthSummary,
 	})
 	if err != nil {
 		return []byte{}

--- a/internal/api/v1/metrics/handlers.go
+++ b/internal/api/v1/metrics/handlers.go
@@ -27,7 +27,7 @@ var (
 )
 
 func init() {
-	go onDemandStreamSummary()
+	go streamSummary()
 }
 
 func getDataCenterMetricsSummary(c *gin.Context) {

--- a/internal/api/v1/nodes/details.go
+++ b/internal/api/v1/nodes/details.go
@@ -35,6 +35,7 @@ func addMetricToNode(node *definition.Node, hypervisor *hypervisors.Hypervisor) 
 		UsedPercent: float64(hypervisor.VCPUsUsed) / float64(hypervisor.VCPUs) * 100,
 		FreePercent: float64(hypervisor.VCPUs-hypervisor.VCPUsUsed) / float64(hypervisor.VCPUs) * 100,
 	}
+
 	node.Memory = definition.SpaceStatistic{
 		TotalMiB:    float64(hypervisor.MemoryMB),
 		UsedMiB:     float64(hypervisor.MemoryMBUsed),
@@ -42,6 +43,7 @@ func addMetricToNode(node *definition.Node, hypervisor *hypervisors.Hypervisor) 
 		UsedPercent: float64(hypervisor.MemoryMBUsed) / float64(hypervisor.MemoryMB) * 100,
 		FreePercent: float64(hypervisor.MemoryMB-hypervisor.MemoryMBUsed) / float64(hypervisor.MemoryMB) * 100,
 	}
+
 	node.Storage = definition.SpaceStatistic{
 		TotalMiB:    float64(hypervisor.LocalGB) * 1024,
 		UsedMiB:     float64(hypervisor.LocalGBUsed) * 1024,

--- a/internal/api/v1/nodes/handlers.go
+++ b/internal/api/v1/nodes/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
-	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
 )
@@ -20,45 +19,35 @@ var (
 	}
 )
 
+func init() {
+	go streamNodes()
+}
+
 // TODO M1: have to check why sometime take a long time to get the nodes list
 // suspect the cluster-wise license fetching might be slow by hex cli
 func getNodes(c *gin.Context) {
-	pageOpts, err := genPageOptsByQueryParams(c)
+	h, err := initReqHelper(c)
 	if err != nil {
-		log.Errorf("request(%s): %s", api.GetReqId(c), err.Error())
+		log.Errorf("request(%s): %v", api.GetReqId(c), err)
 		api.SetBadRequest(c, err)
 		return
 	}
 
-	allNodes, err := cubecos.ListNodes()
+	resp, err := h.genNodeResp()
 	if err != nil {
-		log.Errorf("request(%s): failed to get nodes: %s", api.GetReqId(c), err.Error())
+		log.Errorf("request(%s): failed to gen node: %v", api.GetReqId(c), err)
 		api.SetInternalServerError(c, err)
 		return
 	}
 
-	pagedNodes, err := paginateNodes(allNodes, pageOpts)
-	if err != nil {
-		log.Errorf("request(%s): failed to paginate nodes: %s", api.GetReqId(c), err.Error())
-		api.SetInternalServerError(c, err)
+	if h.watch {
+		watchNodes(h, *resp)
 		return
 	}
 
-	page, err := genPageInfo(allNodes, pageOpts)
-	if err != nil {
-		log.Errorf("request(%s): failed to gen page info: %s", api.GetReqId(c), err.Error())
-		api.SetInternalServerError(c, err)
-		return
-	}
-
-	addLicenseInfoToNodes(c, &pagedNodes)
-	addNodeDetailsToNodes(c, &pagedNodes)
 	api.SetStatusOk(
 		c,
 		"fetch nodes list successfully",
-		data{
-			Nodes: pagedNodes,
-			Page:  page,
-		},
+		resp,
 	)
 }

--- a/internal/api/v1/nodes/helper.go
+++ b/internal/api/v1/nodes/helper.go
@@ -1,0 +1,108 @@
+package nodes
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
+)
+
+type helper struct {
+	c *gin.Context
+	definition.Page
+	watch bool
+}
+
+func initReqHelper(c *gin.Context) (*helper, error) {
+	h := &helper{c: c}
+
+	err := h.parsePage()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseWatch()
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *helper) parsePage() error {
+	num := h.c.DefaultQuery("pageNum", "")
+	size := h.c.DefaultQuery("pageSize", "")
+	if !h.Page.IsRequired() {
+		return nil
+	}
+
+	if num == "" {
+		return fmt.Errorf("pageNum should be provided if pageSize is provided")
+	}
+
+	if size == "" {
+		return fmt.Errorf("pageSize should be provided if pageNum is provided")
+	}
+
+	var err error
+	h.Page.Number, err = strconv.Atoi(num)
+	if err != nil {
+		return fmt.Errorf("pageNum should be an integer: %s", num)
+	}
+
+	h.Page.Size, err = strconv.Atoi(size)
+	if err != nil {
+		return fmt.Errorf("pageSize should be an integer: %s", size)
+	}
+
+	if h.Page.Number <= 0 {
+		return fmt.Errorf("pageNum should be greater than 0 if pageSize is provided")
+	}
+
+	if h.Page.Size <= 0 {
+		return fmt.Errorf("pageSize should be greater than 0 if pageNum is provided")
+	}
+
+	return nil
+}
+
+func (h *helper) parseWatch() error {
+	var err error
+	h.watch, err = api.ParseWatch(h.c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *helper) genNodeResp() (*data, error) {
+	nodes, err := cubecos.ListNodes()
+	if err != nil {
+		log.Errorf("request(%s): failed to get nodes: %s", api.GetReqId(h.c), err.Error())
+		return nil, err
+	}
+
+	pagedNodes, err := paginateNodes(nodes, h.Page)
+	if err != nil {
+		log.Errorf("request(%s): failed to paginate nodes: %s", api.GetReqId(h.c), err.Error())
+		return nil, err
+	}
+
+	page, err := genPageInfo(nodes, h.Page)
+	if err != nil {
+		log.Errorf("request(%s): failed to gen page info: %s", api.GetReqId(h.c), err.Error())
+		return nil, err
+	}
+
+	addLicenseInfoToNodes(h.c, &pagedNodes)
+	addNodeDetailsToNodes(h.c, &pagedNodes)
+	return &data{
+		Nodes: pagedNodes,
+		Page:  page,
+	}, nil
+}

--- a/internal/api/v1/nodes/pagination.go
+++ b/internal/api/v1/nodes/pagination.go
@@ -1,52 +1,10 @@
 package nodes
 
 import (
-	"fmt"
 	"math"
-	"strconv"
 
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
-	"github.com/gin-gonic/gin"
 )
-
-func genPageOptsByQueryParams(c *gin.Context) (definition.Page, error) {
-	var err error
-	page := definition.Page{}
-	num := c.DefaultQuery("pageNum", "")
-	size := c.DefaultQuery("pageSize", "")
-
-	if !definition.IsPageRequired(num, size) {
-		return page, nil
-	}
-
-	if num == "" {
-		return page, fmt.Errorf("pageNum should be provided if pageSize is provided")
-	}
-
-	if size == "" {
-		return page, fmt.Errorf("pageSize should greater than 0 if pageNum is provided")
-	}
-
-	page.Number, err = strconv.Atoi(num)
-	if err != nil {
-		return page, fmt.Errorf("pageNum should be an integer: %s", num)
-	}
-
-	page.Size, err = strconv.Atoi(size)
-	if err != nil {
-		return page, fmt.Errorf("pageSize should be an integer: %s", size)
-	}
-
-	if page.Number <= 0 {
-		return page, fmt.Errorf("pageNum should be greater than 0 if pageSize is provided")
-	}
-
-	if page.Size <= 0 {
-		return page, fmt.Errorf("pageSize should be greater than 0 if pageNum is provided")
-	}
-
-	return page, nil
-}
 
 func paginateNodes(nodes []*definition.Node, page definition.Page) ([]*definition.Node, error) {
 	if !page.IsRequired() {

--- a/internal/api/v1/nodes/watch.go
+++ b/internal/api/v1/nodes/watch.go
@@ -1,20 +1,22 @@
-package metrics
+package nodes
 
 import (
 	"errors"
 	"net/http"
-	"strconv"
 	"sync"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
-	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/gin-gonic/gin"
 	json "github.com/json-iterator/go"
-	log "go-micro.dev/v5/logger"
 )
 
-type watcher chan cubecos.Summary
+type respChan chan data
+
+type watcher struct {
+	helper
+	respChan
+}
 
 var (
 	stream = struct {
@@ -23,23 +25,22 @@ var (
 	}{}
 )
 
-func streamSummary() {
+func streamNodes() {
 	for {
 		wait.Seconds(2)
 		if len(stream.Watchers) == 0 {
 			continue
 		}
 
-		summary, err := cubecos.GetDataCenterSummary()
-		if err != nil {
-			log.Errorf("summary: failed to fetch data center summary: %v", err)
-			continue
-		}
-
 		stream.Lock()
 		for _, w := range stream.Watchers {
+			nodes, err := w.genNodeResp()
+			if err != nil {
+				continue
+			}
+
 			select {
-			case w <- *summary:
+			case w.respChan <- *nodes:
 			default:
 			}
 		}
@@ -48,30 +49,20 @@ func streamSummary() {
 	}
 }
 
-func parseWatch(c *gin.Context) (bool, error) {
-	rawParam := c.DefaultQuery("watch", "false")
-	watch, err := strconv.ParseBool(rawParam)
-	if err != nil {
-		return false, errors.New("watch parameter is invalid, it should be true or false if provided")
-	}
-
-	return watch, nil
-}
-
-func watchSummary(c *gin.Context, summary *cubecos.Summary) {
-	setChunkedTransfer(c)
-	flusher, ok := c.Writer.(http.Flusher)
+func watchNodes(h *helper, nodes data) {
+	setChunkedTransfer(h.c)
+	flusher, ok := h.c.Writer.(http.Flusher)
 	if !ok {
-		api.SetBadRequest(c, errors.New("http chunked transfer is not supported"))
+		api.SetBadRequest(h.c, errors.New("http chunked transfer is not supported"))
 		return
 	}
 
-	watcher := make(watcher)
+	watcher := watcher{helper: *h, respChan: make(respChan)}
 	addWatcher(watcher)
 	defer removeWatcher(watcher)
 
-	sendFirstSummary(c, flusher, summary)
-	streamingSummary(c, flusher, watcher)
+	sendFirstSummary(h.c, flusher, nodes)
+	streamingSummary(h.c, flusher, watcher)
 }
 
 func setChunkedTransfer(c *gin.Context) {
@@ -102,8 +93,8 @@ func removeWatcher(watcherToRemove watcher) {
 	}
 }
 
-func sendFirstSummary(c *gin.Context, flusher http.Flusher, summary *cubecos.Summary) {
-	c.Writer.Write(streamingResp(summary))
+func sendFirstSummary(c *gin.Context, flusher http.Flusher, nodes data) {
+	c.Writer.Write(streamingResp(nodes))
 	c.Writer.Write([]byte("\n"))
 	flusher.Flush()
 }
@@ -112,23 +103,23 @@ func streamingSummary(c *gin.Context, flusher http.Flusher, watcher watcher) {
 	ctx := c.Request.Context()
 	for {
 		select {
-		case summary := <-watcher:
-			c.Writer.Write(streamingResp(&summary))
+		case nodes := <-watcher.respChan:
+			c.Writer.Write(streamingResp(nodes))
 			c.Writer.Write([]byte("\n"))
 			flusher.Flush()
 		case <-ctx.Done():
-			api.SetStatusOk(c, "summary watching is stopped successfully", nil)
+			api.SetStatusOk(c, "nodes watching is stopped successfully", nil)
 			return
 		}
 	}
 }
 
-func streamingResp(summary *cubecos.Summary) []byte {
+func streamingResp(nodes data) []byte {
 	b, err := json.Marshal(gin.H{
 		"code":   http.StatusOK,
 		"status": "ok",
-		"msg":    "fetch data center summary successfully",
-		"data":   *summary,
+		"msg":    "fetch nodes successfully",
+		"data":   nodes,
 	})
 	if err != nil {
 		return []byte{}

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/influx"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/api/query"
@@ -59,7 +60,7 @@ func countEvents(c *api.QueryTableResult) (int64, error) {
 }
 
 func GetEvents(stmt string) ([]definition.Event, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(60))
 	defer cancel()
 
 	h := influx.GetGlobalHelper()


### PR DESCRIPTION
### What type of PR is this?

feat

<br/>

### Which issue(s) this PR fixes?

#70  

<br/>

### What this PR does?

To add the "watch" toggle in the APIs below to support the HTTP Chunked Transfer

Also add the corresponding param to the API doc

- /api/v1/datacenters/{dataCenter}/metrics?watch=true

- /api/v1/datacenters/{dataCenter}/healths?watch=true

- /api/v1/datacenters/{dataCenter}/events?watch=true

- /api/v1/datacenters/{dataCenter}/nodes?watch=true


<br/>

### Test results (optional)

1). See the video to review the watch behavior from the APIs

https://github.com/user-attachments/assets/5f3bfb4e-0dc2-4dd3-ad76-59130540d5ba

<br/>

2). See the video to review the adjusted API docs

https://github.com/user-attachments/assets/9cdda036-47a0-4fff-acbc-d1c3da405394

