### PR TITLE
Align the swagger doc with cos-openapi

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1258,6 +1258,7 @@ const docTemplate = `{
         },
         "/api/v1/datacenters/{dataCenter}/metrics": {
             "get": {
+                "operationId": "getMetrics",
                 "tags": [
                     "Metrics"
                 ],
@@ -1272,16 +1273,6 @@ const docTemplate = `{
                         },
                         "description": "The name of the data center to operate",
                         "example": "example-data-center"
-                    },
-                    {
-                        "in": "query",
-                        "name": "watch",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        },
-                        "description": "The toggle to enable http chunked transfer for continues server push.",
-                        "example": true
                     }
                 ],
                 "responses": {
@@ -1290,254 +1281,7 @@ const docTemplate = `{
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "code": {
-                                            "type": "integer",
-                                            "example": 200
-                                        },
-                                        "data": {
-                                            "type": "object",
-                                            "properties": {
-                                                "host": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "role": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "controlConverged": {
-                                                                    "type": "integer",
-                                                                    "example": 10
-                                                                },
-                                                                "control": {
-                                                                    "type": "integer",
-                                                                    "example": 3
-                                                                },
-                                                                "compute": {
-                                                                    "type": "integer",
-                                                                    "example": 5
-                                                                },
-                                                                "storage": {
-                                                                    "type": "integer",
-                                                                    "example": 2
-                                                                },
-                                                                "others": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                }
-                                                            }
-                                                        },
-                                                        "usage": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "vcpu": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalCores": {
-                                                                            "type": "integer",
-                                                                            "example": 80
-                                                                        },
-                                                                        "usedCores": {
-                                                                            "type": "integer",
-                                                                            "example": 31
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.75
-                                                                        },
-                                                                        "freeCores": {
-                                                                            "type": "integer",
-                                                                            "example": 49
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.25
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "memory": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 257371
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 98255
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.2
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 159116
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.8
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "storage": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 102400
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "vm": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "status": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "total": {
-                                                                    "type": "integer",
-                                                                    "example": 10
-                                                                },
-                                                                "running": {
-                                                                    "type": "integer",
-                                                                    "example": 8
-                                                                },
-                                                                "stopped": {
-                                                                    "type": "integer",
-                                                                    "example": 2
-                                                                },
-                                                                "paused": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                },
-                                                                "suspend": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                },
-                                                                "error": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                },
-                                                                "unknown": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                }
-                                                            }
-                                                        },
-                                                        "usage": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "vcpu": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalCores": {
-                                                                            "type": "integer",
-                                                                            "example": 80
-                                                                        },
-                                                                        "usedCores": {
-                                                                            "type": "integer",
-                                                                            "example": 31
-                                                                        },
-                                                                        "freeCores": {
-                                                                            "type": "integer",
-                                                                            "example": 49
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.75
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.25
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "memory": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 257371
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 98255
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 159116
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.2
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.8
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "storage": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 102400
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "msg": {
-                                            "type": "string",
-                                            "example": "fetch summary successfully"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "example": "ok"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/GetMetricsResponse"
                                 }
                             }
                         }
@@ -2017,97 +1761,56 @@ const docTemplate = `{
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "oneOf": [
-                                        {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
                                             "type": "object",
                                             "properties": {
-                                                "code": {
-                                                    "type": "integer",
-                                                    "example": 200
-                                                },
-                                                "data": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "read": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "time": {
-                                                                        "type": "string",
-                                                                        "example": "2025-01-01T01:00:00Z"
-                                                                    },
-                                                                    "bytes": {
-                                                                        "type": "number",
-                                                                        "example": 682.6666
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "write": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "time": {
-                                                                        "type": "string",
-                                                                        "example": "2025-01-01T01:00:00Z"
-                                                                    },
-                                                                    "bytes": {
-                                                                        "type": "number",
-                                                                        "example": 4.5
-                                                                    }
-                                                                }
+                                                "read": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "time": {
+                                                                "type": "string",
+                                                                "example": "2025-01-01T01:00:00Z"
+                                                            },
+                                                            "bytes": {
+                                                                "type": "number",
+                                                                "example": 682.6666
                                                             }
                                                         }
                                                     }
                                                 },
-                                                "msg": {
-                                                    "type": "string",
-                                                    "example": "fetch metrics successfully"
-                                                },
-                                                "status": {
-                                                    "type": "string",
-                                                    "example": "ok"
+                                                "write": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "time": {
+                                                                "type": "string",
+                                                                "example": "2025-01-01T01:00:00Z"
+                                                            },
+                                                            "bytes": {
+                                                                "type": "number",
+                                                                "example": 4.5
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "status": {
-                                                    "type": "string",
-                                                    "example": "ok"
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                "examples": {
-                                    "example1": {
-                                        "value": {
-                                            "code": 200,
-                                            "data": {
-                                                "read": [
-                                                    {
-                                                        "time": "2025-01-01T01:00:00Z",
-                                                        "bytes": 682.6666
-                                                    }
-                                                ],
-                                                "write": [
-                                                    {
-                                                        "time": "2025-01-01T01:00:00Z",
-                                                        "bytes": 4.5
-                                                    }
-                                                ]
-                                            },
-                                            "msg": "fetch metrics successfully",
-                                            "status": "ok"
-                                        }
-                                    },
-                                    "example2": {
-                                        "value": {
-                                            "status": "ok"
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "fetch metrics successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "ok"
                                         }
                                     }
                                 }
@@ -2887,7 +2590,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/network/hosts?metricType=egress&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/network/hosts": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -2997,7 +2700,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/cpu/vms?metricType=usage&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/cpu/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -3111,7 +2814,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/memory/vms?metricType=usage&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/memory/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -3225,7 +2928,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/storage/vms?metricType={metricType}&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/storage/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -3339,7 +3042,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/network/vms?metricType={metricType}&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/network/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -5153,12 +4856,12 @@ const docTemplate = `{
                     "name": {
                         "type": "string",
                         "description": "the name of user to generate the token",
-                        "example": "test-name"
+                        "example": "example-name"
                     },
                     "password": {
                         "type": "string",
                         "description": "the password of user to generate the token",
-                        "example": "test-password"
+                        "example": "example-password"
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -1254,6 +1254,7 @@
         },
         "/api/v1/datacenters/{dataCenter}/metrics": {
             "get": {
+                "operationId": "getMetrics",
                 "tags": [
                     "Metrics"
                 ],
@@ -1268,16 +1269,6 @@
                         },
                         "description": "The name of the data center to operate",
                         "example": "example-data-center"
-                    },
-                    {
-                        "in": "query",
-                        "name": "watch",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        },
-                        "description": "The toggle to enable http chunked transfer for continues server push.",
-                        "example": true
                     }
                 ],
                 "responses": {
@@ -1286,254 +1277,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "code": {
-                                            "type": "integer",
-                                            "example": 200
-                                        },
-                                        "data": {
-                                            "type": "object",
-                                            "properties": {
-                                                "host": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "role": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "controlConverged": {
-                                                                    "type": "integer",
-                                                                    "example": 10
-                                                                },
-                                                                "control": {
-                                                                    "type": "integer",
-                                                                    "example": 3
-                                                                },
-                                                                "compute": {
-                                                                    "type": "integer",
-                                                                    "example": 5
-                                                                },
-                                                                "storage": {
-                                                                    "type": "integer",
-                                                                    "example": 2
-                                                                },
-                                                                "others": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                }
-                                                            }
-                                                        },
-                                                        "usage": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "vcpu": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalCores": {
-                                                                            "type": "integer",
-                                                                            "example": 80
-                                                                        },
-                                                                        "usedCores": {
-                                                                            "type": "integer",
-                                                                            "example": 31
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.75
-                                                                        },
-                                                                        "freeCores": {
-                                                                            "type": "integer",
-                                                                            "example": 49
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.25
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "memory": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 257371
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 98255
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.2
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 159116
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.8
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "storage": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 102400
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "vm": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "status": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "total": {
-                                                                    "type": "integer",
-                                                                    "example": 10
-                                                                },
-                                                                "running": {
-                                                                    "type": "integer",
-                                                                    "example": 8
-                                                                },
-                                                                "stopped": {
-                                                                    "type": "integer",
-                                                                    "example": 2
-                                                                },
-                                                                "paused": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                },
-                                                                "suspend": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                },
-                                                                "error": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                },
-                                                                "unknown": {
-                                                                    "type": "integer",
-                                                                    "example": 0
-                                                                }
-                                                            }
-                                                        },
-                                                        "usage": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "vcpu": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalCores": {
-                                                                            "type": "integer",
-                                                                            "example": 80
-                                                                        },
-                                                                        "usedCores": {
-                                                                            "type": "integer",
-                                                                            "example": 31
-                                                                        },
-                                                                        "freeCores": {
-                                                                            "type": "integer",
-                                                                            "example": 49
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.75
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.25
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "memory": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 257371
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 98255
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 159116
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 38.2
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 61.8
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "storage": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "totalMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 102400
-                                                                        },
-                                                                        "usedMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "freeMiB": {
-                                                                            "type": "integer",
-                                                                            "example": 51200
-                                                                        },
-                                                                        "usedPercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        },
-                                                                        "freePercent": {
-                                                                            "type": "number",
-                                                                            "example": 50
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "msg": {
-                                            "type": "string",
-                                            "example": "fetch summary successfully"
-                                        },
-                                        "status": {
-                                            "type": "string",
-                                            "example": "ok"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/GetMetricsResponse"
                                 }
                             }
                         }
