### PR TITLE
Add a GET API to fetch the selectable filter factors in a particular time range

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -721,6 +721,153 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/events/filterConditions": {
+            "get": {
+                "operationId": "getEventFilterConditions",
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Retrieve the event filter conditions",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00Z"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the event filter conditions successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetEventFilterConditionResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Event filter conditions",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "system": {
+                                                    "severities": [
+                                                        "Critical",
+                                                        "Info",
+                                                        "Warning"
+                                                    ],
+                                                    "categories": [
+                                                        "KSN",
+                                                        "NET",
+                                                        "SDN",
+                                                        "SRV"
+                                                    ]
+                                                },
+                                                "instance": {
+                                                    "ids": [
+                                                        "028952d3-c0ba-4494-96c0-2bf1bab407e5",
+                                                        "02ecd121-c19b-41c7-8ed7-390745b01af4",
+                                                        "12893f22-a353-4dce-a164-f889e0f39951",
+                                                        "fbd5d7c2-38c8-436b-97f4-d9e5b322d02b"
+                                                    ],
+                                                    "categories": [
+                                                        "CPU",
+                                                        "MEM"
+                                                    ]
+                                                },
+                                                "host": {
+                                                    "names": [
+                                                        "example-node-0"
+                                                    ],
+                                                    "categories": [
+                                                        "DSK",
+                                                        "MEM"
+                                                    ]
+                                                }
+                                            },
+                                            "msg": "fetch event filter conditions successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid 'start' time: 2021-09-01T111:00:00Z"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch event filter conditions: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/events/abstract": {
             "get": {
                 "operationId": "getAbstractedEvents",
@@ -1107,7 +1254,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "integer"
                         },
