### PR TITLE
Add POST APIs for licenses import

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1254,6 +1254,158 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "post": {
+                "operationId": "importClusterLicense",
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Update licenses for the cluster",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the node to operate",
+                        "example": "example-node"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PostLicenseRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Update licenses successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostLicenseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update licenses: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{node}/licenses": {
+            "operationId": "importNodeLicense",
+            "post": {
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Update licenses for specific node",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the node to operate",
+                        "example": "example-node"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PostLicenseRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Update licenses successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostLicenseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update licenses: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/datacenters/{dataCenter}/metrics": {
@@ -4530,6 +4682,46 @@ const docTemplate = `{
                     },
                     "status": {
                         "type": "string"
+                    }
+                }
+            },
+            "PostLicenseRequest": {
+                "type": "object",
+                "required": [
+                    "license"
+                ],
+                "properties": {
+                    "license": {
+                        "type": "string",
+                        "format": "binary",
+                        "description": "License file (must have a .license extension)"
+                    }
+                }
+            },
+            "PostLicenseResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "null",
+                        "example": null
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "update licenses successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -1250,6 +1250,158 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "operationId": "importClusterLicense",
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Update licenses for the cluster",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the node to operate",
+                        "example": "example-node"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PostLicenseRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Update licenses successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostLicenseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update licenses: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{node}/licenses": {
+            "operationId": "importNodeLicense",
+            "post": {
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Update licenses for specific node",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the node to operate",
+                        "example": "example-node"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PostLicenseRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Update licenses successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostLicenseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update licenses: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/datacenters/{dataCenter}/metrics": {
@@ -4526,6 +4678,46 @@
                     },
                     "status": {
                         "type": "string"
+                    }
+                }
+            },
+            "PostLicenseRequest": {
+                "type": "object",
+                "required": [
+                    "license"
+                ],
+                "properties": {
+                    "license": {
+                        "type": "string",
+                        "format": "binary",
+                        "description": "License file (must have a .license extension)"
+                    }
+                }
+            },
+            "PostLicenseResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "null",
+                        "example": null
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "update licenses successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
                     }
                 }
             },

--- a/internal/api/v1/licenses/delegation.go
+++ b/internal/api/v1/licenses/delegation.go
@@ -1,0 +1,54 @@
+package licenses
+
+import (
+	"fmt"
+	"mime/multipart"
+	"net/url"
+
+	cubeHttp "github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/bigstack-oss/cube-cos-api/internal/service"
+	log "go-micro.dev/v5/logger"
+)
+
+func genUrl(node definition.Node) string {
+	u := url.URL{
+		Scheme: "http",
+		Host:   node.Address,
+		Path:   fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/licenses", definition.DataCenterName, node.Role),
+	}
+	return u.String()
+}
+
+func sendLicenseToOtherNodes(nodeName string, licenseFile *multipart.FileHeader) error {
+	nodes, err := service.GetNodesByRole(nodeName)
+	if err != nil {
+		log.Errorf("failed to get nodes by role %s: %s", nodeName, err.Error())
+		return err
+	}
+
+	reader, err := licenseFile.Open()
+	if err != nil {
+		log.Errorf("failed to open license file: %s", err.Error())
+		return err
+	}
+
+	node := nodes[0]
+	h := cubeHttp.GetGlobalHelper()
+
+	resp, err := h.R().
+		SetFileReader("license", licenseFile.Filename, reader).
+		SetHeader("secret", "Dev@Cube").
+		Post(genUrl(node))
+	if resp.IsError() || err != nil {
+		log.Errorf(
+			"failed to send license to node %s: %d %s",
+			node.Hostname,
+			resp.StatusCode(),
+			string(resp.Body()),
+		)
+		return err
+	}
+
+	return nil
+}

--- a/internal/api/v1/licenses/handlers.go
+++ b/internal/api/v1/licenses/handlers.go
@@ -23,6 +23,12 @@ var (
 			Path:    "/licenses",
 			Func:    importClusterLicense,
 		},
+		{
+			Version: api.V1,
+			Method:  http.MethodPost,
+			Path:    "/nodes/:node/licenses",
+			Func:    importNodeLicense,
+		},
 	}
 )
 
@@ -88,6 +94,16 @@ func importClusterLicense(c *gin.Context) {
 
 	if err := cubecos.ImportClusterLicense(filePath); err != nil {
 		log.Errorf("request(%s): failed to import cluster license: %s", api.GetReqId(c), err.Error())
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	api.SetStatusOk(c, "update licenses successfully", nil)
+}
+
+func importNodeLicense(c *gin.Context) {
+	if err := importOrDelegateLicense(c, c.Param("node")); err != nil {
+		log.Errorf("request(%s): failed to import license: %s", api.GetReqId(c), err.Error())
 		api.SetInternalServerError(c, err)
 		return
 	}

--- a/internal/api/v1/licenses/handlers.go
+++ b/internal/api/v1/licenses/handlers.go
@@ -17,6 +17,12 @@ var (
 			Path:    "/licenses",
 			Func:    getLicenses,
 		},
+		{
+			Version: api.V1,
+			Method:  http.MethodPost,
+			Path:    "/licenses",
+			Func:    importClusterLicense,
+		},
 	}
 )
 
@@ -57,4 +63,34 @@ func getLicenses(c *gin.Context) {
 			Page:     page,
 		},
 	)
+}
+
+func importClusterLicense(c *gin.Context) {
+	licenseFile, err := c.FormFile("license")
+	if err != nil {
+		log.Errorf("request(%s): %s", api.GetReqId(c), err.Error())
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	filePath, err := getLicenseStorePath(licenseFile.Filename)
+	if err != nil {
+		log.Errorf("request(%s): failed to generate license store path: %s", api.GetReqId(c), err.Error())
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	if err := c.SaveUploadedFile(licenseFile, filePath); err != nil {
+		log.Errorf("request(%s): failed to save license file: %s", api.GetReqId(c), err.Error())
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	if err := cubecos.ImportClusterLicense(filePath); err != nil {
+		log.Errorf("request(%s): failed to import cluster license: %s", api.GetReqId(c), err.Error())
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	api.SetStatusOk(c, "update licenses successfully", nil)
 }

--- a/internal/api/v1/licenses/license.go
+++ b/internal/api/v1/licenses/license.go
@@ -2,8 +2,15 @@ package licenses
 
 import (
 	"errors"
+	"mime/multipart"
 	"path/filepath"
 	"strings"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
 )
 
 const (
@@ -22,4 +29,33 @@ func getLicenseStorePath(filename string) (string, error) {
 	}
 
 	return filePath, nil
+}
+
+func importOrDelegateLicense(c *gin.Context, nodeName string) error {
+	licenseFile, err := c.FormFile("license")
+	if err != nil {
+		log.Errorf("failed to get license file: %s", api.GetReqId(c), err.Error())
+		return err
+	}
+
+	if nodeName != definition.Hostname {
+		return sendLicenseToOtherNodes(nodeName, licenseFile)
+	}
+
+	return importLicenseToNode(c, licenseFile)
+}
+
+func importLicenseToNode(c *gin.Context, licenseFile *multipart.FileHeader) error {
+	filePath, err := getLicenseStorePath(licenseFile.Filename)
+	if err != nil {
+		log.Errorf("failed to generate license store path: %s", err.Error())
+		return err
+	}
+
+	if err := c.SaveUploadedFile(licenseFile, filePath); err != nil {
+		log.Errorf("failed to save license file: %s", err.Error())
+		return err
+	}
+
+	return cubecos.ImportNodeLicense(filePath)
 }

--- a/internal/api/v1/licenses/license.go
+++ b/internal/api/v1/licenses/license.go
@@ -1,0 +1,25 @@
+package licenses
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	licenseExtension = ".license"
+	licenseStorePath = "/var/support"
+)
+
+func getLicenseStorePath(filename string) (string, error) {
+	filePath, err := filepath.Abs(filepath.Join(licenseStorePath, filename))
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(filePath, licenseStorePath) {
+		return "", errors.New("invalid filename")
+	}
+
+	return filePath, nil
+}

--- a/internal/cubecos/licenses.go
+++ b/internal/cubecos/licenses.go
@@ -3,10 +3,22 @@ package cubecos
 import (
 	"encoding/json"
 	"os/exec"
+	"path/filepath"
 
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	log "go-micro.dev/v5/logger"
 )
+
+func ImportClusterLicense(licensePath string) error {
+	dir := filepath.Dir(licensePath)
+	base := filepath.Base(licensePath)
+	_, err := exec.Command("hex_config", "sdk_run", "license_cluster_import", dir, base).Output()
+	if err != nil {
+		log.Errorf("failed to import licenses: %v", err)
+		return err
+	}
+	return nil
+}
 
 func ListLicenses() ([]definition.License, error) {
 	b, err := exec.Command("hex_config", "sdk_run", "-f", "json", "license_cluster_show").Output()

--- a/internal/cubecos/licenses.go
+++ b/internal/cubecos/licenses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	log "go-micro.dev/v5/logger"
@@ -13,6 +14,18 @@ func ImportClusterLicense(licensePath string) error {
 	dir := filepath.Dir(licensePath)
 	base := filepath.Base(licensePath)
 	_, err := exec.Command("hex_config", "sdk_run", "license_cluster_import", dir, base).Output()
+	if err != nil {
+		log.Errorf("failed to import licenses: %v", err)
+		return err
+	}
+	return nil
+}
+
+func ImportNodeLicense(licensePath string) error {
+	dir := filepath.Dir(licensePath)
+	filename := strings.TrimSuffix(filepath.Base(licensePath), filepath.Ext(licensePath))
+
+	_, err := exec.Command("hex_config", "sdk_run", "license_node_import", dir, filename).Output()
 	if err != nil {
 		log.Errorf("failed to import licenses: %v", err)
 		return err

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -47,6 +47,7 @@ func newRouter() *gin.Engine {
 	router.Any("/saml/*any", gin.WrapH(saml.SpAuth))
 	router.Use(gin.Recovery())
 	router.Use(initReqInfo)
+	router.Use(verifyDevSecret())
 	router.Use(verifyAuthToken())
 	router.Use(conditionalSaml())
 	return router
@@ -59,8 +60,27 @@ func initReqInfo(c *gin.Context) {
 	c.Next()
 }
 
+// TODO M1: Due to we still don't have a mechanism for API communicate
+// so use a dev secret for it when developing, but should be removed before M1 release
+func verifyDevSecret() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		secret := c.GetHeader("secret")
+		if secret == "Dev@Cube" {
+			c.Set("isSecretValid", true)
+		}
+
+		c.Next()
+	}
+}
+
 func verifyAuthToken() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		_, found := c.Get("isSecretValid")
+		if found {
+			c.Next()
+			return
+		}
+
 		token := parseToken(c)
 		err := oidc.VerifyToken(token)
 		if err == nil {
@@ -88,7 +108,13 @@ func parseToken(c *gin.Context) string {
 func conditionalSaml() gin.HandlerFunc {
 	doSamlAuth := adapter.Wrap(saml.SpAuth.RequireAccount)
 	return func(c *gin.Context) {
-		_, found := c.Get("isTokenValid")
+		_, found := c.Get("isSecretValid")
+		if found {
+			c.Next()
+			return
+		}
+
+		_, found = c.Get("isTokenValid")
 		if found {
 			c.Next()
 			return


### PR DESCRIPTION
### What type of PR is this?

feat

### Which issue(s) this PR fixes?

#40 

### What this PR does?

* Provide two POST APIs: one for cluster license import and another for node license import. This is the first iteration and will be refactored in the future.
* Create a `DevSecret` middleware to handle API communication. It will read the secret from the header and bypass token verification, only for development until we implement proper API-to-API communication verification. The secret bypass should **be removed** before the M1 release.
* The `hex_sdk` always returns code 0 for license imports, regardless of success or failure. Need to check with the COS developer.

### Test results (optional)

* For cluster license importing, send the request to the `dell13` server and ensure it delegates the request to `dell200`, confirming that the license has been imported on `dell200`.
<img width="1079" alt="image" src="https://github.com/user-attachments/assets/0c180c77-515c-4b89-bc3b-219cf41060e1" />

* Swagger of the cluster license import
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/4611b500-0ac1-4468-b748-80eddcd448da" />
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/31e61b18-b91a-4c21-950e-dd34d5043c87" />


* For node license importing, ensure the license has beed imported on the host
<img width="1079" alt="image" src="https://github.com/user-attachments/assets/76ce7253-0487-453c-9549-9476d15045cb" />

* Swagger of the node license import
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/96d69e24-7b52-47c1-8cf4-9300429267a7" />
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/be195c46-691c-4440-90ba-e1056bda2ee2" />

