### PR TITLE
Adjust the home page APIs by the feedbacks from team 

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -299,6 +299,10 @@ const docTemplate = `{
                                                         "properties": {
                                                             "type": {
                                                                 "type": "string",
+                                                                "example": "system"
+                                                            },
+                                                            "severity": {
+                                                                "type": "string",
                                                                 "example": "Info"
                                                             },
                                                             "id": {
@@ -494,6 +498,9 @@ const docTemplate = `{
                                                             "type": {
                                                                 "type": "string"
                                                             },
+                                                            "severity": {
+                                                                "type": "string"
+                                                            },
                                                             "id": {
                                                                 "type": "string"
                                                             },
@@ -555,7 +562,8 @@ const docTemplate = `{
                                             "data": {
                                                 "events": [
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"ccc449e4-a26c-47ac-afc1-c792ab1ed20a\" at 192.168.0.10 is reachable",
                                                         "host": "",
@@ -569,7 +577,8 @@ const docTemplate = `{
                                                         "time": "2025-02-04T06:05:08Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"441ddbcb-c6a3-48cd-933c-c416d52032b8\" at 192.168.0.127 is reachable",
                                                         "host": "",
@@ -583,7 +592,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T19:30:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"17fa8b83-3f9c-4541-a4a8-10b972f19bd2\" at 10.254.1.149 is reachable",
                                                         "host": "",
@@ -597,7 +607,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T19:15:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "SDN00002I",
                                                         "description": "PROJ001 deleted virtual port 192.168.1.87 (fa:16:3e:b1:5c:89)",
                                                         "host": "",
@@ -612,7 +623,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T17:32:09Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "SDN00002I",
                                                         "description": "PROJ001 deleted virtual port 192.168.1.5 (fa:16:3e:ce:ab:6b)",
                                                         "host": "",
@@ -627,7 +639,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T17:32:09Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"e5a85381-023c-4087-a607-c74687dc3b52\" at 10.254.1.235 is reachable",
                                                         "host": "",
@@ -641,7 +654,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T17:30:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"66cdfddb-efe1-4b67-b864-76c5d106524c\" at 10.254.131.183 is reachable",
                                                         "host": "",
@@ -655,7 +669,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T17:30:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"f682fc8d-2c8d-4557-9b84-049e5a72b713\" at 192.168.0.157 is reachable",
                                                         "host": "",
@@ -669,7 +684,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T17:15:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"6942ec52-f089-434d-ba5c-6137015b91b1\" at 192.168.0.108 is reachable",
                                                         "host": "",
@@ -683,7 +699,8 @@ const docTemplate = `{
                                                         "time": "2025-02-03T16:50:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"2d9ce9a4-5fe9-4011-84ae-8ecb20f64594\" at 192.168.0.111 is reachable",
                                                         "host": "",

--- a/api/docs.go
+++ b/api/docs.go
@@ -4165,9 +4165,9 @@ const docTemplate = `{
                                                                     }
                                                                 }
                                                             },
