### PR TITLE
Add a new event listing api for event abstract purpose

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -332,6 +332,343 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/events/abstract": {
+            "get": {
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Retrieve the abstracted events",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The type of event to query, the value can be only 'system', 'host', and 'instance'.",
+                        "example": "system"
+                    },
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The limit of the abstracted events to return (default is 10).",
+                        "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the abstracted events successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "events": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "host": {
+                                                                "type": "string"
+                                                            },
+                                                            "category": {
+                                                                "type": "string"
+                                                            },
+                                                            "service": {
+                                                                "type": "string"
+                                                            },
+                                                            "metadata": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ip": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "time": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "limit": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "number": {
+                                                            "type": "integer"
+                                                        },
+                                                        "description": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Abstracted recent events",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "events": [
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"ccc449e4-a26c-47ac-afc1-c792ab1ed20a\" at 192.168.0.10 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "ccc449e4-a26c-47ac-afc1-c792ab1ed20a",
+                                                            "ip": "192.168.0.10"
+                                                        },
+                                                        "time": "2025-02-04T06:05:08Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"441ddbcb-c6a3-48cd-933c-c416d52032b8\" at 192.168.0.127 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "441ddbcb-c6a3-48cd-933c-c416d52032b8",
+                                                            "ip": "192.168.0.127"
+                                                        },
+                                                        "time": "2025-02-03T19:30:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"17fa8b83-3f9c-4541-a4a8-10b972f19bd2\" at 10.254.1.149 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "17fa8b83-3f9c-4541-a4a8-10b972f19bd2",
+                                                            "ip": "10.254.1.149"
+                                                        },
+                                                        "time": "2025-02-03T19:15:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "SDN00002I",
+                                                        "description": "PROJ001 deleted virtual port 192.168.1.87 (fa:16:3e:b1:5c:89)",
+                                                        "host": "",
+                                                        "category": "sdn",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "sdn",
+                                                            "device_id": "32f4993f-c692-49c9-9b5e-e1bd1014699e",
+                                                            "network_id": "cae0e230-9713-4717-a94e-7e2a50cb2d86",
+                                                            "port_id": "5f20ef48-a1ea-4ef9-8463-6a790b2026c2"
+                                                        },
+                                                        "time": "2025-02-03T17:32:09Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "SDN00002I",
+                                                        "description": "PROJ001 deleted virtual port 192.168.1.5 (fa:16:3e:ce:ab:6b)",
+                                                        "host": "",
+                                                        "category": "sdn",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "sdn",
+                                                            "device_id": "4222d5e8-ccb2-4069-af14-d8f0fe3fbfea",
+                                                            "network_id": "cae0e230-9713-4717-a94e-7e2a50cb2d86",
+                                                            "port_id": "1caa0da6-8c58-4a80-9bac-2eda77c23c92"
+                                                        },
+                                                        "time": "2025-02-03T17:32:09Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"e5a85381-023c-4087-a607-c74687dc3b52\" at 10.254.1.235 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "e5a85381-023c-4087-a607-c74687dc3b52",
+                                                            "ip": "10.254.1.235"
+                                                        },
+                                                        "time": "2025-02-03T17:30:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"66cdfddb-efe1-4b67-b864-76c5d106524c\" at 10.254.131.183 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "66cdfddb-efe1-4b67-b864-76c5d106524c",
+                                                            "ip": "10.254.131.183"
+                                                        },
+                                                        "time": "2025-02-03T17:30:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"f682fc8d-2c8d-4557-9b84-049e5a72b713\" at 192.168.0.157 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "f682fc8d-2c8d-4557-9b84-049e5a72b713",
+                                                            "ip": "192.168.0.157"
+                                                        },
+                                                        "time": "2025-02-03T17:15:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"6942ec52-f089-434d-ba5c-6137015b91b1\" at 192.168.0.108 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "6942ec52-f089-434d-ba5c-6137015b91b1",
+                                                            "ip": "192.168.0.108"
+                                                        },
+                                                        "time": "2025-02-03T16:50:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"2d9ce9a4-5fe9-4011-84ae-8ecb20f64594\" at 192.168.0.111 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "2d9ce9a4-5fe9-4011-84ae-8ecb20f64594",
+                                                            "ip": "192.168.0.111"
+                                                        },
+                                                        "time": "2025-02-03T16:35:15Z"
+                                                    }
+                                                ],
+                                                "limit": {
+                                                    "number": 10,
+                                                    "description": "the top 10 recent events"
+                                                }
+                                            },
+                                            "msg": "fetch event abstract successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid 'start' time: 2021-09-01T111:00:00Z"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch events: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/healths": {
             "get": {
                 "tags": [
@@ -922,10 +1259,11 @@ const docTemplate = `{
                                                             "status": "ng",
                                                             "error": {
                                                                 "type": "service down",
+                                                                "reason": "1 node down",
                                                                 "nodes": [
                                                                     "example-node-0"
                                                                 ],
-                                                                "description": "nova has 1 node down",
+                                                                "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... best effort error summary / direction ...}",
                                                                 "log": "http://datacenter1:8888/log/nova/dell180-20250205113459-b3gc.log"
                                                             }

--- a/api/docs.json
+++ b/api/docs.json
@@ -328,6 +328,343 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/events/abstract": {
+            "get": {
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Retrieve the abstracted events",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The type of event to query, the value can be only 'system', 'host', and 'instance'.",
+                        "example": "system"
+                    },
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The limit of the abstracted events to return (default is 10).",
+                        "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the abstracted events successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "events": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "host": {
+                                                                "type": "string"
+                                                            },
+                                                            "category": {
+                                                                "type": "string"
+                                                            },
+                                                            "service": {
+                                                                "type": "string"
+                                                            },
+                                                            "metadata": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ip": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "time": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "limit": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "number": {
+                                                            "type": "integer"
+                                                        },
+                                                        "description": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Abstracted recent events",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "events": [
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"ccc449e4-a26c-47ac-afc1-c792ab1ed20a\" at 192.168.0.10 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "ccc449e4-a26c-47ac-afc1-c792ab1ed20a",
+                                                            "ip": "192.168.0.10"
+                                                        },
+                                                        "time": "2025-02-04T06:05:08Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"441ddbcb-c6a3-48cd-933c-c416d52032b8\" at 192.168.0.127 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "441ddbcb-c6a3-48cd-933c-c416d52032b8",
+                                                            "ip": "192.168.0.127"
+                                                        },
+                                                        "time": "2025-02-03T19:30:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"17fa8b83-3f9c-4541-a4a8-10b972f19bd2\" at 10.254.1.149 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "17fa8b83-3f9c-4541-a4a8-10b972f19bd2",
+                                                            "ip": "10.254.1.149"
+                                                        },
+                                                        "time": "2025-02-03T19:15:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "SDN00002I",
+                                                        "description": "PROJ001 deleted virtual port 192.168.1.87 (fa:16:3e:b1:5c:89)",
+                                                        "host": "",
+                                                        "category": "sdn",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "sdn",
+                                                            "device_id": "32f4993f-c692-49c9-9b5e-e1bd1014699e",
+                                                            "network_id": "cae0e230-9713-4717-a94e-7e2a50cb2d86",
+                                                            "port_id": "5f20ef48-a1ea-4ef9-8463-6a790b2026c2"
+                                                        },
+                                                        "time": "2025-02-03T17:32:09Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "SDN00002I",
+                                                        "description": "PROJ001 deleted virtual port 192.168.1.5 (fa:16:3e:ce:ab:6b)",
+                                                        "host": "",
+                                                        "category": "sdn",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "sdn",
+                                                            "device_id": "4222d5e8-ccb2-4069-af14-d8f0fe3fbfea",
+                                                            "network_id": "cae0e230-9713-4717-a94e-7e2a50cb2d86",
+                                                            "port_id": "1caa0da6-8c58-4a80-9bac-2eda77c23c92"
+                                                        },
+                                                        "time": "2025-02-03T17:32:09Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"e5a85381-023c-4087-a607-c74687dc3b52\" at 10.254.1.235 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "e5a85381-023c-4087-a607-c74687dc3b52",
+                                                            "ip": "10.254.1.235"
+                                                        },
+                                                        "time": "2025-02-03T17:30:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"66cdfddb-efe1-4b67-b864-76c5d106524c\" at 10.254.131.183 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "66cdfddb-efe1-4b67-b864-76c5d106524c",
+                                                            "ip": "10.254.131.183"
+                                                        },
+                                                        "time": "2025-02-03T17:30:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"f682fc8d-2c8d-4557-9b84-049e5a72b713\" at 192.168.0.157 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "f682fc8d-2c8d-4557-9b84-049e5a72b713",
+                                                            "ip": "192.168.0.157"
+                                                        },
+                                                        "time": "2025-02-03T17:15:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"6942ec52-f089-434d-ba5c-6137015b91b1\" at 192.168.0.108 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "6942ec52-f089-434d-ba5c-6137015b91b1",
+                                                            "ip": "192.168.0.108"
+                                                        },
+                                                        "time": "2025-02-03T16:50:15Z"
+                                                    },
+                                                    {
+                                                        "type": "Info",
+                                                        "id": "NET00003I",
+                                                        "description": "instance \"2d9ce9a4-5fe9-4011-84ae-8ecb20f64594\" at 192.168.0.111 is reachable",
+                                                        "host": "",
+                                                        "category": "net",
+                                                        "service": "",
+                                                        "metadata": {
+                                                            "category": "net",
+                                                            "id": "2d9ce9a4-5fe9-4011-84ae-8ecb20f64594",
+                                                            "ip": "192.168.0.111"
+                                                        },
+                                                        "time": "2025-02-03T16:35:15Z"
+                                                    }
+                                                ],
+                                                "limit": {
+                                                    "number": 10,
+                                                    "description": "the top 10 recent events"
+                                                }
+                                            },
+                                            "msg": "fetch event abstract successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid 'start' time: 2021-09-01T111:00:00Z"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch events: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/healths": {
             "get": {
                 "tags": [
@@ -918,10 +1255,11 @@
                                                             "status": "ng",
                                                             "error": {
                                                                 "type": "service down",
+                                                                "reason": "1 node down",
                                                                 "nodes": [
                                                                     "example-node-0"
                                                                 ],
-                                                                "description": "nova has 1 node down",
+                                                                "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... best effort error summary / direction ...}",
                                                                 "log": "http://datacenter1:8888/log/nova/dell180-20250205113459-b3gc.log"
                                                             }

--- a/internal/api/v1/events/handlers.go
+++ b/internal/api/v1/events/handlers.go
@@ -16,6 +16,12 @@ var (
 			Path:    "/events",
 			Func:    getEvents,
 		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/events/abstract",
+			Func:    getEventAbstract,
+		},
 	}
 )
 
@@ -24,28 +30,55 @@ func init() {
 }
 
 func getEvents(c *gin.Context) {
-	h, err := initReqHelper(c)
+	h, err := initReqHelper(c, "getEvents")
 	if err != nil {
 		log.Errorf("request(%s): %v", api.GetReqId(c), err)
 		api.SetBadRequest(c, err)
 		return
 	}
 
-	resp, err := h.genEventResp()
+	events, err := h.genEvents()
 	if err != nil {
-		log.Errorf("request(%s): failed to gen event resp: %v", api.GetReqId(c), err)
+		log.Errorf("request(%s): failed to gen events: %v", api.GetReqId(c), err)
 		api.SetInternalServerError(c, err)
 		return
 	}
 
 	if h.watch {
-		watchEvents(h, resp)
+		watchEvents(h, events)
 		return
 	}
 
 	api.SetStatusOk(
 		c,
 		"fetch events successfully",
-		resp,
+		events,
+	)
+}
+
+func getEventAbstract(c *gin.Context) {
+	h, err := initReqHelper(c, "getEventAbstract")
+	if err != nil {
+		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	abstract, err := h.genEventAbstract()
+	if err != nil {
+		log.Errorf("request(%s): failed to gen event abstract: %v", api.GetReqId(c), err)
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	if h.watch {
+		watchEvents(h, abstract)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"fetch event abstract successfully",
+		abstract,
 	)
 }

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -14,9 +15,13 @@ import (
 
 type helper struct {
 	c         *gin.Context
+	handler   string
 	eventType string
+
 	period
 	definition.Page
+	limit int
+
 	watch bool
 }
 
@@ -25,9 +30,22 @@ type period struct {
 	stop  string
 }
 
-func initReqHelper(c *gin.Context) (*helper, error) {
+func initReqHelper(c *gin.Context, handler string) (*helper, error) {
 	h := &helper{c: c}
 
+	switch handler {
+	case "getEvents":
+		h.handler = "getEvents"
+		return h.parseEventListingParams()
+	case "getEventAbstract":
+		h.handler = "getEventAbstract"
+		return h.parseEventAbstractParams()
+	}
+
+	return nil, errors.New("no internal function supported")
+}
+
+func (h *helper) parseEventListingParams() (*helper, error) {
 	err := h.parseType()
 	if err != nil {
 		return nil, err
@@ -39,6 +57,25 @@ func initReqHelper(c *gin.Context) (*helper, error) {
 	}
 
 	err = h.parsePage()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseWatch()
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *helper) parseEventAbstractParams() (*helper, error) {
+	err := h.parseType()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseLimit()
 	if err != nil {
 		return nil, err
 	}
@@ -65,19 +102,22 @@ func (h *helper) parseType() error {
 }
 
 func (h *helper) parsePeriod() error {
-	start := h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
-	_, err := time.Parse(time.RFC3339, start)
+	qStart := h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
+	start, err := time.Parse(time.RFC3339, qStart)
 	if err != nil {
-		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", start)
+		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", qStart)
 	}
 
-	stop := h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
-	_, err = time.Parse(time.RFC3339, stop)
+	qStop := h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
+	stop, err := time.Parse(time.RFC3339, qStop)
 	if err != nil {
-		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", stop)
+		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", qStop)
 	}
 
-	h.period = period{start: start, stop: stop}
+	h.period = period{
+		start: definition.TimeUTC(start),
+		stop:  definition.TimeUTC(stop),
+	}
 	return nil
 }
 
@@ -93,35 +133,58 @@ func (h *helper) parsePage() error {
 	}
 
 	if size == "" {
-		return fmt.Errorf("pageSize should greater than 0 if pageNum is provided")
+		return fmt.Errorf("pageSize should be provided if pageNum is provided")
 	}
 
-	intPageNum, err := strconv.Atoi(num)
+	var err error
+	h.Page.Number, err = strconv.Atoi(num)
 	if err != nil {
 		return fmt.Errorf("pageNum should be an integer: %s", num)
 	}
 
-	intPageSize, err := strconv.Atoi(size)
+	h.Page.Size, err = strconv.Atoi(size)
 	if err != nil {
 		return fmt.Errorf("pageSize should be an integer: %s", size)
 	}
 
-	h.Page = definition.Page{Number: intPageNum, Size: intPageSize}
+	if h.Page.Number <= 0 {
+		return fmt.Errorf("pageNum should be greater than 0 if pageSize is provided")
+	}
+
+	if h.Page.Size <= 0 {
+		return fmt.Errorf("pageSize should be greater than 0 if pageNum is provided")
+	}
+
 	return nil
 }
 
-func (h *helper) parseWatch() error {
-	watch, err := api.ParseWatch(h.c)
+func (h *helper) parseLimit() error {
+	var err error
+	limit := h.c.DefaultQuery("limit", "10")
+	h.limit, err = strconv.Atoi(limit)
 	if err != nil {
 		return err
 	}
 
-	h.watch = watch
+	if h.limit <= 0 {
+		return fmt.Errorf("limit should be greater than 0")
+	}
+
 	return nil
 }
 
-func (h *helper) genEventResp() (*resp, error) {
-	stmt := h.genQueryStmt()
+func (h *helper) parseWatch() error {
+	var err error
+	h.watch, err = api.ParseWatch(h.c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *helper) genEvents() (*data, error) {
+	stmt := h.genListingStmt()
 	events, err := cubecos.GetEvents(stmt)
 	if err != nil {
 		log.Errorf("request(%s): failed to get events: %v", api.GetReqId(h.c), err)
@@ -134,5 +197,25 @@ func (h *helper) genEventResp() (*resp, error) {
 		return nil, err
 	}
 
-	return &resp{Events: events, Page: page}, nil
+	return &data{
+		Events: events,
+		Page:   &page,
+	}, nil
+}
+
+func (h *helper) genEventAbstract() (*data, error) {
+	stmt := h.genAbstractStmt()
+	events, err := cubecos.GetEvents(stmt)
+	if err != nil {
+		log.Errorf("request(%s): failed to get events: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	return &data{
+		Events: events,
+		Limit: &definition.Limit{
+			Number:      h.limit,
+			Description: fmt.Sprintf("the top %d recent events", h.limit),
+		},
+	}, nil
 }

--- a/internal/api/v1/events/resp.go
+++ b/internal/api/v1/events/resp.go
@@ -2,7 +2,8 @@ package events
 
 import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 
-type resp struct {
-	Events          []definition.Event `json:"events"`
-	definition.Page `json:"page"`
+type data struct {
+	Events            []definition.Event `json:"events"`
+	*definition.Page  `json:"page,omitempty"`
+	*definition.Limit `json:"limit,omitempty"`
 }

--- a/internal/api/v1/events/stmt.go
+++ b/internal/api/v1/events/stmt.go
@@ -31,6 +31,16 @@ var (
 			|> sort(columns: ["_time"], desc: true)
 			|> limit(n: %d, offset: %d)
 	`
+
+	eventLimitingQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: 0)
+			|> filter(fn: (r) => r._measurement == "%s")
+			|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+			|> group()
+			|> sort(columns: ["_time"], desc: true)
+			|> limit(n: %d)
+	`
 )
 
 func (h *helper) genCountQueryStmt() string {
@@ -42,7 +52,7 @@ func (h *helper) genCountQueryStmt() string {
 	)
 }
 
-func (h *helper) genQueryStmt() string {
+func (h *helper) genListingStmt() string {
 	if !h.isPageRequired() {
 		return h.genNonPagingQueryStmt()
 	}
@@ -68,5 +78,13 @@ func (h *helper) genPagingQueryStmt() string {
 		h.eventType,
 		h.Page.Size,
 		offset,
+	)
+}
+
+func (h *helper) genAbstractStmt() string {
+	return fmt.Sprintf(
+		eventLimitingQueryTemplate,
+		h.eventType,
+		h.limit,
 	)
 }

--- a/internal/api/v1/events/watch.go
+++ b/internal/api/v1/events/watch.go
@@ -11,11 +11,11 @@ import (
 	json "github.com/json-iterator/go"
 )
 
-type respChan chan resp
+type dataChan chan data
 
 type watcher struct {
 	helper
-	respChan
+	dataChan
 }
 
 var (
@@ -34,13 +34,13 @@ func streamEvents() {
 
 		stream.Lock()
 		for _, w := range stream.Watchers {
-			resp, err := w.genEventResp()
+			resp, err := streamEventsByHandlerType(&w.helper)
 			if err != nil {
 				continue
 			}
 
 			select {
-			case w.respChan <- *resp:
+			case w.dataChan <- *resp:
 			default:
 			}
 		}
@@ -49,7 +49,18 @@ func streamEvents() {
 	}
 }
 
-func watchEvents(h *helper, resp *resp) {
+func streamEventsByHandlerType(h *helper) (*data, error) {
+	switch h.handler {
+	case "getEvents":
+		return h.genEvents()
+	case "getEventAbstract":
+		return h.genEventAbstract()
+	}
+
+	return nil, errors.New("no internal function supported")
+}
+
+func watchEvents(h *helper, data *data) {
 	setChunkedTransfer(h.c)
 	flusher, ok := h.c.Writer.(http.Flusher)
 	if !ok {
@@ -57,11 +68,11 @@ func watchEvents(h *helper, resp *resp) {
 		return
 	}
 
-	watcher := watcher{helper: *h, respChan: make(respChan)}
+	watcher := watcher{helper: *h, dataChan: make(dataChan)}
 	addWatcher(watcher)
 	defer removeWatcher(watcher)
 
-	sendFirstSummary(h.c, flusher, resp)
+	sendFirstSummary(h.c, flusher, data)
 	streamingSummary(h.c, flusher, watcher)
 }
 
@@ -93,8 +104,8 @@ func removeWatcher(watcherToRemove watcher) {
 	}
 }
 
-func sendFirstSummary(c *gin.Context, flusher http.Flusher, resp *resp) {
-	c.Writer.Write(streamingResp(resp))
+func sendFirstSummary(c *gin.Context, flusher http.Flusher, data *data) {
+	c.Writer.Write(streamingResp(data))
 	c.Writer.Write([]byte("\n"))
 	flusher.Flush()
 }
@@ -103,8 +114,8 @@ func streamingSummary(c *gin.Context, flusher http.Flusher, watcher watcher) {
 	ctx := c.Request.Context()
 	for {
 		select {
-		case resp := <-watcher.respChan:
-			c.Writer.Write(streamingResp(&resp))
+		case data := <-watcher.dataChan:
+			c.Writer.Write(streamingResp(&data))
 			c.Writer.Write([]byte("\n"))
 			flusher.Flush()
 		case <-ctx.Done():
@@ -114,12 +125,12 @@ func streamingSummary(c *gin.Context, flusher http.Flusher, watcher watcher) {
 	}
 }
 
-func streamingResp(resp *resp) []byte {
+func streamingResp(data *data) []byte {
 	b, err := json.Marshal(gin.H{
 		"code":   http.StatusOK,
 		"status": "ok",
 		"msg":    "fetch event successfully",
-		"data":   *resp,
+		"data":   *data,
 	})
 	if err != nil {
 		return []byte{}

--- a/internal/api/v1/healths/helper.go
+++ b/internal/api/v1/healths/helper.go
@@ -61,22 +61,26 @@ func initReqHelper(c *gin.Context) (*helper, error) {
 }
 
 func (h *helper) parsePeriod() error {
-	h.period.start = h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
-	start, err := time.Parse(time.RFC3339, h.period.start)
+	qStart := h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
+	start, err := time.Parse(time.RFC3339, qStart)
 	if err != nil {
-		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", h.period.start)
+		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", qStart)
 	}
 
-	h.period.stop = h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
-	stop, err := time.Parse(time.RFC3339, h.period.stop)
+	qStop := h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
+	stop, err := time.Parse(time.RFC3339, qStop)
 	if err != nil {
-		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", h.period.stop)
+		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", qStop)
 	}
 
 	if stop.Before(start) {
 		return fmt.Errorf("'stop' time should be after 'start' time(start: %s, stop: %s)", start, stop)
 	}
 
+	h.period = period{
+		start: definition.TimeUTC(start),
+		stop:  definition.TimeUTC(stop),
+	}
 	return nil
 }
 

--- a/internal/api/v1/healths/payload.go
+++ b/internal/api/v1/healths/payload.go
@@ -113,7 +113,8 @@ func (h *helper) setFakeError(checkResult *cubecos.HealthCheckPoint) {
 	checkResult.Error = &cubecos.Error{
 		Type:        "service down",
 		Nodes:       []string{definition.DataCenterName},
-		Description: "nova has 1 nodes down",
+		Reason:      "1 node down",
+		Description: "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
 		Details:     "{ ... the best efforts of error summary / direction ...} ",
 		Log: fmt.Sprintf(
 			"http://{dataCenter}:8888/log/nova/%s-20250205113459-b3gc.log",

--- a/internal/api/v1/metrics/parameter.go
+++ b/internal/api/v1/metrics/parameter.go
@@ -78,19 +78,22 @@ func (h *helper) parsePeriod() error {
 		return nil
 	}
 
-	h.Period.Start = h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
-	start, err := time.Parse(time.RFC3339, h.Period.Start)
+	qStart := h.c.DefaultQuery("start", definition.TimeRFC3339(-24*time.Hour))
+	start, err := time.Parse(time.RFC3339, qStart)
 	if err != nil {
-		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", h.Period.Start)
-	}
-	trick.Minus2MinsOnMetricStartTime(&h.Period.Start, start)
-
-	h.Period.Stop = h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
-	_, err = time.Parse(time.RFC3339, h.Period.Stop)
-	if err != nil {
-		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", h.Period.Stop)
+		return fmt.Errorf("'start' time format should be aligned with RFC3339: %s", qStart)
 	}
 
+	qStop := h.c.DefaultQuery("stop", definition.TimeNowRFC3339())
+	stop, err := time.Parse(time.RFC3339, qStop)
+	if err != nil {
+		return fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", qStop)
+	}
+
+	h.Period = definition.Period{
+		Start: definition.TimeUTC(trick.Minus2MinsOnMetricStart(start)),
+		Stop:  definition.TimeUTC(stop),
+	}
 	return nil
 }
 

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -72,7 +72,7 @@ func GetEvents(stmt string) ([]definition.Event, error) {
 
 	defer c.Close()
 	events := []definition.Event{}
-	err = parseEventsFromCursor(c, &events)
+	err = parseEvents(c, &events)
 	if err != nil {
 		log.Errorf("failed to parse events from cursor: %v", err)
 		return nil, err
@@ -81,7 +81,7 @@ func GetEvents(stmt string) ([]definition.Event, error) {
 	return events, nil
 }
 
-func parseEventsFromCursor(c *api.QueryTableResult, events *[]definition.Event) error {
+func parseEvents(c *api.QueryTableResult, events *[]definition.Event) error {
 	for c.Next() {
 		record := c.Record()
 		event := genEventByRecord(record)
@@ -96,7 +96,7 @@ func parseEventsFromCursor(c *api.QueryTableResult, events *[]definition.Event) 
 }
 
 func genEventByRecord(record *query.FluxRecord) definition.Event {
-	date, err := time.Parse(eventTimeLayout, record.Time().String())
+	date, err := time.Parse(eventTimeLayout, record.Time().Local().String())
 	if err != nil {
 		log.Warnf("failed to parse date from record: %v", record)
 	}
@@ -121,7 +121,7 @@ func genEventByRecord(record *query.FluxRecord) definition.Event {
 		Id:          eventId,
 		Description: msg,
 		Host:        "",
-		Time:        date.Format(time.RFC3339),
+		Time:        definition.TimeLocalISO8601(date),
 	}
 }
 

--- a/internal/cubecos/health.go
+++ b/internal/cubecos/health.go
@@ -35,6 +35,7 @@ type HealthCheckPoint struct {
 
 type Error struct {
 	Type        string   `json:"type"`
+	Reason      string   `json:"reason"`
 	Nodes       []string `json:"nodes"`
 	Description string   `json:"description"`
 	Details     string   `json:"details"`

--- a/internal/cubecos/metrics.go
+++ b/internal/cubecos/metrics.go
@@ -773,7 +773,7 @@ func parseHostStorageUsageRank(c *api.QueryTableResult) ([]definition.HostPercen
 func parseTimeOpsSeries(c *api.QueryTableResult) ([]definition.TimeOpsPoint, error) {
 	points := []definition.TimeOpsPoint{}
 	for c.Next() {
-		date, err := time.Parse(eventTimeLayout, c.Record().Time().String())
+		date, err := time.Parse(eventTimeLayout, c.Record().Time().Local().String())
 		if err != nil {
 			continue
 		}
@@ -793,7 +793,7 @@ func parseTimeOpsSeries(c *api.QueryTableResult) ([]definition.TimeOpsPoint, err
 func parseTimeLatencySeries(c *api.QueryTableResult) ([]definition.TimeLatencyPoint, error) {
 	points := []definition.TimeLatencyPoint{}
 	for c.Next() {
-		date, err := time.Parse(eventTimeLayout, c.Record().Time().String())
+		date, err := time.Parse(eventTimeLayout, c.Record().Time().Local().String())
 		if err != nil {
 			continue
 		}
@@ -801,7 +801,7 @@ func parseTimeLatencySeries(c *api.QueryTableResult) ([]definition.TimeLatencyPo
 		points = append(
 			points,
 			definition.TimeLatencyPoint{
-				Time: date.Format(time.RFC3339),
+				Time: definition.TimeLocalISO8601(date),
 				Ms:   math.RoundDown(c.Record().Value().(float64), 4),
 			},
 		)
@@ -844,7 +844,7 @@ func getHostStorageBandwidthSeries(stmt string) ([]definition.TimeBytesPoint, er
 func parseTimeBytesSeries(c *api.QueryTableResult) ([]definition.TimeBytesPoint, error) {
 	points := []definition.TimeBytesPoint{}
 	for c.Next() {
-		date, err := time.Parse(eventTimeLayout, c.Record().Time().String())
+		date, err := time.Parse(eventTimeLayout, c.Record().Time().Local().String())
 		if err != nil {
 			continue
 		}
@@ -852,7 +852,7 @@ func parseTimeBytesSeries(c *api.QueryTableResult) ([]definition.TimeBytesPoint,
 		points = append(
 			points,
 			definition.TimeBytesPoint{
-				Time:  date.Format(time.RFC3339),
+				Time:  definition.TimeLocalISO8601(date),
 				Bytes: math.RoundDown(c.Record().Value().(float64), 4),
 			},
 		)

--- a/internal/definition/v1/pagination.go
+++ b/internal/definition/v1/pagination.go
@@ -13,3 +13,8 @@ func (p Page) IsRequired() bool {
 func IsPageRequired(pageNum, pageSize string) bool {
 	return pageNum != "" || pageSize != ""
 }
+
+type Limit struct {
+	Number      int    `json:"number"`
+	Description string `json:"description"`
+}

--- a/internal/definition/v1/time.go
+++ b/internal/definition/v1/time.go
@@ -1,9 +1,12 @@
 package v1
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 const (
-	Iso8601 = "2006-01-02T15:04:05"
+	ISO8601 = "2006-01-02T15:04:05"
 	RFC3339 = time.RFC3339
 )
 
@@ -12,10 +15,18 @@ type Period struct {
 	Stop  string
 }
 
+func TimeUTC(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
 func TimeNowRFC3339() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
 
 func TimeRFC3339(duration time.Duration) string {
 	return time.Now().Add(duration).UTC().Format(time.RFC3339)
+}
+
+func TimeLocalISO8601(t time.Time) string {
+	return fmt.Sprintf("%sZ", t.Format(ISO8601))
 }

--- a/internal/trick/time.go
+++ b/internal/trick/time.go
@@ -2,7 +2,6 @@ package trick
 
 import "time"
 
-func Minus2MinsOnMetricStartTime(start *string, t time.Time) {
-	minusStart := t.Add(-2 * time.Minute).Format(time.RFC3339)
-	*start = minusStart
+func Minus2MinsOnMetricStart(t time.Time) time.Time {
+	return t.Add(-2 * time.Minute)
 }


### PR DESCRIPTION
### What type of PR is this?

feat

<br/>

### Which issue(s) this PR fixes?

#84 

<br/>

### What this PR does?

Based on the current decision with FE(details can be checked in #84 ), to add the API below for support event abstract

- /api/v1/datacenters/{dataCenter}/events/abstract

<br>

The usage could be

- normal use: /api/v1/datacenters/dell180/events/abstract?type=system&limit=1

- with watch: /api/v1/datacenters/dell180/events/abstract?type=system&limit=1&watch=true


<br/>

### Test results (optional)

1). Make sure event abstract can be fetched successfully in normal use or with watch mode

![Screenshot 2025-02-07 at 12 46 23 AM](https://github.com/user-attachments/assets/cd41105f-6483-42cd-9b28-c64bfe9d3ad1)

![Screenshot 2025-02-07 at 12 57 17 AM](https://github.com/user-attachments/assets/dbd19c20-1a97-4e47-8caa-1373d677dc32)


<br/>

2). Make sure the corresponding API doc can be viewed on the Swagger

![Screenshot 2025-02-07 at 12 55 31 AM](https://github.com/user-attachments/assets/3dfd4672-c709-4325-8d10-f46ee2dd7747)

![Screenshot 2025-02-07 at 12 45 29 AM](https://github.com/user-attachments/assets/beb35864-131f-4fc2-ac61-343224a2aad2)

![Screenshot 2025-02-07 at 12 45 46 AM](https://github.com/user-attachments/assets/bc49fd92-cec2-4438-a3b7-19531171b2d1)

![Screenshot 2025-02-07 at 12 45 56 AM](https://github.com/user-attachments/assets/db63ed92-5469-4da9-8660-16894d2e2faf)

