### PR TITLE
Pick the missed swagger items from PR#89

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -621,7 +621,6 @@ const docTemplate = `{
                                                         "modules": [
                                                             {
                                                                 "name": "link",
-                                                                "isAutoRepairable": false,
                                                                 "status": {
                                                                     "current": "ok"
                                                                 }
@@ -655,7 +654,6 @@ const docTemplate = `{
                                                         "modules": [
                                                             {
                                                                 "name": "ceph_osd",
-                                                                "isAutoRepairable": false,
                                                                 "status": {
                                                                     "current": "ng",
                                                                     "description": "ceph has 2 ceph_osd down"
@@ -4122,24 +4120,18 @@ const docTemplate = `{
                                             "type": "array",
                                             "required": [
                                                 "name",
-                                                "isAutoRepairable",
                                                 "status"
                                             ],
                                             "items": {
                                                 "type": "object",
                                                 "required": [
                                                     "name",
-                                                    "isAutoRepairable",
                                                     "status"
                                                 ],
                                                 "properties": {
                                                     "name": {
                                                         "type": "string",
                                                         "example": "link"
-                                                    },
-                                                    "isAutoRepairable": {
-                                                        "type": "boolean",
-                                                        "example": false
                                                     },
                                                     "status": {
                                                         "type": "object",

--- a/api/docs.json
+++ b/api/docs.json
@@ -617,7 +617,6 @@
                                                         "modules": [
                                                             {
                                                                 "name": "link",
-                                                                "isAutoRepairable": false,
                                                                 "status": {
                                                                     "current": "ok"
                                                                 }
@@ -651,7 +650,6 @@
                                                         "modules": [
                                                             {
                                                                 "name": "ceph_osd",
-                                                                "isAutoRepairable": false,
                                                                 "status": {
                                                                     "current": "ng",
                                                                     "description": "ceph has 2 ceph_osd down"
@@ -4118,24 +4116,18 @@
                                             "type": "array",
                                             "required": [
                                                 "name",
-                                                "isAutoRepairable",
                                                 "status"
                                             ],
                                             "items": {
                                                 "type": "object",
                                                 "required": [
                                                     "name",
-                                                    "isAutoRepairable",
                                                     "status"
                                                 ],
                                                 "properties": {
                                                     "name": {
                                                         "type": "string",
                                                         "example": "link"
-                                                    },
-                                                    "isAutoRepairable": {
-                                                        "type": "boolean",
-                                                        "example": false
                                                     },
                                                     "status": {
                                                         "type": "object",

--- a/internal/definition/v1/service.go
+++ b/internal/definition/v1/service.go
@@ -12,7 +12,7 @@ type Service struct {
 type Module struct {
 	Name             string         `json:"name" bson:"name"`
 	Status           status.Details `json:"status,omitempty" bson:"status,omitempty"`
-	IsAutoRepairable bool           `json:"isAutoRepairable" bson:"isAutoRepairable"`
+	IsAutoRepairable bool           `json:"-" bson:"isAutoRepairable"`
 	Description      string         `json:"description,omitempty" bson:"description"`
 }
 

--- a/internal/operators/v1/healths/sync.go
+++ b/internal/operators/v1/healths/sync.go
@@ -57,7 +57,6 @@ func repairServices(health cubecos.Health) {
 		err = cubecos.CheckServiceHealth(svc)
 		if err != nil {
 			log.Warnf(healthVerifyFailed, err.Error())
-			continue
 		}
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

Fix (picked the missed swagger adjustments from PR https://github.com/bigstack-oss/cube-cos-api/pull/89)


<br/>

### Which issue(s) this PR fixes?

#86 

<br/>


### What this PR does?

- Remove the health record control from mongodb. markerfile will be the central mechanism in health feature between api and cos.

- Remove the repair lock, it will be controlled by cos sdk

- Adjust the status fetching logic by parsing from cos sdk's markerfile(but it's still developing in cos side, will integrate it when it's done in cos)

- Adjust the listing payload by removing `inUser, error, and fixing`. all services and the their modules will be placed in the `data.services` array.

- Use force repair in the single module repair.

- Swagger: to include the changes above.




<br/>

### Test results (optional)

1). make sure the listing payload is shown as expected

https://github.com/user-attachments/assets/51a475be-d19b-4767-a513-57f28d118c4d

<br/>

2). make sure the check/repair logic is not impacted by the adjustments above

![Screenshot 2025-02-09 at 1 32 21 AM](https://github.com/user-attachments/assets/430f31cf-3845-4ab5-a842-2eba3bbfa3d9)

![Screenshot 2025-02-09 at 1 32 38 AM](https://github.com/user-attachments/assets/318654cd-4fbc-4ecd-8399-76424008fd02)

<br/>

3). make sure the force repair logic works in single module case

![Screenshot 2025-02-09 at 1 33 45 AM](https://github.com/user-attachments/assets/2041df55-55c8-488f-a83b-4535d111ca36)

![Screenshot 2025-02-09 at 1 33 56 AM](https://github.com/user-attachments/assets/1a3a1bac-075a-4e12-bdc4-12b9e0289e6f)

