### PR TITLE
Add a GET API to fetch event statistic

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -600,6 +600,16 @@ const docTemplate = `{
                     },
                     {
                         "in": "query",
+                        "name": "id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The id of the event to query.",
+                        "example": "NET00003I"
+                    },
+                    {
+                        "in": "query",
                         "name": "start",
                         "required": false,
                         "schema": {
@@ -736,7 +746,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "string",
                             "enum": [
-                                "start",
+                                "system",
                                 "host",
                                 "instance"
                             ]
@@ -939,6 +949,212 @@ const docTemplate = `{
                                                 }
                                             },
                                             "msg": "fetch event abstract successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid 'start' time: 2021-09-01T111:00:00Z"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch events: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/events/rank": {
+            "get": {
+                "operationId": "getRankedEvents",
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Retrieve the ranked events",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "system",
+                                "host",
+                                "instance"
+                            ]
+                        },
+                        "description": "The type of event to query, the value can be only 'system', 'host', and 'instance'.",
+                        "example": "system"
+                    },
+                    {
+                        "in": "query",
+                        "name": "category",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The category of the event to query.",
+                        "example": "NET"
+                    },
+                    {
+                        "in": "query",
+                        "name": "severity",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The severity of the event to query, the value can be only 'Info', 'Warning', and 'Error'.",
+                        "example": "Info"
+                    },
+                    {
+                        "in": "query",
+                        "name": "host",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The host of the event to query.",
+                        "example": "dell180"
+                    },
+                    {
+                        "in": "query",
+                        "name": "instance",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The instance of the event to query.",
+                        "example": "ccc449e4-a26c-47ac-afc1-c792ab1ed20a"
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The limit of the abstracted events to return (default is 10).",
+                        "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the abstracted events successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetRankedEventsResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Abstracted recent events",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "events": [
+                                                    {
+                                                        "id": "NET00003I",
+                                                        "percent": 98.2142,
+                                                        "number": 440,
+                                                        "query": "https://example-datat-center.host/api/v1/datacenters/example-data-center/events?type=system&id=NET00003I&start=2024-12-01T00:00:00Z&stop=2025-02-17T00:00:00Z&pageNum=1&pageSize=20"
+                                                    },
+                                                    {
+                                                        "id": "NET00001I",
+                                                        "percent": 1.7857,
+                                                        "number": 8,
+                                                        "query": "https://example-datat-center.host/api/v1/datacenters/example-data-center/events?type=system&id=NET00001I&start=2024-12-01T00:00:00Z&stop=2025-02-17T00:00:00Z&pageNum=1&pageSize=20"
+                                                    }
+                                                ],
+                                                "limit": {
+                                                    "number": 25,
+                                                    "description": "The top 2 event IDs with the highest proportion"
+                                                }
+                                            },
+                                            "msg": "fetch event rank successfully",
                                             "status": "ok"
                                         }
                                     }