@@ -2013,97 +1757,56 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "oneOf": [
-                                        {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
                                             "type": "object",
                                             "properties": {
-                                                "code": {
-                                                    "type": "integer",
-                                                    "example": 200
-                                                },
-                                                "data": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "read": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "time": {
-                                                                        "type": "string",
-                                                                        "example": "2025-01-01T01:00:00Z"
-                                                                    },
-                                                                    "bytes": {
-                                                                        "type": "number",
-                                                                        "example": 682.6666
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "write": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "time": {
-                                                                        "type": "string",
-                                                                        "example": "2025-01-01T01:00:00Z"
-                                                                    },
-                                                                    "bytes": {
-                                                                        "type": "number",
-                                                                        "example": 4.5
-                                                                    }
-                                                                }
+                                                "read": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "time": {
+                                                                "type": "string",
+                                                                "example": "2025-01-01T01:00:00Z"
+                                                            },
+                                                            "bytes": {
+                                                                "type": "number",
+                                                                "example": 682.6666
                                                             }
                                                         }
                                                     }
                                                 },
-                                                "msg": {
-                                                    "type": "string",
-                                                    "example": "fetch metrics successfully"
-                                                },
-                                                "status": {
-                                                    "type": "string",
-                                                    "example": "ok"
+                                                "write": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "time": {
+                                                                "type": "string",
+                                                                "example": "2025-01-01T01:00:00Z"
+                                                            },
+                                                            "bytes": {
+                                                                "type": "number",
+                                                                "example": 4.5
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "status": {
-                                                    "type": "string",
-                                                    "example": "ok"
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                "examples": {
-                                    "example1": {
-                                        "value": {
-                                            "code": 200,
-                                            "data": {
-                                                "read": [
-                                                    {
-                                                        "time": "2025-01-01T01:00:00Z",
-                                                        "bytes": 682.6666
-                                                    }
-                                                ],
-                                                "write": [
-                                                    {
-                                                        "time": "2025-01-01T01:00:00Z",
-                                                        "bytes": 4.5
-                                                    }
-                                                ]
-                                            },
-                                            "msg": "fetch metrics successfully",
-                                            "status": "ok"
-                                        }
-                                    },
-                                    "example2": {
-                                        "value": {
-                                            "status": "ok"
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "fetch metrics successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "ok"
                                         }
                                     }
                                 }
@@ -2883,7 +2586,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/network/hosts?metricType=egress&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/network/hosts": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -2993,7 +2696,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/cpu/vms?metricType=usage&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/cpu/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -3107,7 +2810,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/memory/vms?metricType=usage&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/memory/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -3221,7 +2924,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/storage/vms?metricType={metricType}&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/storage/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -3335,7 +3038,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/metrics/network/vms?metricType={metricType}&reportType=rank": {
+        "/api/v1/datacenters/{dataCenter}/metrics/network/vms": {
             "get": {
                 "tags": [
                     "Metrics"
@@ -5149,12 +4852,12 @@
                     "name": {
                         "type": "string",
                         "description": "the name of user to generate the token",
-                        "example": "test-name"
+                        "example": "example-name"
                     },
                     "password": {
                         "type": "string",
                         "description": "the password of user to generate the token",
-                        "example": "test-password"
+                        "example": "example-password"
                     }
                 }
             },


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

#86 

<br/>

### What this PR does?

based on Raven's new adjustment to align the swagger doc between this repo and cos-openapi.

generally, this bi-directional sync won't be a common case during developing.

we do this because we just had the openapi repo and FE has helped us to fine tuned it in recent days.



<br/>

### Test results (optional)

make sure the metrics part has aligned with the newest version in the cos-openapi

<img width="1435" alt="Screenshot 2025-02-09 at 2 40 57 AM" src="https://github.com/user-attachments/assets/7d237f62-e2d0-45d3-b046-1ef7e5ad8fe2" />