-                        "description": "The limit of the abstracted events to return (default is 10).",
+                        "description": "The limit of the rank of event to return (default is 10).",
                         "example": 10
                     },
                     {
@@ -1123,7 +1270,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Retrieve the abstracted events successfully",
+                        "description": "Retrieve the rank of event successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1131,7 +1278,7 @@ const docTemplate = `{
                                 },
                                 "examples": {
                                     "example1": {
-                                        "summary": "Abstracted recent events",
+                                        "summary": "Ranked events",
                                         "value": {
                                             "code": 200,
                                             "data": {
@@ -4627,6 +4774,99 @@ const docTemplate = `{
                                     },
                                     "description": {
                                         "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "GetEventFilterConditionResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "system",
+                            "instance",
+                            "host"
+                        ],
+                        "properties": {
+                            "system": {
+                                "type": "object",
+                                "required": [
+                                    "severities",
+                                    "categories"
+                                ],
+                                "properties": {
+                                    "severities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "instance": {
+                                "type": "object",
+                                "required": [
+                                    "ids",
+                                    "categories"
+                                ],
+                                "properties": {
+                                    "ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "host": {
+                                "type": "object",
+                                "required": [
+                                    "names",
+                                    "categories"
+                                ],
+                                "properties": {
+                                    "severities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }

--- a/api/docs.json
+++ b/api/docs.json
@@ -717,6 +717,153 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/events/filterConditions": {
+            "get": {
+                "operationId": "getEventFilterConditions",
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Retrieve the event filter conditions",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00Z"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00Z"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the event filter conditions successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetEventFilterConditionResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Event filter conditions",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "system": {
+                                                    "severities": [
+                                                        "Critical",
+                                                        "Info",
+                                                        "Warning"
+                                                    ],
+                                                    "categories": [
+                                                        "KSN",
+                                                        "NET",
+                                                        "SDN",
+                                                        "SRV"
+                                                    ]
+                                                },
+                                                "instance": {
+                                                    "ids": [
+                                                        "028952d3-c0ba-4494-96c0-2bf1bab407e5",
+                                                        "02ecd121-c19b-41c7-8ed7-390745b01af4",
+                                                        "12893f22-a353-4dce-a164-f889e0f39951",
+                                                        "fbd5d7c2-38c8-436b-97f4-d9e5b322d02b"
+                                                    ],
+                                                    "categories": [
+                                                        "CPU",
+                                                        "MEM"
+                                                    ]
+                                                },
+                                                "host": {
+                                                    "names": [
+                                                        "example-node-0"
+                                                    ],
+                                                    "categories": [
+                                                        "DSK",
+                                                        "MEM"
+                                                    ]
+                                                }
+                                            },
+                                            "msg": "fetch event filter conditions successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid 'start' time: 2021-09-01T111:00:00Z"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch event filter conditions: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/events/abstract": {
             "get": {
                 "operationId": "getAbstractedEvents",
@@ -1103,7 +1250,7 @@
                         "schema": {
                             "type": "integer"
                         },
-                        "description": "The limit of the abstracted events to return (default is 10).",
+                        "description": "The limit of the rank of event to return (default is 10).",
                         "example": 10
                     },
                     {
@@ -1119,7 +1266,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Retrieve the abstracted events successfully",
+                        "description": "Retrieve the rank of event successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1127,7 +1274,7 @@
                                 },
                                 "examples": {
                                     "example1": {
-                                        "summary": "Abstracted recent events",
+                                        "summary": "Ranked events",
                                         "value": {
                                             "code": 200,
                                             "data": {
@@ -4623,6 +4770,99 @@
                                     },
                                     "description": {
                                         "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "GetEventFilterConditionResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "system",
+                            "instance",
+                            "host"
+                        ],
+                        "properties": {
+                            "system": {
+                                "type": "object",
+                                "required": [
+                                    "severities",
+                                    "categories"
+                                ],
+                                "properties": {
+                                    "severities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "instance": {
+                                "type": "object",
+                                "required": [
+                                    "ids",
+                                    "categories"
+                                ],
+                                "properties": {
+                                    "ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "host": {
+                                "type": "object",
+                                "required": [
+                                    "names",
+                                    "categories"
+                                ],
+                                "properties": {
+                                    "severities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }

--- a/internal/api/v1/events/handlers.go
+++ b/internal/api/v1/events/handlers.go
@@ -28,6 +28,12 @@ var (
 			Path:    "/events/rank",
 			Func:    genEventRank,
 		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/events/filterConditions",
+			Func:    getEventFilterConditions,
+		},
 	}
 )
 
@@ -113,5 +119,27 @@ func genEventRank(c *gin.Context) {
 		c,
 		"fetch event rank successfully",
 		rank,
+	)
+}
+
+func getEventFilterConditions(c *gin.Context) {
+	h, err := initReqHelper(c, "getEventFilterConditions")
+	if err != nil {
+		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	conditions, err := h.genEventFilterConditions()
+	if err != nil {
+		log.Errorf("request(%s): failed to gen event filter conditions: %v", api.GetReqId(c), err)
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"fetch event filter conditions successfully",
+		conditions,
 	)
 }

--- a/internal/api/v1/events/helper.go
+++ b/internal/api/v1/events/helper.go
@@ -47,6 +47,8 @@ func initReqHelper(c *gin.Context, handler string) (*helper, error) {
 		return h.parseEventAbstractParams()
 	case "genEventRank":
 		return h.parseEventRankParams()
+	case "getEventFilterConditions":
+		return h.parseEventFilterConditions()
 	}
 
 	return nil, errors.New("no internal function supported")
@@ -122,6 +124,15 @@ func (h *helper) parseEventRankParams() (*helper, error) {
 	}
 
 	err = h.parseWatch()
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *helper) parseEventFilterConditions() (*helper, error) {
+	err := h.parsePeriod()
 	if err != nil {
 		return nil, err
 	}
@@ -222,6 +233,7 @@ func (h *helper) parseLimit() error {
 func (h *helper) parseRankFactors() error {
 	h.category = h.c.DefaultQuery("category", "")
 	h.severity = h.c.DefaultQuery("severity", "")
+	h.severity = definition.SeverityShortName(h.severity)
 	h.host = h.c.DefaultQuery("host", "")
 	h.instance = h.c.DefaultQuery("instance", "")
 	return nil
@@ -320,4 +332,69 @@ func (h *helper) genEventQuery(event definition.EventStat) string {
 		h.period.start,
 		h.period.stop,
 	)
+}
+
+func (h *helper) genEventFilterConditions() (*definition.EventFilter, error) {
+	systemCategories, err := cubecos.GetEventFilterConditions(h.genFilterConditionStmt("system", "category"))
+	if err != nil {
+		log.Errorf("request(%s): failed to get system categories: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	systemSeverities, err := cubecos.GetEventFilterConditions(h.genFilterConditionStmt("system", "severity"))
+	if err != nil {
+		log.Errorf("request(%s): failed to get system severities: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	hostCategories, err := cubecos.GetEventFilterConditions(h.genFilterConditionStmt("host", "category"))
+	if err != nil {
+		log.Errorf("request(%s): failed to get host categories: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	hostNames, err := cubecos.GetEventFilterConditions(h.genFilterConditionStmt("host", "host"))
+	if err != nil {
+		log.Errorf("request(%s): failed to get host names: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	instanceCategories, err := cubecos.GetEventFilterConditions(h.genFilterConditionStmt("instance", "category"))
+	if err != nil {
+		log.Errorf("request(%s): failed to get instance categories: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	instanceIds, err := cubecos.GetEventFilterConditions(h.genFilterConditionStmt("instance", "instance"))
+	if err != nil {
+		log.Errorf("request(%s): failed to get instances: %v", api.GetReqId(h.c), err)
+		return nil, err
+	}
+
+	return &definition.EventFilter{
+		System: definition.SystemFilter{
+			Categories: systemCategories,
+			Severities: convertSystemSeverities(systemSeverities),
+		},
+		Host: definition.HostFilter{
+			Categories: hostCategories,
+			Names:      hostNames,
+		},
+		Instance: definition.InstanceFilter{
+			Categories: instanceCategories,
+			Ids:        instanceIds,
+		},
+	}, nil
+}
+
+func convertSystemSeverities(severities []string) []string {
+	converted := []string{}
+	for _, s := range severities {
+		converted = append(
+			converted,
+			definition.SeverityFullName(s),
+		)
+	}
+
+	return converted
 }

--- a/internal/api/v1/events/stmt.go
+++ b/internal/api/v1/events/stmt.go
@@ -14,12 +14,12 @@ var (
 	`
 
 	eventIdCountQueryTemplate = `
-	from(bucket: "events")
-		|> range(start: %s, stop: %s)
-		|> filter(fn: (r) => r._measurement == "%s")
-		|> filter(fn: (r) => r.key == "%s")
-		|> count()
-`
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "%s")
+			|> filter(fn: (r) => r.key == "%s")
+			|> count()
+	`
 
 	eventNonPagingQueryTemplate = `
 		from(bucket: "events")
@@ -114,6 +114,15 @@ var (
 			|> group()
 			|> sort(columns: ["number"], desc: true)
 			|> limit(n: %d)
+	`
+
+	eventFilterConditionQueryTemplate = `
+		from(bucket: "events")
+			|> range(start: %s, stop: %s)
+			|> filter(fn: (r) => r._measurement == "%s")
+			|> keep(columns: ["%s"])
+			|> group()                    
+			|> distinct(column: "%s")
 	`
 )
 
@@ -238,5 +247,16 @@ func (h *helper) genInstanceRankStmt() string {
 		h.category,
 		h.instance,
 		h.limit,
+	)
+}
+
+func (h *helper) genFilterConditionStmt(eventType, column string) string {
+	return fmt.Sprintf(
+		eventFilterConditionQueryTemplate,
+		h.period.start,
+		h.period.stop,
+		eventType,
+		column,
+		column,
 	)
 }

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -105,6 +105,42 @@ func GetEventRank(stmt string) ([]definition.EventStat, error) {
 	return events, nil
 }
 
+func GetEventFilterConditions(stmt string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(60))
+	defer cancel()
+
+	h := influx.GetGlobalHelper()
+	c, err := h.QueryApiClient.Query(ctx, stmt)
+	if err != nil {
+		log.Errorf("failed to get cursor of event filter condition: %v", err)
+		return nil, err
+	}
+
+	defer c.Close()
+	values := []string{}
+	err = parseEventValues(c, &values)
+	if err != nil {
+		log.Errorf("failed to parse filter condition from cursor: %v", err)
+		return nil, err
+	}
+
+	return values, nil
+}
+
+func parseEventValues(c *api.QueryTableResult, values *[]string) error {
+	for c.Next() {
+		*values = append(
+			*values,
+			c.Record().Value().(string),
+		)
+	}
+	if c.Err() != nil {
+		return c.Err()
+	}
+
+	return nil
+}
+
 func setPercentageToEachEvent(events *[]definition.EventStat) {
 	total := int64(0)
 	for _, event := range *events {

--- a/internal/definition/v1/events.go
+++ b/internal/definition/v1/events.go
@@ -25,6 +25,27 @@ type EventStat struct {
 	Query   string  `json:"query"`
 }
 
+type EventFilter struct {
+	System   SystemFilter   `json:"system"`
+	Instance InstanceFilter `json:"instance"`
+	Host     HostFilter     `json:"host"`
+}
+
+type SystemFilter struct {
+	Severities []string `json:"severities"`
+	Categories []string `json:"categories"`
+}
+
+type InstanceFilter struct {
+	Ids        []string `json:"ids"`
+	Categories []string `json:"categories"`
+}
+
+type HostFilter struct {
+	Names      []string `json:"names"`
+	Categories []string `json:"categories"`
+}
+
 func SeverityFullName(severity string) string {
 	switch strings.ToLower(severity) {
 	case "c":
@@ -35,5 +56,18 @@ func SeverityFullName(severity string) string {
 		return "Info"
 	}
 
-	return "Unknown"
+	return severity
+}
+
+func SeverityShortName(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "C"
+	case "warning":
+		return "W"
+	case "info":
+		return "I"
+	}
+
+	return severity
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -20,6 +20,7 @@ func NewOk() *Details {
 	return &Details{Current: Ok}
 }
 
+// Might need to separate the Details for Tuning and Health.
 type Details struct {
 	Current string `json:"current,omitempty" bson:"current"`
 	Desired string `json:"desired,omitempty" bson:"desired"`
@@ -27,8 +28,9 @@ type Details struct {
 	CreatedAt          string `json:"createdAt,omitempty" bson:"createdAt"`
 	UpdatedAt          string `json:"updatedAt,omitempty" bson:"updatedAt"`
 	MaxPendingDuration int    `json:"maxPendingDuration,omitempty" bson:"maxPendingDuration"`
+	IsFixing           bool   `json:"isFixing" bson:"isFixing"`
 
-	Description string `json:"description,omitempty" bson:"description"`
+	Description string `json:"descriptions" bson:"description"`
 }
 
 func (s *Details) ClearDesired() {


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

Major: #49 

<br/>

### What this PR does?

Major:

- add a GET API to fetch the selectable filter factors for event within a particular time range

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

<img width="1572" alt="Screenshot 2025-02-18 at 2 26 44 AM" src="https://github.com/user-attachments/assets/02768601-fc88-4907-b346-e65478263896" />

<img width="1574" alt="Screenshot 2025-02-18 at 2 22 51 AM" src="https://github.com/user-attachments/assets/d24e1543-108a-435f-ae99-e14516c484cc" />

<img width="1572" alt="Screenshot 2025-02-18 at 2 23 02 AM" src="https://github.com/user-attachments/assets/1d1d0156-5d51-4f40-b2c8-0aff198ee693" />

<img width="1571" alt="Screenshot 2025-02-18 at 2 23 11 AM" src="https://github.com/user-attachments/assets/6ae2708b-e50b-4b95-b763-04e9ed74cafa" />

<br>

2). make sure the mentioned apis can work properly

<img width="1723" alt="Screenshot 2025-02-18 at 2 23 27 AM" src="https://github.com/user-attachments/assets/9c034337-8b7d-45c2-b923-d16fa103353d" />

<img width="1721" alt="Screenshot 2025-02-18 at 2 23 38 AM" src="https://github.com/user-attachments/assets/5a74f9c5-0676-4fb2-91ed-1a1486891d6c" />

 