@@ -4324,6 +4540,76 @@ const docTemplate = `{
                                             }
                                         },
                                         "time": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "limit": {
+                                "type": "object",
+                                "required": [
+                                    "number",
+                                    "description"
+                                ],
+                                "properties": {
+                                    "number": {
+                                        "type": "integer"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "GetRankedEventsResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "events",
+                            "limit"
+                        ],
+                        "properties": {
+                            "events": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "percent",
+                                        "number",
+                                        "query"
+                                    ],
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "percent": {
+                                            "type": "number"
+                                        },
+                                        "number": {
+                                            "type": "integer"
+                                        },
+                                        "query": {
                                             "type": "string"
                                         }
                                     }

--- a/api/docs.json
+++ b/api/docs.json
@@ -596,6 +596,16 @@
                     },
                     {
                         "in": "query",
+                        "name": "id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The id of the event to query.",
+                        "example": "NET00003I"
+                    },
+                    {
+                        "in": "query",
                         "name": "start",
                         "required": false,
                         "schema": {
@@ -732,7 +742,7 @@
                         "schema": {
                             "type": "string",
                             "enum": [
-                                "start",
+                                "system",
                                 "host",
                                 "instance"
                             ]
@@ -935,6 +945,212 @@
                                                 }
                                             },
                                             "msg": "fetch event abstract successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid 'start' time: 2021-09-01T111:00:00Z"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch events: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/events/rank": {
+            "get": {
+                "operationId": "getRankedEvents",
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Retrieve the ranked events",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "system",
+                                "host",
+                                "instance"
+                            ]
+                        },
+                        "description": "The type of event to query, the value can be only 'system', 'host', and 'instance'.",
+                        "example": "system"
+                    },
+                    {
+                        "in": "query",
+                        "name": "category",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The category of the event to query.",
+                        "example": "NET"
+                    },
+                    {
+                        "in": "query",
+                        "name": "severity",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The severity of the event to query, the value can be only 'Info', 'Warning', and 'Error'.",
+                        "example": "Info"
+                    },
+                    {
+                        "in": "query",
+                        "name": "host",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The host of the event to query.",
+                        "example": "dell180"
+                    },
+                    {
+                        "in": "query",
+                        "name": "instance",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The instance of the event to query.",
+                        "example": "ccc449e4-a26c-47ac-afc1-c792ab1ed20a"
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The limit of the abstracted events to return (default is 10).",
+                        "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "The toggle to enable http chunked transfer for continues server push.",
+                        "example": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the abstracted events successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetRankedEventsResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Abstracted recent events",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "events": [
+                                                    {
+                                                        "id": "NET00003I",
+                                                        "percent": 98.2142,
+                                                        "number": 440,
+                                                        "query": "https://example-datat-center.host/api/v1/datacenters/example-data-center/events?type=system&id=NET00003I&start=2024-12-01T00:00:00Z&stop=2025-02-17T00:00:00Z&pageNum=1&pageSize=20"
+                                                    },
+                                                    {
+                                                        "id": "NET00001I",
+                                                        "percent": 1.7857,
+                                                        "number": 8,
+                                                        "query": "https://example-datat-center.host/api/v1/datacenters/example-data-center/events?type=system&id=NET00001I&start=2024-12-01T00:00:00Z&stop=2025-02-17T00:00:00Z&pageNum=1&pageSize=20"
+                                                    }
+                                                ],
+                                                "limit": {
+                                                    "number": 25,
+                                                    "description": "The top 2 event IDs with the highest proportion"
+                                                }
+                                            },
+                                            "msg": "fetch event rank successfully",
                                             "status": "ok"
                                         }
                                     }
@@ -4320,6 +4536,76 @@
                                             }
                                         },
                                         "time": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "limit": {
+                                "type": "object",
+                                "required": [
+                                    "number",
+                                    "description"
+                                ],
+                                "properties": {
+                                    "number": {
+                                        "type": "integer"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "GetRankedEventsResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "events",
+                            "limit"
+                        ],
+                        "properties": {
+                            "events": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "percent",
+                                        "number",
+                                        "query"
+                                    ],
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "percent": {
+                                            "type": "number"
+                                        },
+                                        "number": {
+                                            "type": "integer"
+                                        },
+                                        "query": {
                                             "type": "string"
                                         }
                                     }

--- a/internal/api/v1/events/handlers.go
+++ b/internal/api/v1/events/handlers.go
@@ -26,7 +26,7 @@ var (
 			Version: api.V1,
 			Method:  http.MethodGet,
 			Path:    "/events/rank",
-			Func:    getEventRank,
+			Func:    genEventRank,
 		},
 	}
 )
@@ -89,15 +89,15 @@ func getEventAbstract(c *gin.Context) {
 	)
 }
 
-func getEventRank(c *gin.Context) {
-	h, err := initReqHelper(c, "getEventRank")
+func genEventRank(c *gin.Context) {
+	h, err := initReqHelper(c, "genEventRank")
 	if err != nil {
 		log.Errorf("request(%s): %v", api.GetReqId(c), err)
 		api.SetBadRequest(c, err)
 		return
 	}
 
-	rank, err := h.getEventRank()
+	rank, err := h.genEventRank()
 	if err != nil {
 		log.Errorf("request(%s): failed to gen event rank: %v", api.GetReqId(c), err)
 		api.SetInternalServerError(c, err)

--- a/internal/api/v1/events/handlers.go
+++ b/internal/api/v1/events/handlers.go
@@ -22,6 +22,12 @@ var (
 			Path:    "/events/abstract",
 			Func:    getEventAbstract,
 		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/events/rank",
+			Func:    getEventRank,
+		},
 	}
 )
 
@@ -80,5 +86,32 @@ func getEventAbstract(c *gin.Context) {
 		c,
 		"fetch event abstract successfully",
 		abstract,
+	)
+}
+
+func getEventRank(c *gin.Context) {
+	h, err := initReqHelper(c, "getEventRank")
+	if err != nil {
+		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	rank, err := h.getEventRank()
+	if err != nil {
+		log.Errorf("request(%s): failed to gen event rank: %v", api.GetReqId(c), err)
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	if h.watch {
+		watchEvents(h, rank)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"fetch event rank successfully",
+		rank,
 	)
 }

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -219,3 +219,25 @@ func (h *helper) genEventAbstract() (*data, error) {
 		},
 	}, nil
 }
+
+func (h *helper) getEventRank() (*data, error) {
+	stmt, err := h.genRankStmt()
+	if err != nil {
+		log.Errorf("request(%s): %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	rank, err := cubecos.GetEventRank(stmt)
+	if err != nil {
+		log.Errorf("request(%s): failed to get events: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	return &data{
+		Events: rank,
+		Limit: &definition.Limit{
+			Number:      h.limit,
+			Description: fmt.Sprintf("the top %d recent events", h.limit),
+		},
+	}, nil
+}

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -19,6 +19,7 @@ type helper struct {
 	handler string
 
 	eventType string
+	eventId   string
 	category  string
 	severity  string
 	host      string
@@ -53,6 +54,11 @@ func initReqHelper(c *gin.Context, handler string) (*helper, error) {
 
 func (h *helper) parseEventListingParams() (*helper, error) {
 	err := h.parseType()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseId()
 	if err != nil {
 		return nil, err
 	}
@@ -133,6 +139,11 @@ func (h *helper) parseType() error {
 	}
 
 	h.eventType = t
+	return nil
+}
+
+func (h *helper) parseId() error {
+	h.eventId = h.c.DefaultQuery("id", "")
 	return nil
 }
 
@@ -296,15 +307,16 @@ func (h *helper) genEventQueryUrl(event definition.EventStat) string {
 	u := url.URL{}
 	u.Scheme = "https"
 	u.Host = h.c.Request.Host
-	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/events/%s", definition.DataCenterName, event.Id)
-	u.RawQuery = h.genEventQuery()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/events", definition.DataCenterName)
+	u.RawQuery = h.genEventQuery(event)
 	return u.String()
 }
 
-func (h *helper) genEventQuery() string {
+func (h *helper) genEventQuery(event definition.EventStat) string {
 	return fmt.Sprintf(
-		"?type=%s&start=%s&stop=%s",
+		"type=%s&id=%s&start=%s&stop=%s&pageNum=1&pageSize=20",
 		h.eventType,
+		event.Id,
 		h.period.start,
 		h.period.stop,
 	)

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -44,7 +44,7 @@ func initReqHelper(c *gin.Context, handler string) (*helper, error) {
 		return h.parseEventListingParams()
 	case "getEventAbstract":
 		return h.parseEventAbstractParams()
-	case "getEventRank":
+	case "genEventRank":
 		return h.parseEventRankParams()
 	}
 
@@ -263,7 +263,7 @@ func (h *helper) genEventAbstract() (*data, error) {
 	}, nil
 }
 
-func (h *helper) getEventRank() (*data, error) {
+func (h *helper) genEventRank() (*data, error) {
 	stmt, err := h.genRankStmt()
 	if err != nil {
 		log.Errorf("request(%s): %v", api.GetReqId(h.c), err)

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -3,6 +3,7 @@ package events
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -14,9 +15,14 @@ import (
 )
 
 type helper struct {
-	c         *gin.Context
-	handler   string
+	c       *gin.Context
+	handler string
+
 	eventType string
+	category  string
+	severity  string
+	host      string
+	instance  string
 
 	period
 	definition.Page
@@ -31,15 +37,15 @@ type period struct {
 }
 
 func initReqHelper(c *gin.Context, handler string) (*helper, error) {
-	h := &helper{c: c}
+	h := &helper{c: c, handler: handler}
 
 	switch handler {
 	case "getEvents":
-		h.handler = "getEvents"
 		return h.parseEventListingParams()
 	case "getEventAbstract":
-		h.handler = "getEventAbstract"
 		return h.parseEventAbstractParams()
+	case "getEventRank":
+		return h.parseEventRankParams()
 	}
 
 	return nil, errors.New("no internal function supported")
@@ -76,6 +82,35 @@ func (h *helper) parseEventAbstractParams() (*helper, error) {
 	}
 
 	err = h.parseLimit()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseWatch()
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *helper) parseEventRankParams() (*helper, error) {
+	err := h.parseType()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parsePeriod()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseLimit()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseRankFactors()
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +208,14 @@ func (h *helper) parseLimit() error {
 	return nil
 }
 
+func (h *helper) parseRankFactors() error {
+	h.category = h.c.DefaultQuery("category", "")
+	h.severity = h.c.DefaultQuery("severity", "")
+	h.host = h.c.DefaultQuery("host", "")
+	h.instance = h.c.DefaultQuery("instance", "")
+	return nil
+}
+
 func (h *helper) parseWatch() error {
 	var err error
 	h.watch, err = api.ParseWatch(h.c)
@@ -233,11 +276,36 @@ func (h *helper) getEventRank() (*data, error) {
 		return nil, err
 	}
 
+	h.setQueryUrlToEachEvent(&rank)
 	return &data{
 		Events: rank,
 		Limit: &definition.Limit{
 			Number:      h.limit,
-			Description: fmt.Sprintf("the top %d recent events", h.limit),
+			Description: fmt.Sprintf("The top %d event IDs with the highest proportion", len(rank)),
 		},
 	}, nil
+}
+
+func (h *helper) setQueryUrlToEachEvent(events *[]definition.EventStat) {
+	for i, event := range *events {
+		(*events)[i].Query = h.genEventQueryUrl(event)
+	}
+}
+
+func (h *helper) genEventQueryUrl(event definition.EventStat) string {
+	u := url.URL{}
+	u.Scheme = "https"
+	u.Host = h.c.Request.Host
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/events/%s", definition.DataCenterName, event.Id)
+	u.RawQuery = h.genEventQuery()
+	return u.String()
+}
+
+func (h *helper) genEventQuery() string {
+	return fmt.Sprintf(
+		"?type=%s&start=%s&stop=%s",
+		h.eventType,
+		h.period.start,
+		h.period.stop,
+	)
 }

--- a/internal/api/v1/events/pagination.go
+++ b/internal/api/v1/events/pagination.go
@@ -17,6 +17,10 @@ func (h *helper) isPageRequired() bool {
 	return h.Page.Number > 0 || h.Page.Size > 0
 }
 
+func (h *helper) isIdRequired() bool {
+	return h.eventId != ""
+}
+
 func (h *helper) genPageInfo(events []definition.Event) (definition.Page, error) {
 	if !h.isPageRequired() {
 		return definition.Page{

--- a/internal/api/v1/events/resp.go
+++ b/internal/api/v1/events/resp.go
@@ -3,7 +3,7 @@ package events
 import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 
 type data struct {
-	Events            []definition.Event `json:"events"`
+	Events            interface{} `json:"events"`
 	*definition.Page  `json:"page,omitempty"`
 	*definition.Limit `json:"limit,omitempty"`
 }

--- a/internal/api/v1/events/stmt.go
+++ b/internal/api/v1/events/stmt.go
@@ -41,6 +41,51 @@ var (
 			|> sort(columns: ["_time"], desc: true)
 			|> limit(n: %d)
 	`