-                                                            "uptime": {
-                                                                "type": "string",
-                                                                "example": "26 days"
+                                                            "uptimeSeconds": {
+                                                                "type": "number",
+                                                                "example": 5658305.34
                                                             },
                                                             "labels": {
                                                                 "type": "object",

--- a/api/docs.go
+++ b/api/docs.go
@@ -24,6 +24,94 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/me": {
+            "get": {
+                "tags": [
+                    "User Info"
+                ],
+                "summary": "Retrieve the own user info",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the own user info successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }  
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Own user info",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "name": "admin"
+                                            },
+                                            "msg": "fetch own user info successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch own user info: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters": {
             "get": {
                 "description": "Retrieve the list of data centers",
@@ -51,6 +139,10 @@ const docTemplate = `{
                                                     "name": {
                                                         "type": "string",
                                                         "example": "bigstack-data-center"
+                                                    },
+                                                    "version": {
+                                                        "type": "string",
+                                                        "example": "Cube Appliance 3.0.0"
                                                     },
                                                     "virtualIp": {
                                                         "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -20,6 +20,94 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/me": {
+            "get": {
+                "tags": [
+                    "User Info"
+                ],
+                "summary": "Retrieve the own user info",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the own user info successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }  
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Own user info",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "name": "admin"
+                                            },
+                                            "msg": "fetch own user info successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch own user info: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters": {
             "get": {
                 "description": "Retrieve the list of data centers",
@@ -47,6 +135,10 @@
                                                     "name": {
                                                         "type": "string",
                                                         "example": "bigstack-data-center"
+                                                    },
+                                                    "version": {
+                                                        "type": "string",
+                                                        "example": "Cube Appliance 3.0.0"
                                                     },
                                                     "virtualIp": {
                                                         "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -295,6 +295,10 @@
                                                         "properties": {
                                                             "type": {
                                                                 "type": "string",
+                                                                "example": "system"
+                                                            },
+                                                            "severity": {
+                                                                "type": "string",
                                                                 "example": "Info"
                                                             },
                                                             "id": {
@@ -490,6 +494,9 @@
                                                             "type": {
                                                                 "type": "string"
                                                             },
+                                                            "severity": {
+                                                                "type": "string"
+                                                            },
                                                             "id": {
                                                                 "type": "string"
                                                             },
@@ -551,7 +558,8 @@
                                             "data": {
                                                 "events": [
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"ccc449e4-a26c-47ac-afc1-c792ab1ed20a\" at 192.168.0.10 is reachable",
                                                         "host": "",
@@ -565,7 +573,8 @@
                                                         "time": "2025-02-04T06:05:08Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"441ddbcb-c6a3-48cd-933c-c416d52032b8\" at 192.168.0.127 is reachable",
                                                         "host": "",
@@ -579,7 +588,8 @@
                                                         "time": "2025-02-03T19:30:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"17fa8b83-3f9c-4541-a4a8-10b972f19bd2\" at 10.254.1.149 is reachable",
                                                         "host": "",
@@ -593,7 +603,8 @@
                                                         "time": "2025-02-03T19:15:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "SDN00002I",
                                                         "description": "PROJ001 deleted virtual port 192.168.1.87 (fa:16:3e:b1:5c:89)",
                                                         "host": "",
@@ -608,7 +619,8 @@
                                                         "time": "2025-02-03T17:32:09Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "SDN00002I",
                                                         "description": "PROJ001 deleted virtual port 192.168.1.5 (fa:16:3e:ce:ab:6b)",
                                                         "host": "",
@@ -623,7 +635,8 @@
                                                         "time": "2025-02-03T17:32:09Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"e5a85381-023c-4087-a607-c74687dc3b52\" at 10.254.1.235 is reachable",
                                                         "host": "",
@@ -637,7 +650,8 @@
                                                         "time": "2025-02-03T17:30:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"66cdfddb-efe1-4b67-b864-76c5d106524c\" at 10.254.131.183 is reachable",
                                                         "host": "",
@@ -651,7 +665,8 @@
                                                         "time": "2025-02-03T17:30:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"f682fc8d-2c8d-4557-9b84-049e5a72b713\" at 192.168.0.157 is reachable",
                                                         "host": "",
@@ -665,7 +680,8 @@
                                                         "time": "2025-02-03T17:15:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"6942ec52-f089-434d-ba5c-6137015b91b1\" at 192.168.0.108 is reachable",
                                                         "host": "",
@@ -679,7 +695,8 @@
                                                         "time": "2025-02-03T16:50:15Z"
                                                     },
                                                     {
-                                                        "type": "Info",
+                                                        "type": "system",
+                                                        "severity": "Info",
                                                         "id": "NET00003I",
                                                         "description": "instance \"2d9ce9a4-5fe9-4011-84ae-8ecb20f64594\" at 192.168.0.111 is reachable",
                                                         "host": "",

--- a/api/docs.json
+++ b/api/docs.json
@@ -4161,9 +4161,9 @@
                                                                     }
                                                                 }
                                                             },
-                                                            "uptime": {
-                                                                "type": "string",
-                                                                "example": "26 days"
+                                                            "uptimeSeconds": {
+                                                                "type": "number",
+                                                                "example": 5658305.34
                                                             },
                                                             "labels": {
                                                                 "type": "object",

--- a/configs/cube-cos-api.yaml
+++ b/configs/cube-cos-api.yaml
@@ -8,7 +8,9 @@ spec:
     address:
       local: 0.0.0.0
   identity:
-    osPolicy: /etc/settings.txt
+    os:
+      policy: /etc/settings.txt
+      system: /etc/settings.sys
     logoutRedirect: "/api/v1/datacenters"
     keycloak:
       host: https://10.32.10.113:10443/auth

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0
-	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250205114656-72189664ae06
+	github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250207174004-e1f28e8ba740
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/coreos/go-oidc v2.3.0+incompatible
 	github.com/crewjam/saml v0.4.14

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,10 @@ github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67a
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250204145842-9b1f8c1f67af/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250205114656-72189664ae06 h1:ojNtJyNiaTAVbG8fvu5TFNt4wfkMx9viioMywIG4i48=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250205114656-72189664ae06/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250206210944-477b489199b0 h1:0V36AHKe74UtJCLQseYbyA/Ioyx5pS2FBwsgjfnxcJg=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250206210944-477b489199b0/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250207174004-e1f28e8ba740 h1:QVXn0w91x9Q87+C9ltVpiIqWz4rEzIEDIjHkQhvUm7g=
+github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250207174004-e1f28e8ba740/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/api/v1/datacenters/handlers.go
+++ b/internal/api/v1/datacenters/handlers.go
@@ -29,6 +29,7 @@ func getDataCenters(c *gin.Context) {
 		[]definition.DataCenter{
 			{
 				Name:        definition.DataCenterName,
+				Version:     definition.DataCenterVersion,
 				VirtualIp:   definition.DataCenterVip,
 				IsLocal:     true,
 				IsHaEnabled: definition.IsHaEnabled,

--- a/internal/api/v1/me/handlers.go
+++ b/internal/api/v1/me/handlers.go
@@ -1,0 +1,29 @@
+package me
+
+import (
+	"net/http"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/crewjam/saml/samlsp"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	Handlers = []api.Handler{
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/me",
+			Func:    getMe,
+		},
+	}
+)
+
+func getMe(c *gin.Context) {
+	username := samlsp.AttributeFromContext(c.Request.Context(), "username")
+	api.SetStatusOk(
+		c,
+		"fetch own user info successfully",
+		gin.H{"name": username},
+	)
+}

--- a/internal/api/v1/nodes/details.go
+++ b/internal/api/v1/nodes/details.go
@@ -1,8 +1,11 @@
 package nodes
 
 import (
-	"regexp"
+	"os"
+	"strconv"
+	"strings"
 
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/math"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/openstack/v2"
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
@@ -23,7 +26,7 @@ func addNodeDetailsToNodes(c *gin.Context, nodes *[]*definition.Node) {
 		node.ManagementIP = hypervisor.HostIP
 		node.Status = hypervisor.State
 		addMetricToNode(node, hypervisor)
-		addUptimeToNode(c, node, hypervisor)
+		addUptimeToNode(c, node)
 	}
 }
 
@@ -32,41 +35,45 @@ func addMetricToNode(node *definition.Node, hypervisor *hypervisors.Hypervisor) 
 		TotalCores:  hypervisor.VCPUs,
 		UsedCores:   hypervisor.VCPUsUsed,
 		FreeCores:   hypervisor.VCPUs - hypervisor.VCPUsUsed,
-		UsedPercent: float64(hypervisor.VCPUsUsed) / float64(hypervisor.VCPUs) * 100,
-		FreePercent: float64(hypervisor.VCPUs-hypervisor.VCPUsUsed) / float64(hypervisor.VCPUs) * 100,
+		UsedPercent: math.RoundDown(float64(hypervisor.VCPUsUsed)/float64(hypervisor.VCPUs)*100, 4),
+		FreePercent: math.RoundDown(float64(hypervisor.VCPUs-hypervisor.VCPUsUsed)/float64(hypervisor.VCPUs)*100, 4),
 	}
 
 	node.Memory = definition.SpaceStatistic{
 		TotalMiB:    float64(hypervisor.MemoryMB),
 		UsedMiB:     float64(hypervisor.MemoryMBUsed),
 		FreeMiB:     float64(hypervisor.MemoryMB - hypervisor.MemoryMBUsed),
-		UsedPercent: float64(hypervisor.MemoryMBUsed) / float64(hypervisor.MemoryMB) * 100,
-		FreePercent: float64(hypervisor.MemoryMB-hypervisor.MemoryMBUsed) / float64(hypervisor.MemoryMB) * 100,
+		UsedPercent: math.RoundDown(float64(hypervisor.MemoryMBUsed)/float64(hypervisor.MemoryMB)*100, 4),
+		FreePercent: math.RoundDown(float64(hypervisor.MemoryMB-hypervisor.MemoryMBUsed)/float64(hypervisor.MemoryMB)*100, 4),
 	}
 
 	node.Storage = definition.SpaceStatistic{
 		TotalMiB:    float64(hypervisor.LocalGB) * 1024,
 		UsedMiB:     float64(hypervisor.LocalGBUsed) * 1024,
 		FreeMiB:     float64(hypervisor.LocalGB-hypervisor.LocalGBUsed) * 1024,
-		UsedPercent: float64(hypervisor.LocalGBUsed) / float64(hypervisor.LocalGB) * 100,
-		FreePercent: float64(hypervisor.LocalGB-hypervisor.LocalGBUsed) / float64(hypervisor.LocalGB) * 100,
+		UsedPercent: math.RoundDown(float64(hypervisor.LocalGBUsed)/float64(hypervisor.LocalGB)*100, 4),
+		FreePercent: math.RoundDown(float64(hypervisor.LocalGB-hypervisor.LocalGBUsed)/float64(hypervisor.LocalGB)*100, 4),
 	}
 }
 
-func addUptimeToNode(c *gin.Context, node *definition.Node, hypervisor *hypervisors.Hypervisor) {
-	h := openstack.GetGlobalHelper()
-	time, err := h.GetHypervisorUpTime(hypervisor.ID)
+func addUptimeToNode(c *gin.Context, node *definition.Node) {
+	data, err := os.ReadFile("/proc/uptime")
 	if err != nil {
-		log.Debugf("request(%s): failed to add hypervisor uptime to the node: %s", api.GetReqId(c), err.Error())
+		log.Errorf("request(%s): failed to read uptime file: %s", api.GetReqId(c), err.Error())
 		return
 	}
 
-	regex := regexp.MustCompile(`up\s+(.*?),`)
-	match := regex.FindStringSubmatch(time.Uptime)
-	if len(match) > 1 {
-		node.Uptime = match[1]
+	fields := strings.Fields(string(data))
+	if len(fields) < 1 {
+		log.Errorf("request(%s): invalid uptime format", api.GetReqId(c))
 		return
 	}
 
-	node.Uptime = "no uptime from system"
+	uptimeSeconds, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		log.Errorf("request(%s): failed to parse uptime: %s", api.GetReqId(c), err.Error())
+		return
+	}
+
+	node.UptimeSeconds = uptimeSeconds
 }

--- a/internal/api/v1/nodes/handlers.go
+++ b/internal/api/v1/nodes/handlers.go
@@ -33,7 +33,7 @@ func getNodes(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.genNodeResp()
+	resp, err := h.getNodesResp()
 	if err != nil {
 		log.Errorf("request(%s): failed to gen node: %v", api.GetReqId(c), err)
 		api.SetInternalServerError(c, err)

--- a/internal/api/v1/nodes/helper.go
+++ b/internal/api/v1/nodes/helper.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
-	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
@@ -80,8 +79,8 @@ func (h *helper) parseWatch() error {
 	return nil
 }
 
-func (h *helper) genNodeResp() (*data, error) {
-	nodes, err := cubecos.ListNodes()
+func (h *helper) getNodesResp() (*data, error) {
+	nodes, err := definition.ListNodes()
 	if err != nil {
 		log.Errorf("request(%s): failed to get nodes: %s", api.GetReqId(h.c), err.Error())
 		return nil, err

--- a/internal/api/v1/nodes/watch.go
+++ b/internal/api/v1/nodes/watch.go
@@ -34,7 +34,7 @@ func streamNodes() {
 
 		stream.Lock()
 		for _, w := range stream.Watchers {
-			nodes, err := w.genNodeResp()
+			nodes, err := w.getNodesResp()
 			if err != nil {
 				continue
 			}

--- a/internal/api/v1/tunings/delegation.go
+++ b/internal/api/v1/tunings/delegation.go
@@ -8,7 +8,6 @@ import (
 	cubeHttp "github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	cuberr "github.com/bigstack-oss/cube-cos-api/internal/errors"
-	"github.com/bigstack-oss/cube-cos-api/internal/service"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -35,7 +34,7 @@ func delegateToOtherNodes(tuning definition.Tuning) {
 	}
 
 	for _, role := range roles {
-		nodes, err := service.GetNodesByRole(role.Name)
+		nodes, err := definition.GetNodesByRole(role.Name)
 		if err == nil {
 			sendTuningToOtherNodes(tuning, nodes)
 			continue
@@ -52,11 +51,11 @@ func delegateToOtherNodes(tuning definition.Tuning) {
 	}
 }
 
-func sendTuningToOtherNodes(tuning definition.Tuning, nodes []definition.Node) {
+func sendTuningToOtherNodes(tuning definition.Tuning, nodes []*definition.Node) {
 	h := cubeHttp.GetGlobalHelper()
 
 	for _, node := range nodes {
-		resp, err := h.R().SetBody(tuning).Put(genUrl(node, tuning))
+		resp, err := h.R().SetBody(tuning).Put(genUrl(*node, tuning))
 		if !resp.IsError() && err == nil {
 			continue
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,8 @@ func init() {
 	flag.StringVar(&Opts.Spec.Listen.Address.Local, "listen.address.local", Opts.Spec.Listen.Address.Local, "")
 	flag.StringVar(&Opts.Spec.Listen.Address.Advertise, "listen.address.advertise", Opts.Spec.Listen.Address.Advertise, "")
 	flag.IntVar(&Opts.Spec.Listen.Port, "listen.port", Opts.Spec.Listen.Port, "")
-	flag.StringVar(&Opts.Spec.Identity.OsPolicy, "identity.osPolicy", Opts.Spec.Identity.OsPolicy, "")
+	flag.StringVar(&Opts.Spec.Identity.Os.Policy, "identity.os.policy", Opts.Spec.Identity.Os.Policy, "")
+	flag.StringVar(&Opts.Spec.Identity.Os.System, "identity.os.system", Opts.Spec.Identity.Os.System, "")
 	flag.StringVar(&Opts.Spec.Identity.LogoutRedirect, "identity.logoutRedirect", Opts.Spec.Identity.LogoutRedirect, "")
 	flag.StringVar(&Opts.Spec.Identity.Keycloak.Host, "identity.keycloak.host", Opts.Spec.Identity.Keycloak.Host, "")
 	flag.StringVar(&Opts.Spec.Identity.Keycloak.Realm, "identity.keycloak.realm", Opts.Spec.Identity.Keycloak.Realm, "")
@@ -98,10 +99,15 @@ type Address struct {
 }
 
 type Identity struct {
-	OsPolicy       string           `json:"osPolicy" yaml:"osPolicy"`
+	Os             `json:"os" yaml:"os"`
 	LogoutRedirect string           `json:"logoutRedirect" yaml:"logoutRedirect"`
 	Keycloak       keycloak.Options `json:"keycloak" yaml:"keycloak"`
 	Saml           saml.Options     `json:"saml" yaml:"saml"`
+}
+
+type Os struct {
+	Policy string `json:"policy" yaml:"policy"`
+	System string `json:"system" yaml:"system"`
 }
 
 type ResourceControl struct {

--- a/internal/cubecos/cluster.go
+++ b/internal/cubecos/cluster.go
@@ -1,6 +1,7 @@
 package cubecos
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -42,4 +43,18 @@ func GetDataCenterName() (string, error) {
 	}
 
 	return ReadHexTuning(CubeSysController)
+}
+
+func GetDataCenterVersion() (string, error) {
+	desc, err := ReadSettingSys(SysProductDescription)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := ReadSettingSys(SysProductVersion)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s %s", desc, version), nil
 }

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -117,7 +117,8 @@ func genEventByRecord(record *query.FluxRecord) definition.Event {
 	}
 
 	return definition.Event{
-		Type:        definition.SeverityFullName(severity),
+		Type:        record.Measurement(),
+		Severity:    definition.SeverityFullName(severity),
 		Id:          eventId,
 		Description: msg,
 		Host:        "",

--- a/internal/cubecos/node.go
+++ b/internal/cubecos/node.go
@@ -15,6 +15,9 @@ func ListNodes() ([]*definition.Node, error) {
 			log.Warnf("failed to get %s nodes: %s", role, err.Error())
 			continue
 		}
+		if len(roleNodes) == 0 {
+			continue
+		}
 
 		nodes = append(nodes, roleNodes...)
 	}

--- a/internal/cubecos/sys.go
+++ b/internal/cubecos/sys.go
@@ -1,0 +1,50 @@
+package cubecos
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/config"
+)
+
+func ReadSettingSys(settingName string) (string, error) {
+	sys, err := os.Open(config.Opts.Spec.Os.System)
+	if err != nil {
+		return "", err
+	}
+
+	defer sys.Close()
+	value := ""
+	scanner := bufio.NewScanner(sys)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if isCommentOrBlank(line) {
+			continue
+		}
+
+		if !strings.HasPrefix(line, settingName) {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if isKeyValuePattern(parts) {
+			value = strings.TrimSpace(parts[1])
+			break
+		}
+	}
+	err = scanner.Err()
+	if err != nil {
+		return "", err
+	}
+
+	return value, nil
+}
+
+func isCommentOrBlank(line string) bool {
+	return strings.HasPrefix(line, "#") || line == ""
+}
+
+func isKeyValuePattern(parts []string) bool {
+	return len(parts) == 2
+}

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -100,6 +100,10 @@ const (
 	TimeTimezone                = "time.timezone"
 	UpdateSecurityAutoUpdate    = "update.security.autoupdate"
 	WatcherDebugEnabled         = "watcher.debug.enabled"
+
+	// setting sys
+	SysProductDescription = "sys.product.description"
+	SysProductVersion     = "sys.product.version"
 )
 
 var (

--- a/internal/definition/v1/datacenter.go
+++ b/internal/definition/v1/datacenter.go
@@ -7,6 +7,7 @@ const (
 type DataCenter struct {
 	Id          string `json:"id,omitempty" bson:"id"`
 	Name        string `json:"name" bson:"name"`
+	Version     string `json:"version" bson:"version"`
 	VirtualIp   string `json:"virtualIp" bson:"virtualIp"`
 	IsLocal     bool   `json:"isLocal" bson:"isLocal"`
 	IsHaEnabled bool   `json:"isHaEnabled" bson:"isHaEnabled"`

--- a/internal/definition/v1/events.go
+++ b/internal/definition/v1/events.go
@@ -8,6 +8,7 @@ const (
 
 type Event struct {
 	Type        string                 `json:"type"`
+	Severity    string                 `json:"severity"`
 	Id          string                 `json:"id"`
 	Description string                 `json:"description"`
 	Host        string                 `json:"host"`

--- a/internal/definition/v1/me.go
+++ b/internal/definition/v1/me.go
@@ -1,0 +1,5 @@
+package v1
+
+const (
+	Me = "me"
+)

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -30,19 +30,19 @@ var (
 )
 
 type Node struct {
-	Id           string `json:"id" yaml:"id"`
-	Hostname     string `json:"hostname" yaml:"hostname"`
-	Role         string `json:"role" yaml:"role"`
-	Protocol     string `json:"protocol,omitempty" yaml:"protocol,omitempty" bson:"protocol,omitempty"`
-	Address      string `json:"address" yaml:"address"`
-	ManagementIP string `json:"managementIP" yaml:"managementIP"`
-	License      `json:"license,omitempty" yaml:"license,omitempty" bson:"license,omitempty"`
-	Status       string            `json:"status" yaml:"status"`
-	Vcpu         ComputeStatistic  `json:"vcpu" yaml:"vcpu" bson:"vcpu"`
-	Memory       SpaceStatistic    `json:"memory" yaml:"memory" bson:"memory"`
-	Storage      SpaceStatistic    `json:"storage" yaml:"storage" bson:"storage"`
-	Uptime       string            `json:"uptime" yaml:"uptime"`
-	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" bson:"labels,omitempty"`
+	Id            string `json:"id" yaml:"id"`
+	Hostname      string `json:"hostname" yaml:"hostname"`
+	Role          string `json:"role" yaml:"role"`
+	Protocol      string `json:"protocol,omitempty" yaml:"protocol,omitempty" bson:"protocol,omitempty"`
+	Address       string `json:"address" yaml:"address"`
+	ManagementIP  string `json:"managementIP" yaml:"managementIP"`
+	License       `json:"license,omitempty" yaml:"license,omitempty" bson:"license,omitempty"`
+	Status        string            `json:"status" yaml:"status"`
+	Vcpu          ComputeStatistic  `json:"vcpu" yaml:"vcpu" bson:"vcpu"`
+	Memory        SpaceStatistic    `json:"memory" yaml:"memory" bson:"memory"`
+	Storage       SpaceStatistic    `json:"storage" yaml:"storage" bson:"storage"`
+	UptimeSeconds float64           `json:"uptimeSeconds" yaml:"uptimeSeconds" bson:"uptimeSeconds"`
+	Labels        map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" bson:"labels,omitempty"`
 }
 
 func GenerateNodeHashByMacAddr() (string, error) {
@@ -55,10 +55,10 @@ func GenerateNodeHashByMacAddr() (string, error) {
 	return hex.EncodeToString(hash[:])[:8], nil
 }
 
-func GetNodesByRole(role string) ([]*Node, error) {
-	svcs, err := registry.GetService(role)
+func GetNodesByRole(roleName string) ([]*Node, error) {
+	svcs, err := registry.GetService(DataCenterName)
 	if err != nil {
-		log.Errorf("failed to get service %s (%s)", role, err.Error())
+		log.Errorf("failed to get %s role from service %s (%s)", roleName, DataCenterName, err.Error())
 		return nil, err
 	}
 	if len(svcs) == 0 {
@@ -67,7 +67,30 @@ func GetNodesByRole(role string) ([]*Node, error) {
 
 	nodes := []*Node{}
 	for _, svc := range svcs {
-		nodes = append(nodes, getNodesByService(svc, svc.Name)...)
+		roleNodes := parseNodesByRole(svc, roleName)
+		if len(roleNodes) == 0 {
+			continue
+		}
+
+		nodes = append(nodes, roleNodes...)
+	}
+
+	return nodes, nil
+}
+
+func ListNodes() ([]*Node, error) {
+	svcs, err := registry.GetService(DataCenterName)
+	if err != nil {
+		log.Errorf("failed to get nodes from %s (%s)", DataCenterName, err.Error())
+		return nil, err
+	}
+	if len(svcs) == 0 {
+		return nil, nil
+	}
+
+	nodes := []*Node{}
+	for _, svc := range svcs {
+		nodes = append(nodes, parseNodes(svc)...)
 	}
 
 	return nodes, nil

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -14,18 +14,19 @@ const (
 )
 
 var (
-	HostID         string
-	Hostname       string
-	DataCenterName string
-	DataCenterVip  string
-	ListenAddr     string
-	ListenPort     int
-	AdvertiseAddr  string
-	AdvertisePort  int
-	MgmtNet        string
-	MgmtIP         string
-	IsHaEnabled    bool
-	IsGpuEnabled   bool
+	HostID            string
+	Hostname          string
+	DataCenterName    string
+	DataCenterVersion string
+	DataCenterVip     string
+	ListenAddr        string
+	ListenPort        int
+	AdvertiseAddr     string
+	AdvertisePort     int
+	MgmtNet           string
+	MgmtIP            string
+	IsHaEnabled       bool
+	IsGpuEnabled      bool
 )
 
 type Node struct {

--- a/internal/definition/v1/roles.go
+++ b/internal/definition/v1/roles.go
@@ -141,22 +141,31 @@ func SyncNodesOfRole() {
 	}
 }
 
-func getNodesByService(svc *registry.Service, role string) []*Node {
+func parseNodes(svc *registry.Service) []*Node {
 	nodes := []*Node{}
-
 	for _, node := range svc.Nodes {
-		nodes = append(
-			nodes,
-			genNodeInfo(node, role),
-		)
+		nodes = append(nodes, newNode(node))
 	}
 
 	return nodes
 }
 
-func genNodeInfo(node *registry.Node, role string) *Node {
+func parseNodesByRole(svc *registry.Service, roleName string) []*Node {
+	nodes := []*Node{}
+	for _, node := range svc.Nodes {
+		if node.Metadata["role"] != roleName {
+			continue
+		}
+
+		nodes = append(nodes, newNode(node))
+	}
+
+	return nodes
+}
+
+func newNode(node *registry.Node) *Node {
 	return &Node{
-		Role:     role,
+		Role:     node.Metadata["role"],
 		Id:       node.Metadata["nodeID"],
 		Hostname: node.Metadata["hostname"],
 		Address:  node.Address,

--- a/internal/runtime/dependency.go
+++ b/internal/runtime/dependency.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/Nerzal/gocloak/v13"
@@ -62,6 +63,12 @@ func initDependencies() error {
 	err = newKeycloakOidcAuth()
 	if err != nil {
 		log.Errorf("failed to init oidc auth in keycloak: %s", err.Error())
+		return err
+	}
+
+	err = newKeycloakSamlMapper()
+	if err != nil {
+		log.Errorf("failed to init saml mapper in keycloak: %s", err.Error())
 		return err
 	}
 
@@ -145,4 +152,53 @@ func newKeycloakOidcAuth() error {
 	}
 
 	return err
+}
+
+func newKeycloakSamlMapper() error {
+	h := keycloak.GetGlobalHelper()
+	err := h.LoginAdmin()
+	if err != nil {
+		log.Errorf("failed to login admin: %s", err.Error())
+		return err
+	}
+
+	samlId := saml.GenServiceProviderMetadataUrl(conf.Opts.Spec.Identity.Saml)
+	clients, err := h.GetClients(
+		definition.DefaultKeycloakRealm,
+		gocloak.GetClientsParams{ClientID: gocloak.StringP(samlId.String())},
+	)
+	if err != nil {
+		log.Errorf("failed to get clients: %s", err.Error())
+		return err
+	}
+	if len(clients) == 0 {
+		return fmt.Errorf("saml client not found")
+	}
+
+	_, err = h.CreateClientProtocolMapper(
+		definition.DefaultKeycloakRealm,
+		*clients[0].ID,
+		genSamlMapper(),
+	)
+	if err == nil {
+		return nil
+	}
+	if err.(*gocloak.APIError).Code == http.StatusConflict {
+		return nil
+	}
+
+	return err
+}
+
+func genSamlMapper() gocloak.ProtocolMapperRepresentation {
+	return gocloak.ProtocolMapperRepresentation{
+		Name:           gocloak.StringP("username"),
+		Protocol:       gocloak.StringP("saml"),
+		ProtocolMapper: gocloak.StringP("saml-user-property-mapper"),
+		Config: &map[string]string{
+			"user.attribute":       "username",
+			"attribute.name":       "username",
+			"attribute.nameformat": "Basic",
+		},
+	}
 }

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/integrations"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/licenses"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/logout"
+	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/me"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/metrics"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/tokens"
@@ -19,6 +20,12 @@ func initNodeApiHandler() {
 	api.RegisterHandlersToRoles(
 		definition.DataCenters,
 		datacenters.Handlers,
+		definition.RoleControl,
+	)
+
+	api.RegisterHandlersToRoles(
+		definition.Me,
+		me.Handlers,
 		definition.RoleControl,
 	)
 

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -62,6 +62,12 @@ func initNodeIdentities() error {
 		return err
 	}
 
+	definition.DataCenterVersion, err = cubecos.GetDataCenterVersion()
+	if err != nil {
+		log.Errorf("failed to get data center version: %s", err.Error())
+		return err
+	}
+
 	definition.ListenAddr = genLocalAddr()
 	definition.ListenPort = conf.Opts.Spec.Listen.Port
 	definition.AdvertiseAddr = genServiceDiscoveryAddr()

--- a/internal/saml/saml.go
+++ b/internal/saml/saml.go
@@ -54,13 +54,13 @@ func NewGlobalAuth(opts Options) error {
 		return err
 	}
 
-	idpMetadata, err := genIdentityProviderMetadata(opts)
+	idpMetadata, err := GenIdentityProviderMetadata(opts)
 	if err != nil {
 		log.Errorf("failed to generate idp metadata: %v", err)
 		return err
 	}
 
-	spMetadataUrl := genServiceProviderMetadataUrl(opts)
+	spMetadataUrl := GenServiceProviderMetadataUrl(opts)
 	SpAuth, err = samlsp.New(samlsp.Options{
 		EntityID:    spMetadataUrl.String(),
 		URL:         genRootUrl(opts),
@@ -91,7 +91,7 @@ func genApiServerCertKeyPair(serverCert, serverKey string) (*tls.Certificate, er
 	return &keyPair, nil
 }
 
-func genIdentityProviderMetadata(opts Options) (*saml.EntityDescriptor, error) {
+func GenIdentityProviderMetadata(opts Options) (*saml.EntityDescriptor, error) {
 	http.DefaultClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: opts.IdentityProvider.Host.TlsInsecureSkipVerify},
@@ -103,11 +103,11 @@ func genIdentityProviderMetadata(opts Options) (*saml.EntityDescriptor, error) {
 	return samlsp.FetchMetadata(
 		ctx,
 		http.DefaultClient,
-		genIdentityProviderMetadataUrl(opts),
+		GenIdentityProviderMetadataUrl(opts),
 	)
 }
 
-func genIdentityProviderMetadataUrl(opts Options) url.URL {
+func GenIdentityProviderMetadataUrl(opts Options) url.URL {
 	return url.URL{
 		Scheme: opts.IdentityProvider.Host.Scheme,
 		Host:   fmt.Sprintf("%s:%d", definition.DataCenterVip, opts.IdentityProvider.Host.Port),
@@ -115,7 +115,7 @@ func genIdentityProviderMetadataUrl(opts Options) url.URL {
 	}
 }
 
-func genServiceProviderMetadataUrl(opts Options) url.URL {
+func GenServiceProviderMetadataUrl(opts Options) url.URL {
 	return url.URL{
 		Scheme: opts.ServiceProvider.Scheme,
 		Host:   fmt.Sprintf("%s:%d", definition.DataCenterVip, opts.ServiceProvider.Host.Port),

--- a/internal/service/node.go
+++ b/internal/service/node.go
@@ -7,7 +7,7 @@ import (
 	"go-micro.dev/v5/registry"
 )
 
-func getNodesByService(svc *registry.Service, role string) []definition.Node {
+func parseNodes(svc *registry.Service) []definition.Node {
 	nodes := []definition.Node{}
 
 	for _, node := range svc.Nodes {
@@ -15,18 +15,15 @@ func getNodesByService(svc *registry.Service, role string) []definition.Node {
 			continue
 		}
 
-		nodes = append(
-			nodes,
-			genNodeInfo(node, role),
-		)
+		nodes = append(nodes, newNode(node))
 	}
 
 	return nodes
 }
 
-func genNodeInfo(node *registry.Node, role string) definition.Node {
+func newNode(node *registry.Node) definition.Node {
 	return definition.Node{
-		Role:     role,
+		Role:     node.Metadata["role"],
 		Id:       definition.HostID,
 		Hostname: definition.Hostname,
 		Address:  node.Address,
@@ -38,7 +35,7 @@ func isCurrentNode(node *registry.Node) bool {
 }
 
 func GetNodesByRole(roleName string) ([]definition.Node, error) {
-	svcs, err := registry.GetService(roleName)
+	svcs, err := registry.GetService(definition.DataCenterName)
 	if err != nil {
 		log.Errorf("failed to get service %s (%s)", roleName, err.Error())
 		return nil, err
@@ -49,10 +46,12 @@ func GetNodesByRole(roleName string) ([]definition.Node, error) {
 
 	nodes := []definition.Node{}
 	for _, svc := range svcs {
-		nodes = append(
-			nodes,
-			getNodesByService(svc, roleName)...,
-		)
+		roleNodes := parseNodes(svc)
+		if len(roleNodes) == 0 {
+			continue
+		}
+
+		nodes = append(nodes, roleNodes...)
 	}
 
 	return nodes, nil


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix


<br/>

### Which issue(s) this PR fixes?

#87 

<br/>


### What this PR does?

- Data center: add COS version in the response


- Users: add an new API `GET /api/v1/datacenters/{dataCenter}/me` to provide own user info
📔 Also add the auto check/init SAML mapper in the keycloak, so that we can fetch the user info from saml service provider.


- Event: adjust the type field and add severity field


- Node: rename the uptime to uptimeSeconds, and adjust the logic to be the duration since the last boot, rather than the age.
📔 Use the system time from /proc/uptime


- Node: fix the unexpected node listing error from the previous registry adjustment, it cause the register.Service can't fetch any of nodes.


- Swagger: to include the changes above.




<br/>

### Test results (optional)

1). make sure the data center has included the cube version

<img width="1721" alt="Screenshot 2025-02-08 at 4 58 02 AM" src="https://github.com/user-attachments/assets/b27e3c9f-0ff4-42c7-b704-f3bb97870176" />

<br/>

<br/>

2). make sure `GET /api/v1/datacenters/{dataCenter}/me` works with saml attribution mapper

and will be recreated automatically if API realized is being removed unexpectedly

<img width="864" alt="Screenshot 2025-02-08 at 4 55 55 AM" src="https://github.com/user-attachments/assets/0e6c251a-8fb3-45ce-9d5a-7194159b8555" />

<br/>

<br/>

3). make sure the severity and type field have been adjusted as discussed

<img width="1718" alt="Screenshot 2025-02-08 at 4 57 10 AM" src="https://github.com/user-attachments/assets/da00285f-e25a-4422-982b-214b1d2cb2db" />

<br/>

<br/>

4). make sure the node list back to work with the adjusted field `uptimeSeconds`

<img width="1717" alt="Screenshot 2025-02-08 at 4 57 25 AM" src="https://github.com/user-attachments/assets/a54d1405-89da-4ccc-82d5-f9bad07ddb03" />

<img width="1721" alt="Screenshot 2025-02-08 at 4 57 34 AM" src="https://github.com/user-attachments/assets/160e82e0-24cf-4902-b016-6565fe1434c9" />

<br/>

<br/>

5). make sure the corresponding changes have been updated to the swagger

for new API `GET /api/v1/datacenters/{dataCenter}/me`

<img width="1434" alt="Screenshot 2025-02-08 at 4 58 42 AM" src="https://github.com/user-attachments/assets/4a2a1d97-01db-48c6-8adb-8117dd3f3b1b" />

for uptimeSeconds

<img width="1435" alt="Screenshot 2025-02-08 at 4 59 32 AM" src="https://github.com/user-attachments/assets/166c7aac-2a05-42bc-80e9-5d35b28fcee3" />

for event field adjustments

<img width="1431" alt="Screenshot 2025-02-08 at 4 59 08 AM" src="https://github.com/user-attachments/assets/eb8f27cc-c526-47b7-863d-d6851968f181" />

for data center version

<img width="1432" alt="Screenshot 2025-02-08 at 4 58 56 AM" src="https://github.com/user-attachments/assets/baf0b280-170b-46cc-98df-9cda44ed357c" />