+
+	eventSystemRankQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "system")
+			|> filter(fn: (r) => r.category == "%s")
+			|> filter(fn: (r) => r.severity == "%s")
+			|> group(columns: ["key", "category", "severity"])
+			|> count(column: "_value")
+			|> rename(columns: {_value: "number"})
+			|> keep(columns: ["key", "category", "severity", "number"])
+			|> group()
+			|> sort(columns: ["number"], desc: true)
+			|> limit(n: %s)
+	`
+
+	eventHostRankQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "host")
+			|> filter(fn: (r) => r.category == "%s")
+			|> filter(fn: (r) => r.host == "%s")
+			|> group(columns: ["key", "category", "host"])
+			|> count(column: "_value")
+			|> rename(columns: {_value: "number"})
+			|> keep(columns: ["key", "category", "host", "number"])
+			|> group()
+			|> sort(columns: ["number"], desc: true)
+			|> limit(n: %s)
+	`
+
+	eventInstanceRankQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "instance")
+			|> filter(fn: (r) => r.category == "%s")
+			|> filter(fn: (r) => r.instance == "%s")
+			|> group(columns: ["key", "category", "instance"])
+			|> count(column: "_value")
+			|> rename(columns: {_value: "number"})
+			|> keep(columns: ["key", "category", "instance", "number"])
+			|> group()
+			|> sort(columns: ["number"], desc: true)
+			|> limit(n: %s)
+	`
 )
 
 func (h *helper) genCountQueryStmt() string {
@@ -84,6 +129,49 @@ func (h *helper) genPagingQueryStmt() string {
 func (h *helper) genAbstractStmt() string {
 	return fmt.Sprintf(
 		eventLimitingQueryTemplate,
+		h.eventType,
+		h.limit,
+	)
+}
+
+func (h *helper) genRankStmt() (string, error) {
+	switch h.eventType {
+	case "system":
+		return h.genSystemRankStmt(), nil
+	case "host":
+		return h.genHostRankStmt(), nil
+	case "instance":
+		return h.genInstanceRankStmt(), nil
+	}
+
+	return "", fmt.Errorf("unsupported event type: %s", h.eventType)
+}
+
+func (h *helper) genSystemRankStmt() string {
+	return fmt.Sprintf(
+		eventSystemRankQueryTemplate,
+		h.period.start,
+		h.period.stop,
+		h.eventType,
+		h.limit,
+	)
+}
+
+func (h *helper) genHostRankStmt() string {
+	return fmt.Sprintf(
+		eventHostRankQueryTemplate,
+		h.period.start,
+		h.period.stop,
+		h.eventType,
+		h.limit,
+	)
+}
+
+func (h *helper) genInstanceRankStmt() string {
+	return fmt.Sprintf(
+		eventInstanceRankQueryTemplate,
+		h.period.start,
+		h.period.stop,
 		h.eventType,
 		h.limit,
 	)

--- a/internal/api/v1/events/stmt.go
+++ b/internal/api/v1/events/stmt.go
@@ -54,7 +54,7 @@ var (
 			|> keep(columns: ["key", "category", "severity", "number"])
 			|> group()
 			|> sort(columns: ["number"], desc: true)
-			|> limit(n: %s)
+			|> limit(n: %d)
 	`
 
 	eventHostRankQueryTemplate = `
@@ -69,7 +69,7 @@ var (
 			|> keep(columns: ["key", "category", "host", "number"])
 			|> group()
 			|> sort(columns: ["number"], desc: true)
-			|> limit(n: %s)
+			|> limit(n: %d)
 	`
 
 	eventInstanceRankQueryTemplate = `
@@ -84,7 +84,7 @@ var (
 			|> keep(columns: ["key", "category", "instance", "number"])
 			|> group()
 			|> sort(columns: ["number"], desc: true)
-			|> limit(n: %s)
+			|> limit(n: %d)
 	`
 )
 
@@ -152,7 +152,8 @@ func (h *helper) genSystemRankStmt() string {
 		eventSystemRankQueryTemplate,
 		h.period.start,
 		h.period.stop,
-		h.eventType,
+		h.category,
+		h.severity,
 		h.limit,
 	)
 }
@@ -162,7 +163,8 @@ func (h *helper) genHostRankStmt() string {
 		eventHostRankQueryTemplate,
 		h.period.start,
 		h.period.stop,
-		h.eventType,
+		h.category,
+		h.host,
 		h.limit,
 	)
 }
@@ -172,7 +174,8 @@ func (h *helper) genInstanceRankStmt() string {
 		eventInstanceRankQueryTemplate,
 		h.period.start,
 		h.period.stop,
-		h.eventType,
+		h.category,
+		h.instance,
 		h.limit,
 	)
 }

--- a/internal/api/v1/events/stmt.go
+++ b/internal/api/v1/events/stmt.go
@@ -13,6 +13,14 @@ var (
 			|> count()
 	`
 
+	eventIdCountQueryTemplate = `
+	from(bucket: "events")
+		|> range(start: %s, stop: %s)
+		|> filter(fn: (r) => r._measurement == "%s")
+		|> filter(fn: (r) => r.key == "%s")
+		|> count()
+`
+
 	eventNonPagingQueryTemplate = `
 		from(bucket: "events")
 			|> range(start: %s, stop: %s)
@@ -22,10 +30,31 @@ var (
 			|> sort(columns: ["_time"], desc: true)
 	`
 
+	eventIdNonPagingQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "%s")
+			|> filter(fn: (r) => r.key == "%s")
+			|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+			|> group()
+			|> sort(columns: ["_time"], desc: true)
+	`
+
 	eventPagingQueryTemplate = `
 		from(bucket: "events")
 			|> range(start: %s, stop: %s)
 			|> filter(fn: (r) => r._measurement == "%s")
+			|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+			|> group()
+			|> sort(columns: ["_time"], desc: true)
+			|> limit(n: %d, offset: %d)
+	`
+
+	eventIdPagingQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "%s")
+			|> filter(fn: (r) => r.key == "%s")
 			|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
 			|> group()
 			|> sort(columns: ["_time"], desc: true)
@@ -89,6 +118,16 @@ var (
 )
 
 func (h *helper) genCountQueryStmt() string {
+	if h.isIdRequired() {
+		return fmt.Sprintf(
+			eventIdCountQueryTemplate,
+			h.period.start,
+			h.period.stop,
+			h.eventType,
+			h.eventId,
+		)
+	}
+
 	return fmt.Sprintf(
 		eventCountQueryTemplate,
 		h.period.start,
@@ -106,6 +145,16 @@ func (h *helper) genListingStmt() string {
 }
 
 func (h *helper) genNonPagingQueryStmt() string {
+	if h.isIdRequired() {
+		return fmt.Sprintf(
+			eventIdNonPagingQueryTemplate,
+			h.period.start,
+			h.period.stop,
+			h.eventType,
+			h.eventId,
+		)
+	}
+
 	return fmt.Sprintf(
 		eventNonPagingQueryTemplate,
 		h.period.start,
@@ -116,6 +165,18 @@ func (h *helper) genNonPagingQueryStmt() string {
 
 func (h *helper) genPagingQueryStmt() string {
 	offset := (h.Page.Number - 1) * h.Page.Size
+	if h.isIdRequired() {
+		return fmt.Sprintf(
+			eventIdPagingQueryTemplate,
+			h.period.start,
+			h.period.stop,
+			h.eventType,
+			h.eventId,
+			h.Page.Size,
+			offset,
+		)
+	}
+
 	return fmt.Sprintf(
 		eventPagingQueryTemplate,
 		h.period.start,

--- a/internal/api/v1/events/watch.go
+++ b/internal/api/v1/events/watch.go
@@ -55,6 +55,8 @@ func streamEventsByHandlerType(h *helper) (*data, error) {
 		return h.genEvents()
 	case "getEventAbstract":
 		return h.genEventAbstract()
+	case "genEventRank":
+		return h.genEventRank()
 	}
 
 	return nil, errors.New("no internal function supported")

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/influx"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/math"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/influxdata/influxdb-client-go/v2/api"
@@ -111,7 +112,8 @@ func setPercentageToEachEvent(events *[]definition.EventStat) {
 	}
 
 	for i := range *events {
-		(*events)[i].Percent = float64((*events)[i].Number) / float64(total)
+		percent := float64((*events)[i].Number) / float64(total) * 100
+		(*events)[i].Percent = math.RoundDown(percent, 4)
 	}
 }
 

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -153,27 +153,27 @@ func parseEvents(c *api.QueryTableResult, events *[]definition.Event) error {
 func genEventByRecord(record *query.FluxRecord) definition.Event {
 	date, err := time.Parse(eventTimeLayout, record.Time().Local().String())
 	if err != nil {
-		log.Warnf("failed to parse date from record: %v", record)
+		log.Debugf("failed to parse date from record: %v", record)
 	}
 
 	severity, ok := record.ValueByKey("severity").(string)
 	if !ok {
-		log.Warnf("failed to parse severity from record: %v", record)
+		log.Debugf("failed to parse severity from record: %v", record)
 	}
 
 	eventId, ok := record.ValueByKey("key").(string)
 	if !ok {
-		log.Warnf("failed to parse key from record: %v", record)
+		log.Debugf("failed to parse key from record: %v", record)
 	}
 
 	msg, ok := record.ValueByKey("message").(string)
 	if !ok {
-		log.Warnf("failed to parse message from record: %v", record)
+		log.Debugf("failed to parse message from record: %v", record)
 	}
 
 	host, ok := record.ValueByKey("host").(string)
 	if !ok {
-		log.Warnf("failed to parse host from record: %v", record)
+		log.Debugf("failed to parse host from record: %v", record)
 	}
 
 	return definition.Event{
@@ -189,14 +189,14 @@ func genEventByRecord(record *query.FluxRecord) definition.Event {
 func setMetadataToEvent(event *definition.Event, record *query.FluxRecord) {
 	metadata, ok := record.ValueByKey("metadata").(string)
 	if !ok {
-		log.Warnf("failed to parse metadata from record: %v", record)
+		log.Debugf("failed to parse metadata from record: %v", record)
 		return
 	}
 
 	metaObj := map[string]interface{}{}
 	err := json.Unmarshal([]byte(metadata), &metaObj)
 	if err != nil {
-		log.Warnf("failed to parse metadata from record: %v", record)
+		log.Debugf("failed to parse metadata from record: %v", record)
 		return
 	}
 

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -81,6 +81,59 @@ func GetEvents(stmt string) ([]definition.Event, error) {
 	return events, nil
 }
 
+func GetEventRank(stmt string) ([]definition.EventStat, error) {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(60))
+	defer cancel()
+
+	h := influx.GetGlobalHelper()
+	c, err := h.QueryApiClient.Query(ctx, stmt)
+	if err != nil {
+		log.Errorf("failed to get query cursor: %v", err)
+		return nil, err
+	}
+
+	defer c.Close()
+	events := []definition.EventStat{}
+	err = parseEventStats(c, &events)
+	if err != nil {
+		log.Errorf("failed to parse events from cursor: %v", err)
+		return nil, err
+	}
+
+	setPercentageToEachEvent(&events)
+	return events, nil
+}
+
+func setPercentageToEachEvent(events *[]definition.EventStat) {
+	total := int64(0)
+	for _, event := range *events {
+		total = total + event.Number
+	}
+
+	for i := range *events {
+		(*events)[i].Percent = float64((*events)[i].Number) / float64(total)
+	}
+}
+
+func parseEventStats(c *api.QueryTableResult, events *[]definition.EventStat) error {
+	for c.Next() {
+		event := genEventStatsByRecord(c.Record())
+		*events = append(*events, event)
+	}
+	if c.Err() != nil {
+		return c.Err()
+	}
+
+	return nil
+}
+
+func genEventStatsByRecord(record *query.FluxRecord) definition.EventStat {
+	return definition.EventStat{
+		Id:     record.ValueByKey("key").(string),
+		Number: record.ValueByKey("number").(int64),
+	}
+}
+
 func parseEvents(c *api.QueryTableResult, events *[]definition.Event) error {
 	for c.Next() {
 		record := c.Record()
@@ -116,12 +169,17 @@ func genEventByRecord(record *query.FluxRecord) definition.Event {
 		log.Warnf("failed to parse message from record: %v", record)
 	}
 
+	host, ok := record.ValueByKey("host").(string)
+	if !ok {
+		log.Warnf("failed to parse host from record: %v", record)
+	}
+
 	return definition.Event{
 		Type:        record.Measurement(),
 		Severity:    definition.SeverityFullName(severity),
 		Id:          eventId,
 		Description: msg,
-		Host:        "",
+		Host:        host,
 		Time:        definition.TimeLocalISO8601(date),
 	}
 }

--- a/internal/definition/v1/api-doc.go
+++ b/internal/definition/v1/api-doc.go
@@ -3,3 +3,7 @@ package v1
 const (
 	ApiDoc = "api-doc"
 )
+
+var (
+	V1ApiDocUrl = ""
+)

--- a/internal/definition/v1/datacenter.go
+++ b/internal/definition/v1/datacenter.go
@@ -15,7 +15,8 @@ type DataCenter struct {
 }
 
 type Additional struct {
-	HelpUrl string `json:"helpUrl,omitempty" bson:"helpUrl"`
+	HelpUrl     string `json:"helpUrl,omitempty" bson:"helpUrl"`
+	V1ApiDocUrl string `json:"v1ApiDoc,omitempty" bson:"v1ApiDoc"`
 }
 
 // M1 TODO: have to think about if we

--- a/internal/definition/v1/events.go
+++ b/internal/definition/v1/events.go
@@ -18,6 +18,13 @@ type Event struct {
 	Time        string                 `json:"time"`
 }
 
+type EventStat struct {
+	Id      string  `json:"id"`
+	Percent float64 `json:"percent"`
+	Number  int64   `json:"number"`
+	Query   string  `json:"query"`
+}
+
 func SeverityFullName(severity string) string {
 	switch strings.ToLower(severity) {
 	case "c":


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

<br/>

### Which issue(s) this PR fixes?

Major: #24 #49 

<br/>

### What this PR does?

Major: as discussed with team in the kickoff of event page,

- add a GET API to fetch event statistic (ranking)

- enrich the event listing API to support query by event id

- based on 2 items above to support cascade event query from the event statistic (hope can bring some convenience to FE for saving their effort to concat query url)

- add corresponding changes in the swagger doc

<br/>

📔 notice:

- originally, I was implementing this by fake data, but during playing some real data in our current system, I realized the aggregation speed of influxdb is quick fast than I imagined even for 90 days search with huge result.

- moreover, the largest time range that team made in M1 is only 14 days, so I still do real time calculation in the influxdb currently, rather than waiting for COS CQ/Flux Task (will check with team again)

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/95865984-5272-4283-8f75-b8ca98cdeaf4


<br>

2). make sure the mentioned apis can work properly


https://github.com/user-attachments/assets/a3346234-d3f6-45d7-b903-0311788267d6




 
