### PR TITLE
2nd iteration for Tuning listing API

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1256,7 +1256,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "description": "The host of the event to query.",
-                        "example": "dell180"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -1447,8 +1447,7 @@ const docTemplate = `{
                                                 "overall": {
                                                     "status": {
                                                         "current": "ok",
-                                                        "isFixing": false,
-                                                        "description": "ceph has 2 ceph_osd down, reason unknown"
+                                                        "isFixing": false
                                                     }
                                                 },
                                                 "services": [
@@ -1481,6 +1480,7 @@ const docTemplate = `{
                                                 "overall": {
                                                     "status": {
                                                         "current": "ng",
+                                                        "isFixing": false,
                                                         "description": "ceph has 2 ceph_osd down"
                                                     }
                                                 },
@@ -1719,11 +1719,11 @@ const docTemplate = `{
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1749,11 +1749,11 @@ const docTemplate = `{
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1779,11 +1779,11 @@ const docTemplate = `{
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1808,11 +1808,11 @@ const docTemplate = `{
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1838,11 +1838,11 @@ const docTemplate = `{
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1868,11 +1868,11 @@ const docTemplate = `{
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1996,7 +1996,8 @@ const docTemplate = `{
                                 "dataPipe",
                                 "metrics",
                                 "logAnalytics",
-                                "notifications"                            ]
+                                "notifications"
+                            ]
                         },
                         "description": "The name of the service to retrieve health history. use GET /api/v1/datacenters/{dataCenter}/services to get the service list and their modules."
                     },
@@ -2131,7 +2132,7 @@ const docTemplate = `{
                                                             ],
                                                             "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                             "details": "{ ... best effort error summary / direction ...}",
-                                                            "log": "http://datacenter1:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                            "log": "http://datacenter1:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                         }
                                                     },
                                                     {
@@ -5336,6 +5337,225 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/tunings": {
+            "get": {
+                "operationId": "listTunings",
+                "tags": [
+                    "Tunings"
+                ],
+                "summary": "Retrieve the list of tunings from a host or data center",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageNum",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The page number of the tunings list",
+                        "example": 1
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The page size of the tunings list",
+                        "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "watch the tuning list continuously",
+                        "example": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the list of tunings from a host or data center successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListTuningResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Tuning list",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "tunings": [
+                                                    {
+                                                        "name": "neutron.debug.enabled",
+                                                        "value": false,
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set to true to enable neutron verbose log.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "bool",
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "cubesys.provider.extra",
+                                                        "value": "",
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set extra provider interfaces ('pvd-' prefix and <= 15 chars) [IF.2:pvd-xxx,eth2:pvd-yyy,...].",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "string",
+                                                            "default": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "barbican.debug.enabled",
+                                                        "value": false,
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set to true to enable barbican verbose log.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "bool",
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "cinder.backup.endpoint",
+                                                        "value": "",
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set cinder backup storage endpoint.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "string",
+                                                            "default": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "influxdb.curator.rp",
+                                                        "value": 7,
+                                                        "hosts": [
+                                                            "example-node-0",
+                                                            "example-node-1"
+                                                        ],
+                                                        "description": "influxdb curator retention policy in days.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "int",
+                                                            "default": 7,
+                                                            "min": 0,
+                                                            "max": 365
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "influxdb.curator.rp",
+                                                        "value": 23,
+                                                        "hosts": [
+                                                            "example-node-3"
+                                                        ],
+                                                        "description": "influxdb curator retention policy in days.",
+                                                        "enabled": false,
+                                                        "isModified": true,
+                                                        "limitation": {
+                                                            "type": "int",
+                                                            "default": 7,
+                                                            "min": 0,
+                                                            "max": 365
+                                                        }
+                                                    }
+                                                ],
+                                                "page": {
+                                                    "total": 15,
+                                                    "number": 1,
+                                                    "size": 5
+                                                }
+                                            },
+                                            "msg": "fetch tuning list successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to list tuning: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -5900,21 +6120,17 @@ const docTemplate = `{
                                         "type": "object",
                                         "required": [
                                             "current",
-                                            "isFixing",
-                                            "description"
+                                            "isFixing"
                                         ],
                                         "properties": {
                                             "current": {
-                                                "type": "string",
-                                                "example": "ng"
+                                                "type": "string"
                                             },
                                             "isFixing": {
-                                                "type": "boolean",
-                                                "example": false
+                                                "type": "boolean"
                                             },
                                             "description": {
-                                                "type": "string",
-                                                "example": "ceph has 2 ceph_osd down"
+                                                "type": "string"
                                             }
                                         }
                                     }
@@ -8731,6 +8947,111 @@ const docTemplate = `{
                     "msg": {
                         "type": "string",
                         "example": "slack webhook deleted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "ListTuningResponse": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name",
+                                "value",
+                                "hosts",
+                                "description",
+                                "enabled",
+                                "isModified",
+                                "limitation"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "hosts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "isModified": {
+                                    "type": "boolean"
+                                },
+                                "limitation": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "default",
+                                        "min",
+                                        "max"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "type": "string"
+                                        },
+                                        "default": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "min": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        },
+                                        "max": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "tuning list retrieved successfully"
                     },
                     "status": {
                         "type": "string",

--- a/api/docs.go
+++ b/api/docs.go
@@ -1446,7 +1446,9 @@ const docTemplate = `{
                                             "data": {
                                                 "overall": {
                                                     "status": {
-                                                        "current": "ok"
+                                                        "current": "ok",
+                                                        "isFixing": false,
+                                                        "description": "ceph has 2 ceph_osd down, reason unknown"
                                                     }
                                                 },
                                                 "services": [
@@ -5898,12 +5900,17 @@ const docTemplate = `{
                                         "type": "object",
                                         "required": [
                                             "current",
+                                            "isFixing",
                                             "description"
                                         ],
                                         "properties": {
                                             "current": {
                                                 "type": "string",
                                                 "example": "ng"
+                                            },
+                                            "isFixing": {
+                                                "type": "boolean",
+                                                "example": false
                                             },
                                             "description": {
                                                 "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -1252,7 +1252,7 @@
                             "type": "string"
                         },
                         "description": "The host of the event to query.",
-                        "example": "dell180"
+                        "example": "example-data-center"
                     },
                     {
                         "in": "query",
@@ -1715,11 +1715,11 @@
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1745,11 +1745,11 @@
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1775,11 +1775,11 @@
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1804,11 +1804,11 @@
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1834,11 +1834,11 @@
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1864,11 +1864,11 @@
                                                                 "type": "service down",
                                                                 "reason": "1 node down",
                                                                 "nodes": [
-                                                                    "dell180"
+                                                                    "example-data-center"
                                                                 ],
                                                                 "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                                 "details": "{ ... the best efforts of error summary / direction ...} ",
-                                                                "log": "http://{dataCenter}:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                                "log": "http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                             }
                                                         },
                                                         {
@@ -1992,7 +1992,8 @@
                                 "dataPipe",
                                 "metrics",
                                 "logAnalytics",
-                                "notifications"                            ]
+                                "notifications"
+                            ]
                         },
                         "description": "The name of the service to retrieve health history. use GET /api/v1/datacenters/{dataCenter}/services to get the service list and their modules."
                     },
@@ -2127,7 +2128,7 @@
                                                             ],
                                                             "description": "nova has 1 node down due to the memory exhausted, and the abnormal memory competition from PID(24887) is detected",
                                                             "details": "{ ... best effort error summary / direction ...}",
-                                                            "log": "http://datacenter1:8888/log/nova/dell180-20250205113459-b3gc.log"
+                                                            "log": "http://datacenter1:8888/log/nova/example-data-center-20250205113459-b3gc.log"
                                                         }
                                                     },
                                                     {
@@ -5320,6 +5321,225 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to create token: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/tunings": {
+            "get": {
+                "operationId": "listTunings",
+                "tags": [
+                    "Tunings"
+                ],
+                "summary": "Retrieve the list of tunings from a host or data center",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "dataCenter",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the data center to operate",
+                        "example": "example-data-center"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageNum",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The page number of the tunings list",
+                        "example": 1
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "The page size of the tunings list",
+                        "example": 10
+                    },
+                    {
+                        "in": "query",
+                        "name": "watch",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "watch the tuning list continuously",
+                        "example": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the list of tunings from a host or data center successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListTuningResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Tuning list",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "tunings": [
+                                                    {
+                                                        "name": "neutron.debug.enabled",
+                                                        "value": false,
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set to true to enable neutron verbose log.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "bool",
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "cubesys.provider.extra",
+                                                        "value": "",
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set extra provider interfaces ('pvd-' prefix and <= 15 chars) [IF.2:pvd-xxx,eth2:pvd-yyy,...].",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "string",
+                                                            "default": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "barbican.debug.enabled",
+                                                        "value": false,
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set to true to enable barbican verbose log.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "bool",
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "cinder.backup.endpoint",
+                                                        "value": "",
+                                                        "hosts": [
+                                                            "example-node-0"
+                                                        ],
+                                                        "description": "Set cinder backup storage endpoint.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "string",
+                                                            "default": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "influxdb.curator.rp",
+                                                        "value": 7,
+                                                        "hosts": [
+                                                            "example-node-0",
+                                                            "example-node-1"
+                                                        ],
+                                                        "description": "influxdb curator retention policy in days.",
+                                                        "enabled": true,
+                                                        "isModified": false,
+                                                        "limitation": {
+                                                            "type": "int",
+                                                            "default": 7,
+                                                            "min": 0,
+                                                            "max": 365
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "influxdb.curator.rp",
+                                                        "value": 23,
+                                                        "hosts": [
+                                                            "example-node-3"
+                                                        ],
+                                                        "description": "influxdb curator retention policy in days.",
+                                                        "enabled": false,
+                                                        "isModified": true,
+                                                        "limitation": {
+                                                            "type": "int",
+                                                            "default": 7,
+                                                            "min": 0,
+                                                            "max": 365
+                                                        }
+                                                    }
+                                                ],
+                                                "page": {
+                                                    "total": 15,
+                                                    "number": 1,
+                                                    "size": 5
+                                                }
+                                            },
+                                            "msg": "fetch tuning list successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to list tuning: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -8723,6 +8943,111 @@
                     "msg": {
                         "type": "string",
                         "example": "slack webhook deleted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "ListTuningResponse": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name",
+                                "value",
+                                "hosts",
+                                "description",
+                                "enabled",
+                                "isModified",
+                                "limitation"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "hosts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "isModified": {
+                                    "type": "boolean"
+                                },
+                                "limitation": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "default",
+                                        "min",
+                                        "max"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "type": "string"
+                                        },
+                                        "default": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "min": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        },
+                                        "max": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "tuning list retrieved successfully"
                     },
                     "status": {
                         "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -1442,7 +1442,8 @@
                                             "data": {
                                                 "overall": {
                                                     "status": {
-                                                        "current": "ok"
+                                                        "current": "ok",
+                                                        "isFixing": false
                                                     }
                                                 },
                                                 "services": [
@@ -1475,6 +1476,7 @@
                                                 "overall": {
                                                     "status": {
                                                         "current": "ng",
+                                                        "isFixing": false,
                                                         "description": "ceph has 2 ceph_osd down"
                                                     }
                                                 },
@@ -5894,16 +5896,17 @@
                                         "type": "object",
                                         "required": [
                                             "current",
-                                            "description"
+                                            "isFixing"
                                         ],
                                         "properties": {
                                             "current": {
-                                                "type": "string",
-                                                "example": "ng"
+                                                "type": "string"
+                                            },
+                                            "isFixing": {
+                                                "type": "boolean"
                                             },
                                             "description": {
-                                                "type": "string",
-                                                "example": "ceph has 2 ceph_osd down"
+                                                "type": "string"
                                             }
                                         }
                                     }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/coreos/go-oidc v2.3.0+incompatible
 	github.com/crewjam/saml v0.4.14
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-micro/plugins/v5/config/encoder/yaml v1.0.0
 	github.com/google/uuid v1.3.1
@@ -46,7 +47,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/crewjam/httperr v0.2.0 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.5 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250219160408-6821709333e1 h1:jeFxWJhDi9hB6IZ7JEhMlc8ko/yJZd013/p2hth7oZw=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250219160408-6821709333e1/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250219193912-ee94b7180d82 h1:YRNdI622fC49xgoaPmilGKPToT96IOfQ14jfNlhVuXQ=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250219193912-ee94b7180d82/go.mod h1:+ZNIuqsaaCjORQF8yZarHnH7o9N6gpLMorPrHgLzSFc=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
@@ -102,8 +100,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.5 h1:J7wGKdGu33ocBOhGy0z653k/lFKLFDPJMG8Gql0kxn4=
 github.com/gabriel-vasile/mimetype v1.4.5/go.mod h1:ibHel+/kbxn9x2407k1izTA1S81ku1z/DlgOW2QE0M4=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -599,7 +597,6 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/api/resp.go
+++ b/internal/api/resp.go
@@ -3,8 +3,16 @@ package api
 import (
 	"net/http"
 
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/gin-gonic/gin"
 )
+
+type TuningListData struct {
+	Code   int         `json:"code"`
+	Status string      `json:"status"`
+	Msg    string      `json:"msg"`
+	Data   []v1.Tuning `json:"data"`
+}
 
 func SetStatusOk(c *gin.Context, msg string, data interface{}) {
 	c.JSON(

--- a/internal/api/v1/nodes/helper.go
+++ b/internal/api/v1/nodes/helper.go
@@ -35,7 +35,7 @@ func initReqHelper(c *gin.Context) (*helper, error) {
 func (h *helper) parsePage() error {
 	num := h.c.DefaultQuery("pageNum", "")
 	size := h.c.DefaultQuery("pageSize", "")
-	if !h.Page.IsRequired() {
+	if !isPageReceived(num, size) {
 		return nil
 	}
 
@@ -104,4 +104,8 @@ func (h *helper) getNodesResp() (*data, error) {
 		Nodes: pagedNodes,
 		Page:  page,
 	}, nil
+}
+
+func isPageReceived(num, size string) bool {
+	return num != "" || size != ""
 }

--- a/internal/api/v1/tunings/handlers.go
+++ b/internal/api/v1/tunings/handlers.go
@@ -24,31 +24,31 @@ var (
 		{
 			Version: api.V1,
 			Method:  http.MethodGet,
-			Path:    "/tunings/specs",
+			Path:    "/tunings/parameters",
 			Func:    getTuningSpecs,
 		},
 		{
 			Version: api.V1,
-			Method:  http.MethodPut,
-			Path:    "/tunings/:ParameterName",
+			Method:  http.MethodPatch,
+			Path:    "/tunings/parameters/:parameterName",
 			Func:    applyTuning,
 		},
 		{
 			Version: api.V1,
-			Method:  http.MethodPut,
+			Method:  http.MethodPatch,
 			Path:    "/tunings",
 			Func:    applyTunings,
 		},
 		{
 			Version: api.V1,
-			Method:  http.MethodPut,
-			Path:    "/tunings/:ParameterName/status",
+			Method:  http.MethodPatch,
+			Path:    "/tunings/parameters/:parameterName/status",
 			Func:    updateTuningStatus,
 		},
 		{
 			Version: api.V1,
 			Method:  http.MethodDelete,
-			Path:    "/tuning/:ParameterName",
+			Path:    "/tuning/parameters/:parameterName",
 			Func:    deleteTuning,
 		},
 		{

--- a/internal/api/v1/tunings/handlers.go
+++ b/internal/api/v1/tunings/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/bigstack-oss/cube-cos-api/internal/operators/v1/tunings"
 	"github.com/gin-gonic/gin"
@@ -61,7 +62,7 @@ var (
 )
 
 func getTunings(c *gin.Context) {
-	tunings, err := getTuningRecords()
+	tunings, err := cubecos.ListNodeTunings(definition.ListTuningOptions{AllNodes: true})
 	if err != nil {
 		log.Errorf("request(%s): failed to get tunings: %s", api.GetReqId(c), err.Error())
 		api.SetInternalServerError(c, err)
@@ -77,7 +78,7 @@ func getTunings(c *gin.Context) {
 
 func getTuningSpecs(c *gin.Context) {
 	specs := []definition.TuningSpec{}
-	definition.GetAllTunings().Range(func(key, value interface{}) bool {
+	definition.GetTuningSpecs().Range(func(key, value interface{}) bool {
 		spec := deepcopy.Copy(value).(*definition.TuningSpec)
 		spec.Roles = selectRolesUsingActivityAndLabels(spec)
 		specs = append(specs, *spec)

--- a/internal/api/v1/tunings/handlers.go
+++ b/internal/api/v1/tunings/handlers.go
@@ -62,7 +62,7 @@ var (
 )
 
 func getTunings(c *gin.Context) {
-	tunings, err := cubecos.ListNodeTunings(definition.ListTuningOptions{AllNodes: true})
+	tunings, err := cubecos.ListTunings(definition.ListTuningOptions{AllNodes: true})
 	if err != nil {
 		log.Errorf("request(%s): failed to get tunings: %s", api.GetReqId(c), err.Error())
 		api.SetInternalServerError(c, err)
@@ -71,7 +71,7 @@ func getTunings(c *gin.Context) {
 
 	api.SetStatusOk(
 		c,
-		"fetch tunings list successfully",
+		"fetch tuning list successfully",
 		tunings,
 	)
 }

--- a/internal/api/v1/tunings/handlers.go
+++ b/internal/api/v1/tunings/handlers.go
@@ -60,6 +60,10 @@ var (
 	}
 )
 
+func init() {
+	go streamTunings()
+}
+
 func getTunings(c *gin.Context) {
 	h, err := initReqHelper(c, "getTunings")
 	if err != nil {
@@ -72,6 +76,11 @@ func getTunings(c *gin.Context) {
 	if err != nil {
 		log.Errorf("request(%s): failed to get tunings: %s", api.GetReqId(c), err.Error())
 		api.SetInternalServerError(c, err)
+		return
+	}
+
+	if h.watch {
+		watchTunings(h, tunings)
 		return
 	}
 

--- a/internal/api/v1/tunings/handlers.go
+++ b/internal/api/v1/tunings/handlers.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
-	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/bigstack-oss/cube-cos-api/internal/operators/v1/tunings"
 	"github.com/gin-gonic/gin"
@@ -62,7 +61,14 @@ var (
 )
 
 func getTunings(c *gin.Context) {
-	tunings, err := cubecos.ListTunings(definition.ListTuningOptions{AllNodes: true})
+	h, err := initReqHelper(c, "getTunings")
+	if err != nil {
+		log.Errorf("request(%s): failed to init request helper: %s", api.GetReqId(c), err.Error())
+		api.SetBadRequest(c, err)
+		return
+	}
+
+	tunings, err := h.ListTunings()
 	if err != nil {
 		log.Errorf("request(%s): failed to get tunings: %s", api.GetReqId(c), err.Error())
 		api.SetInternalServerError(c, err)

--- a/internal/api/v1/tunings/helper.go
+++ b/internal/api/v1/tunings/helper.go
@@ -1,0 +1,147 @@
+package tunings
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
+)
+
+type helper struct {
+	c       *gin.Context
+	handler string
+
+	allNodes bool
+	definition.Page
+
+	watch bool
+}
+
+func initReqHelper(c *gin.Context, handler string) (*helper, error) {
+	h := &helper{c: c, handler: handler}
+	err := h.parsePage()
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.parseScope()
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *helper) parseScope() error {
+	h.allNodes = h.c.DefaultQuery("allNodes", "false") == "true"
+	return nil
+}
+
+func (h *helper) parsePage() error {
+	num := h.c.DefaultQuery("pageNum", "")
+	size := h.c.DefaultQuery("pageSize", "")
+	if !isPageReceived(num, size) {
+		return nil
+	}
+
+	if num == "" {
+		return fmt.Errorf("pageNum should be provided if pageSize is provided")
+	}
+
+	if size == "" {
+		return fmt.Errorf("pageSize should be provided if pageNum is provided")
+	}
+
+	var err error
+	h.Page.Number, err = strconv.Atoi(num)
+	if err != nil {
+		return fmt.Errorf("pageNum should be an integer: %s", num)
+	}
+
+	h.Page.Size, err = strconv.Atoi(size)
+	if err != nil {
+		return fmt.Errorf("pageSize should be an integer: %s", size)
+	}
+
+	if h.Page.Number <= 0 {
+		return fmt.Errorf("pageNum should be greater than 0 if pageSize is provided")
+	}
+
+	if h.Page.Size <= 0 {
+		return fmt.Errorf("pageSize should be greater than 0 if pageNum is provided")
+	}
+
+	return nil
+}
+
+func (h *helper) ListTunings() (*data, error) {
+	tunings, err := cubecos.ListTunings(v1.ListTuningOptions{AllNodes: h.allNodes})
+	if err != nil {
+		log.Errorf("request(%s): failed to get tunings: %s", api.GetReqId(h.c), err.Error())
+		api.SetInternalServerError(h.c, err)
+		return nil, err
+	}
+
+	pagedTunings, err := h.paginateTunings(tunings)
+	if err != nil {
+		log.Errorf("request(%s): failed to paginate tunings: %s", api.GetReqId(h.c), err.Error())
+		api.SetInternalServerError(h.c, err)
+		return nil, err
+	}
+
+	page, err := h.genPageInfo(tunings)
+	if err != nil {
+		log.Errorf("request(%s): failed to gen page info: %s", api.GetReqId(h.c), err.Error())
+		api.SetInternalServerError(h.c, err)
+		return nil, err
+	}
+
+	return &data{
+		Tunings: pagedTunings,
+		Page:    page,
+	}, nil
+}
+
+func (h *helper) paginateTunings(tunings []v1.Tuning) ([]v1.Tuning, error) {
+	if !h.Page.IsRequired() {
+		return tunings, nil
+	}
+
+	left := (h.Page.Number - 1) * h.Page.Size
+	if left > len(tunings) {
+		left = len(tunings)
+	}
+
+	right := left + h.Page.Size
+	if right > len(tunings) {
+		right = len(tunings)
+	}
+
+	return tunings[left:right], nil
+}
+
+func (h *helper) genPageInfo(tunings []v1.Tuning) (definition.Page, error) {
+	if !h.Page.IsRequired() {
+		return definition.Page{
+			Total:  1,
+			Number: 1,
+			Size:   len(tunings),
+		}, nil
+	}
+
+	return definition.Page{
+		Total:  int64(math.Ceil(float64(len(tunings)) / float64(h.Page.Size))),
+		Number: h.Page.Number,
+		Size:   h.Page.Size,
+	}, nil
+}
+
+func isPageReceived(num, size string) bool {
+	return num != "" || size != ""
+}

--- a/internal/api/v1/tunings/helper.go
+++ b/internal/api/v1/tunings/helper.go
@@ -35,10 +35,6 @@ func initReqHelper(c *gin.Context, handler string) (*helper, error) {
 	return h, nil
 }
 
-func (h *helper) parseScope() {
-	h.allNodes = h.c.DefaultQuery("allNodes", "false") == "true"
-}
-
 func (h *helper) parsePage() error {
 	num := h.c.DefaultQuery("pageNum", "")
 	size := h.c.DefaultQuery("pageSize", "")
@@ -74,6 +70,10 @@ func (h *helper) parsePage() error {
 	}
 
 	return nil
+}
+
+func (h *helper) parseScope() {
+	h.allNodes = h.c.DefaultQuery("allNodes", "false") == "true"
 }
 
 func (h *helper) parseWatch() {

--- a/internal/api/v1/tunings/helper.go
+++ b/internal/api/v1/tunings/helper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
-	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
 )
@@ -30,17 +29,14 @@ func initReqHelper(c *gin.Context, handler string) (*helper, error) {
 		return nil, err
 	}
 
-	err = h.parseScope()
-	if err != nil {
-		return nil, err
-	}
+	h.parseScope()
+	h.parseWatch()
 
 	return h, nil
 }
 
-func (h *helper) parseScope() error {
+func (h *helper) parseScope() {
 	h.allNodes = h.c.DefaultQuery("allNodes", "false") == "true"
-	return nil
 }
 
 func (h *helper) parsePage() error {
@@ -80,8 +76,12 @@ func (h *helper) parsePage() error {
 	return nil
 }
 
+func (h *helper) parseWatch() {
+	h.watch = h.c.DefaultQuery("watch", "false") == "true"
+}
+
 func (h *helper) ListTunings() (*data, error) {
-	tunings, err := cubecos.ListTunings(v1.ListTuningOptions{AllNodes: h.allNodes})
+	tunings, err := cubecos.ListTunings(definition.ListTuningOptions{AllNodes: h.allNodes})
 	if err != nil {
 		log.Errorf("request(%s): failed to get tunings: %s", api.GetReqId(h.c), err.Error())
 		api.SetInternalServerError(h.c, err)
@@ -108,7 +108,7 @@ func (h *helper) ListTunings() (*data, error) {
 	}, nil
 }
 
-func (h *helper) paginateTunings(tunings []v1.Tuning) ([]v1.Tuning, error) {
+func (h *helper) paginateTunings(tunings []definition.Tuning) ([]definition.Tuning, error) {
 	if !h.Page.IsRequired() {
 		return tunings, nil
 	}
@@ -126,7 +126,7 @@ func (h *helper) paginateTunings(tunings []v1.Tuning) ([]v1.Tuning, error) {
 	return tunings[left:right], nil
 }
 
-func (h *helper) genPageInfo(tunings []v1.Tuning) (definition.Page, error) {
+func (h *helper) genPageInfo(tunings []definition.Tuning) (definition.Page, error) {
 	if !h.Page.IsRequired() {
 		return definition.Page{
 			Total:  1,

--- a/internal/api/v1/tunings/record.go
+++ b/internal/api/v1/tunings/record.go
@@ -2,9 +2,9 @@ package tunings
 
 import (
 	"context"
-	"time"
 
 	cubeMongo "github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	log "go-micro.dev/v5/logger"
 	"go.mongodb.org/mongo-driver/bson"
@@ -28,7 +28,7 @@ func getTuningRecords() ([]definition.Tuning, error) {
 		}
 
 		appendTuningRecords(cursor, &tunings)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
 		cursor.Close(ctx)
 		cancel()
 	}
@@ -37,9 +37,13 @@ func getTuningRecords() ([]definition.Tuning, error) {
 }
 
 func appendTuningRecords(cursor *mongo.Cursor, tunings *[]definition.Tuning) {
-	for cursor.Next(context.Background()) {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
+	defer cancel()
+
+	for cursor.Next(ctx) {
 		tuning := definition.Tuning{}
-		if err := cursor.Decode(&tuning); err != nil {
+		err := cursor.Decode(&tuning)
+		if err != nil {
 			log.Errorf("failed to decode tuning record (%s)", err.Error())
 			continue
 		}

--- a/internal/api/v1/tunings/resp.go
+++ b/internal/api/v1/tunings/resp.go
@@ -1,0 +1,8 @@
+package tunings
+
+import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+
+type data struct {
+	Tunings         []definition.Tuning `json:"tunings"`
+	definition.Page `json:"page"`
+}

--- a/internal/api/v1/tunings/watch.go
+++ b/internal/api/v1/tunings/watch.go
@@ -1,0 +1,138 @@
+package tunings
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/gin-gonic/gin"
+)
+
+type dataChan chan data
+
+type watcher struct {
+	helper
+	dataChan
+}
+
+var (
+	stream = struct {
+		sync.Mutex
+		Watchers []watcher
+	}{}
+)
+
+func streamTunings() {
+	for {
+		wait.Seconds(2)
+		if len(stream.Watchers) == 0 {
+			continue
+		}
+
+		stream.Lock()
+		for _, w := range stream.Watchers {
+			resp, err := streamTuningsByHandlerType(&w.helper)
+			if err != nil {
+				continue
+			}
+
+			select {
+			case w.dataChan <- *resp:
+			default:
+			}
+		}
+
+		stream.Unlock()
+	}
+}
+
+func streamTuningsByHandlerType(h *helper) (*data, error) {
+	switch h.handler {
+	case "getTunings":
+		return h.ListTunings()
+	}
+
+	return nil, errors.New("no internal function supported")
+}
+
+func watchTunings(h *helper, data *data) {
+	setChunkedTransfer(h.c)
+	flusher, ok := h.c.Writer.(http.Flusher)
+	if !ok {
+		api.SetBadRequest(h.c, errors.New("http chunked transfer is not supported"))
+		return
+	}
+
+	watcher := watcher{helper: *h, dataChan: make(dataChan)}
+	addWatcher(watcher)
+	defer removeWatcher(watcher)
+
+	sendFirstTuning(h.c, flusher, data)
+	streamingTuning(h.c, flusher, watcher)
+}
+
+func setChunkedTransfer(c *gin.Context) {
+	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	c.Writer.Header().Set("Transfer-Encoding", "chunked")
+}
+
+func addWatcher(w watcher) {
+	stream.Lock()
+	stream.Watchers = append(stream.Watchers, w)
+	stream.Unlock()
+}
+
+func removeWatcher(watcherToRemove watcher) {
+	stream.Lock()
+	defer stream.Unlock()
+
+	for i, watcher := range stream.Watchers {
+		if watcher != watcherToRemove {
+			continue
+		}
+
+		stream.Watchers = append(
+			stream.Watchers[:i],
+			stream.Watchers[i+1:]...,
+		)
+		return
+	}
+}
+
+func sendFirstTuning(c *gin.Context, flusher http.Flusher, data *data) {
+	c.Writer.Write(streamingResp(data))
+	c.Writer.Write([]byte("\n"))
+	flusher.Flush()
+}
+
+func streamingTuning(c *gin.Context, flusher http.Flusher, watcher watcher) {
+	ctx := c.Request.Context()
+	for {
+		select {
+		case data := <-watcher.dataChan:
+			c.Writer.Write(streamingResp(&data))
+			c.Writer.Write([]byte("\n"))
+			flusher.Flush()
+		case <-ctx.Done():
+			api.SetStatusOk(c, "tuning watching is stopped successfully", nil)
+			return
+		}
+	}
+}
+
+func streamingResp(data *data) []byte {
+	b, err := json.Marshal(gin.H{
+		"code":   http.StatusOK,
+		"status": "ok",
+		"msg":    "fetch tuning successfully",
+		"data":   *data,
+	})
+	if err != nil {
+		return []byte{}
+	}
+
+	return b
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ func init() {
 	flag.IntVar(&Opts.Spec.Listen.Port, "listen.port", Opts.Spec.Listen.Port, "")
 	flag.StringVar(&Opts.Spec.Identity.Os.Policy, "identity.os.policy", Opts.Spec.Identity.Os.Policy, "")
 	flag.StringVar(&Opts.Spec.Identity.Os.System, "identity.os.system", Opts.Spec.Identity.Os.System, "")
+	flag.StringVar(&Opts.Spec.Identity.Os.Hostname, "identity.os.hostname", Opts.Spec.Identity.Os.Hostname, "")
 	flag.StringVar(&Opts.Spec.Identity.LogoutRedirect, "identity.logoutRedirect", Opts.Spec.Identity.LogoutRedirect, "")
 	flag.StringVar(&Opts.Spec.Identity.Keycloak.Host, "identity.keycloak.host", Opts.Spec.Identity.Keycloak.Host, "")
 	flag.StringVar(&Opts.Spec.Identity.Keycloak.Realm, "identity.keycloak.realm", Opts.Spec.Identity.Keycloak.Realm, "")
@@ -106,8 +107,9 @@ type Identity struct {
 }
 
 type Os struct {
-	Policy string `json:"policy" yaml:"policy"`
-	System string `json:"system" yaml:"system"`
+	Policy   string `json:"policy" yaml:"policy"`
+	System   string `json:"system" yaml:"system"`
+	Hostname string `json:"hostname" yaml:"hostname"`
 }
 
 type ResourceControl struct {

--- a/internal/cubecos/cluster.go
+++ b/internal/cubecos/cluster.go
@@ -10,7 +10,7 @@ import (
 )
 
 func IsHaEnabled() (bool, error) {
-	strIsHaEnabled, err := ReadTuning(CubeSysHa)
+	strIsHaEnabled, err := GetTuningValue(CubeSysHa)
 	if err != nil {
 		return false, err
 	}
@@ -42,7 +42,7 @@ func GetDataCenterName() (string, error) {
 		return os.Hostname()
 	}
 
-	return ReadTuning(CubeSysController)
+	return GetTuningValue(CubeSysController)
 }
 
 func GetDataCenterVersion() (string, error) {

--- a/internal/cubecos/cluster.go
+++ b/internal/cubecos/cluster.go
@@ -10,7 +10,7 @@ import (
 )
 
 func IsHaEnabled() (bool, error) {
-	strIsHaEnabled, err := ReadHexTuning(CubeSysHa)
+	strIsHaEnabled, err := ReadTuning(CubeSysHa)
 	if err != nil {
 		return false, err
 	}
@@ -42,7 +42,7 @@ func GetDataCenterName() (string, error) {
 		return os.Hostname()
 	}
 
-	return ReadHexTuning(CubeSysController)
+	return ReadTuning(CubeSysController)
 }
 
 func GetDataCenterVersion() (string, error) {

--- a/internal/cubecos/net.go
+++ b/internal/cubecos/net.go
@@ -10,7 +10,7 @@ const ()
 
 func GetControllerVirtualIp(mgmtNet string) (string, error) {
 	if definition.IsHaEnabled {
-		return ReadTuning(CubeSysControllerVip)
+		return GetTuningValue(CubeSysControllerVip)
 	}
 
 	if mgmtNet == "" {
@@ -18,11 +18,11 @@ func GetControllerVirtualIp(mgmtNet string) (string, error) {
 	}
 
 	netIfAddrMgmtIp := fmt.Sprintf("%s%s", CubeNetIfAddrPrefix, mgmtNet)
-	return ReadTuning(netIfAddrMgmtIp)
+	return GetTuningValue(netIfAddrMgmtIp)
 }
 
 func GetMgmtNet() (string, error) {
-	return ReadTuning(CubeSysManagementNetwork)
+	return GetTuningValue(CubeSysManagementNetwork)
 }
 
 func GetManagementIp(mgmtNet string) (string, error) {
@@ -31,5 +31,5 @@ func GetManagementIp(mgmtNet string) (string, error) {
 	}
 
 	netIfAddrMgmtIp := fmt.Sprintf("%s%s", CubeNetIfAddrPrefix, mgmtNet)
-	return ReadTuning(netIfAddrMgmtIp)
+	return GetTuningValue(netIfAddrMgmtIp)
 }

--- a/internal/cubecos/net.go
+++ b/internal/cubecos/net.go
@@ -10,7 +10,7 @@ const ()
 
 func GetControllerVirtualIp(mgmtNet string) (string, error) {
 	if definition.IsHaEnabled {
-		return ReadHexTuning(CubeSysControllerVip)
+		return ReadTuning(CubeSysControllerVip)
 	}
 
 	if mgmtNet == "" {
@@ -18,11 +18,11 @@ func GetControllerVirtualIp(mgmtNet string) (string, error) {
 	}
 
 	netIfAddrMgmtIp := fmt.Sprintf("%s%s", CubeNetIfAddrPrefix, mgmtNet)
-	return ReadHexTuning(netIfAddrMgmtIp)
+	return ReadTuning(netIfAddrMgmtIp)
 }
 
 func GetMgmtNet() (string, error) {
-	return ReadHexTuning(CubeSysManagementNetwork)
+	return ReadTuning(CubeSysManagementNetwork)
 }
 
 func GetManagementIp(mgmtNet string) (string, error) {
@@ -31,5 +31,5 @@ func GetManagementIp(mgmtNet string) (string, error) {
 	}
 
 	netIfAddrMgmtIp := fmt.Sprintf("%s%s", CubeNetIfAddrPrefix, mgmtNet)
-	return ReadHexTuning(netIfAddrMgmtIp)
+	return ReadTuning(netIfAddrMgmtIp)
 }

--- a/internal/cubecos/role.go
+++ b/internal/cubecos/role.go
@@ -15,7 +15,7 @@ const (
 )
 
 func GetNodeRole() (string, error) {
-	role, err := ReadHexTuning(cubeSysRole)
+	role, err := ReadTuning(cubeSysRole)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cubecos/role.go
+++ b/internal/cubecos/role.go
@@ -15,7 +15,7 @@ const (
 )
 
 func GetNodeRole() (string, error) {
-	role, err := ReadTuning(cubeSysRole)
+	role, err := GetTuningValue(cubeSysRole)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	policyFile = "/etc/policies/tuning/tuning1_0.yml"
+	TuningPolicyFile = "/etc/policies/tuning/tuning1_0.yml"
 
 	// private tunings
 	CubeSysHa                = "cubesys.ha"
@@ -880,7 +880,7 @@ func init() {
 	definition.SetSpecToTuning(WatcherDebugEnabled, WatcherDebugEnabledSpec)
 }
 
-func ReadHexTuning(parameterName string) (string, error) {
+func ReadTuning(parameterName string) (string, error) {
 	b, err := exec.Command("hex_tuning_helper", "/etc/settings.txt", "", parameterName).Output()
 	if err != nil {
 		log.Errorf("failed to read hex tunning value: %s", err.Error())
@@ -895,7 +895,7 @@ func ReadHexTuning(parameterName string) (string, error) {
 	return keyValue[1], nil
 }
 
-func ApplyHexTuning(isolatedDir string) error {
+func ApplyTuning(isolatedDir string) error {
 	out, err := exec.Command("hex_config", "apply", isolatedDir).CombinedOutput()
 	if err != nil {
 		log.Errorf("failed to apply hex tunning value: %s", string(out))
@@ -905,8 +905,8 @@ func ApplyHexTuning(isolatedDir string) error {
 	return nil
 }
 
-func IsHexTuningApplied(tuning definition.Tuning) error {
-	value, err := ReadHexTuning(tuning.Name)
+func IsTuningApplied(tuning definition.Tuning) error {
+	value, err := ReadTuning(tuning.Name)
 	if err != nil {
 		return err
 	}
@@ -918,7 +918,7 @@ func IsHexTuningApplied(tuning definition.Tuning) error {
 	return nil
 }
 
-func ApplyHexTunings(tunings []definition.Tuning) error {
+func ApplyTunings(tunings []definition.Tuning) error {
 	newTunings, err := genTuningsAsYaml(tunings)
 	if err != nil {
 		return err
@@ -930,7 +930,7 @@ func ApplyHexTunings(tunings []definition.Tuning) error {
 		return err
 	}
 
-	err = ApplyHexTuning(tmpTuningDir)
+	err = ApplyTuning(tmpTuningDir)
 	if err != nil {
 		return err
 	}
@@ -970,7 +970,6 @@ func writeTuningToFile(tmpDir string, yml []byte) error {
 	}
 
 	defer file.Close()
-
 	_, err = io.Writer.Write(file, yml)
 	if err != nil {
 		log.Errorf("failed to write tuning info to isolated file: %s", err.Error())
@@ -993,8 +992,8 @@ func ReleaseTuningLock() error {
 	return nil
 }
 
-func GetPolicy() (*definition.Policy, error) {
-	b, err := os.ReadFile(policyFile)
+func GetPolicy(filePath string) (*definition.Policy, error) {
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -1008,15 +1007,17 @@ func GetPolicy() (*definition.Policy, error) {
 	return policy, nil
 }
 
-func IsHexTuningDeleted(tuning definition.Tuning) error {
-	_, err := ReadHexTuning(tuning.Name)
+func IsTuningDeleted(tuning definition.Tuning) bool {
+	_, err := ReadTuning(tuning.Name)
 	if err == nil {
-		return fmt.Errorf("tuning value is not deleted: %s", tuning.Name)
+		log.Errorf("tuning value is not deleted: %s", tuning.Name)
+		return false
 	}
 
 	if !errors.Is(err, cuberr.TuningParamNotFound) {
-		return fmt.Errorf("failed to check if tuning is deleted: %s", err.Error())
+		log.Errorf("failed to check if tuning is deleted: %s", err.Error())
+		return false
 	}
 
-	return nil
+	return true
 }

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -110,7 +110,7 @@ var (
 	BarbicanDebugEnabledSpec = &definition.TuningSpec{
 		Name:        BarbicanDebugEnabled,
 		Description: "Set to true to enable barbican verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -119,7 +119,7 @@ var (
 	CephDebugEnabledSpec = &definition.TuningSpec{
 		Name:        CephDebugEnabled,
 		Description: "Set to true to enable ceph debug logs.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -128,7 +128,7 @@ var (
 	CephMirrorMetaSyncSpec = &definition.TuningSpec{
 		Name:        CephMirrorMetaSync,
 		Description: "Set to true to enable automatically volume metadata sync.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: true,
 		},
@@ -137,7 +137,7 @@ var (
 	CinderBackupAccountSpec = &definition.TuningSpec{
 		Name:        CinderBackupAccount,
 		Description: "Set cinder backup storage account.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -146,7 +146,7 @@ var (
 	CinderBackupEndpointSpec = &definition.TuningSpec{
 		Name:        CinderBackupEndpoint,
 		Description: "Set cinder backup storage endpoint.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -155,7 +155,7 @@ var (
 	CinderBackupOverrideSpec = &definition.TuningSpec{
 		Name:        CinderBackupOverride,
 		Description: "Enable override cinder backup configurations.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -164,7 +164,7 @@ var (
 	CinderBackupPoolSpec = &definition.TuningSpec{
 		Name:        CinderBackupPool,
 		Description: "Set cinder backup storage pool.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -173,7 +173,7 @@ var (
 	CinderBackupSecretSpec = &definition.TuningSpec{
 		Name:        CinderBackupSecret,
 		Description: "Set cinder backup storage account secret.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -182,7 +182,7 @@ var (
 	CinderBackupTypeSpec = &definition.TuningSpec{
 		Name:        CinderBackupType,
 		Description: "Set cinder backup storage type <cube-storage|cube-swift>.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -191,7 +191,7 @@ var (
 	CinderDebugEnabledSpec = &definition.TuningSpec{
 		Name:        CinderDebugEnabled,
 		Description: "Set to true to enable cinder verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -200,7 +200,7 @@ var (
 	CinderExternalAccountSpec = &definition.TuningSpec{
 		Name:        CinderExternalAccount,
 		Description: "Set cinder external storage account.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -209,7 +209,7 @@ var (
 	CinderExternalDriverSpec = &definition.TuningSpec{
 		Name:        CinderExternalDriver,
 		Description: "Set cinder external storage type name <cube|purestorage>.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -218,7 +218,7 @@ var (
 	CinderExternalEndpointSpec = &definition.TuningSpec{
 		Name:        CinderExternalEndpoint,
 		Description: "Set cinder external storage endpoint.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -227,7 +227,7 @@ var (
 	CinderExternalNameSpec = &definition.TuningSpec{
 		Name:        CinderExternalName,
 		Description: "Set cinder external storage rule name.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -236,7 +236,7 @@ var (
 	CinderExternalPoolSpec = &definition.TuningSpec{
 		Name:        CinderExternalPool,
 		Description: "Set cinder external storage pool.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -245,7 +245,7 @@ var (
 	CinderExternalSecretSpec = &definition.TuningSpec{
 		Name:        CinderExternalSecret,
 		Description: "Set cinder external storage account secret.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -254,7 +254,7 @@ var (
 	CubesysAlertLevelSpec = &definition.TuningSpec{
 		Name:        CubesysAlertLevel,
 		Description: "Set health alert sensible level. (0: default, 1: highly sensitive)",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -265,7 +265,7 @@ var (
 	CubesysAlertLevelSSpec = &definition.TuningSpec{
 		Name:        CubesysAlertLevelS,
 		Description: "Set health alert sensible level for service %s. (0: default, 1: highly sensitive)",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -276,7 +276,7 @@ var (
 	CubesysConntableMaxSpec = &definition.TuningSpec{
 		Name:        CubesysConntableMax,
 		Description: "Set max connection table size.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 262144,
 			Min:     0,
@@ -287,7 +287,7 @@ var (
 	CubesysLogDefaultRetentionSpec = &definition.TuningSpec{
 		Name:        CubesysLogDefaultRetention,
 		Description: "Set log file retention policy in days.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 14,
 			Min:     0,
@@ -298,7 +298,7 @@ var (
 	CubesysProviderExtraSpec = &definition.TuningSpec{
 		Name:        CubesysProviderExtra,
 		Description: "Set extra provider interfaces ('pvd-' prefix and <= 15 chars) [IF.2:pvd-xxx,eth2:pvd-yyy,...].",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -307,7 +307,7 @@ var (
 	CyborgDebugEnabledSpec = &definition.TuningSpec{
 		Name:        CyborgDebugEnabled,
 		Description: "Set to true to enable cyborg verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -316,7 +316,7 @@ var (
 	DebugEnableCoreDumpSSpec = &definition.TuningSpec{
 		Name:        DebugEnableCoreDumpS,
 		Description: "Enable core dump for process %s",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -325,7 +325,7 @@ var (
 	DebugEnableKdumpSpec = &definition.TuningSpec{
 		Name:        DebugEnableKdump,
 		Description: "Enable kdump to collect dump from kernel panic",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -334,7 +334,7 @@ var (
 	DebugLevelSSpec = &definition.TuningSpec{
 		Name:        DebugLevelS,
 		Description: "Set debug level for process %s",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -345,7 +345,7 @@ var (
 	DebugMaxCoreDumpSpec = &definition.TuningSpec{
 		Name:        DebugMaxCoreDump,
 		Description: "Set the total number of core files before oldest are removed",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -356,7 +356,7 @@ var (
 	DesignateDebugEnabledSpec = &definition.TuningSpec{
 		Name:        DesignateDebugEnabled,
 		Description: "Set to true to enable designate verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -365,7 +365,7 @@ var (
 	GlanceDebugEnabledSpec = &definition.TuningSpec{
 		Name:        GlanceDebugEnabled,
 		Description: "Set to true to enable glance verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -374,7 +374,7 @@ var (
 	GlanceExportRpSpec = &definition.TuningSpec{
 		Name:        GlanceExportRp,
 		Description: "glance export retention policy in copies.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 3,
 			Min:     0,
@@ -385,7 +385,7 @@ var (
 	HeatDebugEnabledSpec = &definition.TuningSpec{
 		Name:        HeatDebugEnabled,
 		Description: "Set to true to enable heat verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -394,7 +394,7 @@ var (
 	InfluxdbCuratorRpSpec = &definition.TuningSpec{
 		Name:        InfluxdbCuratorRp,
 		Description: "influxdb curator retention policy in days.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 7,
 			Min:     0,
@@ -405,7 +405,7 @@ var (
 	IronicDebugEnabledSpec = &definition.TuningSpec{
 		Name:        IronicDebugEnabled,
 		Description: "Set to true to enable ironic verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -414,7 +414,7 @@ var (
 	IronicDeployServerSpec = &definition.TuningSpec{
 		Name:        IronicDeployServer,
 		Description: "Set to true to enable ironic deploy server (dhcp/tftp/pxe/http).",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -423,7 +423,7 @@ var (
 	KapacitorAlertCheckEnabledSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertCheckEnabled,
 		Description: "Set true to enable kapacitor alert check.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -432,7 +432,7 @@ var (
 	KapacitorAlertCheckEventIdSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertCheckEventId,
 		Description: "Set kapacitor alert check eventid.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "SYS00002W",
 		},
@@ -441,7 +441,7 @@ var (
 	KapacitorAlertCheckIntervalSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertCheckInterval,
 		Description: "Set kapacitor alert check interval (default to 60m).",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "60m",
 		},
@@ -450,7 +450,7 @@ var (
 	KapacitorAlertExtraPrefixSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertExtraPrefix,
 		Description: "Set kapacitor alert message prefix.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "Cube",
 		},
@@ -459,7 +459,7 @@ var (
 	KapacitorAlertFlowBaseSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertFlowBase,
 		Description: "Set kapacitor alert base for abnormal flow.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "7d",
 		},
@@ -468,7 +468,7 @@ var (
 	KapacitorAlertFlowThresholdSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertFlowThreshold,
 		Description: "Set kapacitor alert threshold for abnormal flow.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 30,
 			Min:     0,
@@ -479,7 +479,7 @@ var (
 	KapacitorAlertFlowUnitSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertFlowUnit,
 		Description: "Set kapacitor alert unit for abnormal flow.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "5m",
 		},
@@ -488,7 +488,7 @@ var (
 	KeystoneDebugEnabledSpec = &definition.TuningSpec{
 		Name:        KeystoneDebugEnabled,
 		Description: "Set to true to enable keystone verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -497,7 +497,7 @@ var (
 	ManilaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        ManilaDebugEnabled,
 		Description: "Set to true to enable manila verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -506,7 +506,7 @@ var (
 	ManilaVolumeTypeSpec = &definition.TuningSpec{
 		Name:        ManilaVolumeType,
 		Description: "Set manila backend volume type.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "CubeStorage",
 		},
@@ -515,7 +515,7 @@ var (
 	MasakariHostEvacuateAllSpec = &definition.TuningSpec{
 		Name:        MasakariHostEvacuateAll,
 		Description: "Set to true to enable evacuate all instances when host goes down.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: true,
 		},
@@ -524,7 +524,7 @@ var (
 	MasakariWaitPeriodSpec = &definition.TuningSpec{
 		Name:        MasakariWaitPeriod,
 		Description: "Set wait period after service update",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -535,7 +535,7 @@ var (
 	MonascaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        MonascaDebugEnabled,
 		Description: "Set to true to enable monasca verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -544,7 +544,7 @@ var (
 	MysqlBackupCuratorRpSpec = &definition.TuningSpec{
 		Name:        MysqlBackupCuratorRp,
 		Description: "mysql backup retention policy in weeks.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 14,
 			Min:     0,
@@ -555,7 +555,7 @@ var (
 	NetIfMtuNameSpec = &definition.TuningSpec{
 		Name:        NetIfMtuName,
 		Description: "Set interface MTU (MTU of parent interface must be greater than its VLAN interface).",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 1500,
 			Min:     68,
@@ -566,7 +566,7 @@ var (
 	NetIpv4TcpSyncookiesSpec = &definition.TuningSpec{
 		Name:        NetIpv4TcpSyncookies,
 		Description: "Turn on the Linux SYN cookies implementation.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: true,
 		},
@@ -575,7 +575,7 @@ var (
 	NetLacpDefaultRateSpec = &definition.TuningSpec{
 		Name:        NetLacpDefaultRate,
 		Description: "Set default LACP rate (fast/slow).",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "fast",
 		},
@@ -584,7 +584,7 @@ var (
 	NetLacpDefaultXmitSpec = &definition.TuningSpec{
 		Name:        NetLacpDefaultXmit,
 		Description: "Set default LACP transmit hash policy (layer2/layer2+3/layer3+4).",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "layer3+4",
 		},
@@ -593,7 +593,7 @@ var (
 	NeutronDebugEnabledSpec = &definition.TuningSpec{
 		Name:        NeutronDebugEnabled,
 		Description: "Set to true to enable neutron verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -602,7 +602,7 @@ var (
 	NovaControlHostMemorySpec = &definition.TuningSpec{
 		Name:        NovaControlHostMemory,
 		Description: "Amount of memory in MB to reserve for the control host.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -613,7 +613,7 @@ var (
 	NovaControlHostVcpuSpec = &definition.TuningSpec{
 		Name:        NovaControlHostVcpu,
 		Description: "Amount of vcpu to reserve for the control host.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -624,7 +624,7 @@ var (
 	NovaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        NovaDebugEnabled,
 		Description: "Set to true to enable nova verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -633,7 +633,7 @@ var (
 	NovaGpuTypeSpec = &definition.TuningSpec{
 		Name:        NovaGpuType,
 		Description: "Specify a supported gpu type instances would get.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -646,7 +646,7 @@ var (
 	NovaOvercommitCpuRatioSpec = &definition.TuningSpec{
 		Name:        NovaOvercommitCpuRatio,
 		Description: "Specify an allowed CPU overcommitted ratio.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "float",
 			Default: 16.0,
 		},
@@ -655,7 +655,7 @@ var (
 	NovaOvercommitDiskRatioSpec = &definition.TuningSpec{
 		Name:        NovaOvercommitDiskRatio,
 		Description: "Specify an allowed disk overcommitted ratio.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "float",
 			Default: 1.0,
 		},
@@ -664,7 +664,7 @@ var (
 	NovaOvercommitRamRatioSpec = &definition.TuningSpec{
 		Name:        NovaOvercommitRamRatio,
 		Description: "Specify an allowed RAM overcommitted ratio.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "float",
 			Default: 1.5,
 		},
@@ -673,7 +673,7 @@ var (
 	NtpDebugEnabledSpec = &definition.TuningSpec{
 		Name:        NtpDebugEnabled,
 		Description: "Set to true to enable ntp verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -682,7 +682,7 @@ var (
 	OctaviaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        OctaviaDebugEnabled,
 		Description: "Set to true to enable octavia verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -691,7 +691,7 @@ var (
 	OctaviaHaSpec = &definition.TuningSpec{
 		Name:        OctaviaHa,
 		Description: "Set to true to enable octavia HA mode.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -700,7 +700,7 @@ var (
 	OpensearchCuratorRpSpec = &definition.TuningSpec{
 		Name:        OpensearchCuratorRp,
 		Description: "opensearch curator retention policy in days.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 7,
 			Min:     0,
@@ -711,7 +711,7 @@ var (
 	OpensearchHeapSizeSpec = &definition.TuningSpec{
 		Name:        OpensearchHeapSize,
 		Description: "Set opensearch heap size in MB.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 1024,
 			Min:     256,
@@ -722,7 +722,7 @@ var (
 	SenlinDebugEnabledSpec = &definition.TuningSpec{
 		Name:        SenlinDebugEnabled,
 		Description: "Set to true to enable senlin verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -731,7 +731,7 @@ var (
 	SkylineDebugEnabledSpec = &definition.TuningSpec{
 		Name:        SkylineDebugEnabled,
 		Description: "Set to true to enable skyline verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -740,7 +740,7 @@ var (
 	SnapshotApplyActionSpec = &definition.TuningSpec{
 		Name:        SnapshotApplyAction,
 		Description: "Set snapshot apply action <apply|revert>.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "apply",
 		},
@@ -749,7 +749,7 @@ var (
 	SnapshotApplyPolicyIgnoreSpec = &definition.TuningSpec{
 		Name:        SnapshotApplyPolicyIgnore,
 		Description: "Set snapshot apply policy ignore <true|false>.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -758,7 +758,7 @@ var (
 	SshdBindToAllInterfacesSpec = &definition.TuningSpec{
 		Name:        SshdBindToAllInterfaces,
 		Description: "Set to true to bind sshd to all interfaces.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -767,7 +767,7 @@ var (
 	SshdSessionInactivitySpec = &definition.TuningSpec{
 		Name:        SshdSessionInactivity,
 		Description: "Set sshd session inactivity timeout in seconds.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -778,7 +778,7 @@ var (
 	TimeTimezoneSpec = &definition.TuningSpec{
 		Name:        TimeTimezone,
 		Description: "Set system timezone.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "UTC",
 		},
@@ -787,7 +787,7 @@ var (
 	UpdateSecurityAutoUpdateSpec = &definition.TuningSpec{
 		Name:        UpdateSecurityAutoUpdate,
 		Description: "Set to true to enable security autoupdate.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -796,7 +796,7 @@ var (
 	WatcherDebugEnabledSpec = &definition.TuningSpec{
 		Name:        WatcherDebugEnabled,
 		Description: "Set to true to enable watcher verbose log.",
-		ExampleValue: definition.ExampleValue{
+		TuningLimitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -880,8 +880,8 @@ func init() {
 	definition.SetSpecToTuning(WatcherDebugEnabled, WatcherDebugEnabledSpec)
 }
 
-func ReadTuning(parameterName string) (string, error) {
-	b, err := exec.Command("hex_tuning_helper", "/etc/settings.txt", "", parameterName).Output()
+func GetTuningValue(name string) (string, error) {
+	b, err := exec.Command("hex_tuning_helper", "/etc/settings.txt", "", name).Output()
 	if err != nil {
 		log.Errorf("failed to read hex tunning value: %s", err.Error())
 		return "", err
@@ -895,6 +895,21 @@ func ReadTuning(parameterName string) (string, error) {
 	return keyValue[1], nil
 }
 
+func GetTuning(name string) (*definition.Tuning, error) {
+	policy, err := GetPolicy(TuningPolicyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tuning := range policy.Tunings {
+		if tuning.Name == name {
+			return &tuning, nil
+		}
+	}
+
+	return nil, cuberr.TuningNotFound
+}
+
 func ApplyTuning(isolatedDir string) error {
 	out, err := exec.Command("hex_config", "apply", isolatedDir).CombinedOutput()
 	if err != nil {
@@ -906,7 +921,7 @@ func ApplyTuning(isolatedDir string) error {
 }
 
 func IsTuningApplied(tuning definition.Tuning) error {
-	value, err := ReadTuning(tuning.Name)
+	value, err := GetTuningValue(tuning.Name)
 	if err != nil {
 		return err
 	}
@@ -1008,7 +1023,7 @@ func GetPolicy(filePath string) (*definition.Policy, error) {
 }
 
 func IsTuningDeleted(tuning definition.Tuning) bool {
-	_, err := ReadTuning(tuning.Name)
+	_, err := GetTuningValue(tuning.Name)
 	if err == nil {
 		log.Errorf("tuning value is not deleted: %s", tuning.Name)
 		return false
@@ -1022,41 +1037,59 @@ func IsTuningDeleted(tuning definition.Tuning) bool {
 	return true
 }
 
-func ListNodeTunings(opts definition.ListTuningOptions) ([]definition.Tuning, error) {
-	if opts.AllNodes {
+func ListTunings(opts definition.ListTuningOptions) ([]definition.Tuning, error) {
+	if !opts.AllNodes {
 		return definition.ListCurrentTunings(), nil
 	}
 
-	return nil, nil
+	return definition.ListCurrentTunings(), nil
 }
 
 func SyncTunings() {
-	for _, tuning := range definition.ListTuningSpecs() {
-		value, err := ReadTuning(tuning.Name)
+	for _, spec := range definition.ListTuningSpecs() {
+		srcTuning, err := GetTuning(spec.Name)
 		if err == nil {
-			checkAndUpdateTuning(tuning.Name, value)
+			srcTuning.IsModified = true
+			srcTuning.Description = spec.Description
+			srcTuning.Limitation = spec.TuningLimitation
+			srcTuning.Hosts = []string{definition.Hostname}
+			checkAndUpdateTuning(spec.Name, *srcTuning)
 		}
 
 		if errors.Is(err, cuberr.TuningNotFound) {
-			setDefaultTuning(tuning)
+			setDefaultTuning(spec)
 		}
 	}
 }
 
-func checkAndUpdateTuning(key, value string) {
+func checkAndUpdateTuning(key string, sourceTuning definition.Tuning) {
 	tuning := definition.GetCurrentTuning(key)
-	if tuning.Value == value {
+	if !isTuningChanged(tuning, sourceTuning) {
 		return
 	}
 
-	tuning.Value = value
-	definition.SetCurrentTuning(tuning)
+	definition.SetCurrentTuning(sourceTuning)
+}
+
+func isTuningChanged(tuning, fileTuning definition.Tuning) bool {
+	if tuning.Value != fileTuning.Value {
+		return true
+	}
+
+	if tuning.Enabled != fileTuning.Enabled {
+		return true
+	}
+
+	return false
 }
 
 func setDefaultTuning(tuning definition.TuningSpec) {
 	definition.SetCurrentTuning(definition.Tuning{
-		Enabled: true,
-		Name:    tuning.Name,
-		Value:   tuning.ExampleValue.Default,
+		Enabled:     true,
+		Name:        tuning.Name,
+		Value:       tuning.TuningLimitation.Default,
+		Hosts:       []string{definition.Hostname},
+		Description: tuning.Description,
+		Limitation:  tuning.TuningLimitation,
 	})
 }

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -6,9 +6,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	cuberr "github.com/bigstack-oss/cube-cos-api/internal/errors"
 	"github.com/google/uuid"
 	log "go-micro.dev/v5/logger"
@@ -1038,11 +1042,96 @@ func IsTuningDeleted(tuning definition.Tuning) bool {
 }
 
 func ListTunings(opts definition.ListTuningOptions) ([]definition.Tuning, error) {
+	localTunings := definition.ListCurrentTunings()
 	if !opts.AllNodes {
-		return definition.ListCurrentTunings(), nil
+		return localTunings, nil
 	}
 
-	return definition.ListCurrentTunings(), nil
+	allTunings, err := ListTuningsFromOtherNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	allTunings[definition.Hostname] = localTunings
+	return aggregateTunings(allTunings), nil
+}
+
+func ListTuningsFromOtherNodes() (map[string][]definition.Tuning, error) {
+	nodes, err := definition.ListNodes()
+	if err != nil {
+		log.Errorf("failed to list nodes for tunings: %s", err.Error())
+		return nil, err
+	}
+
+	nodeTunings := map[string][]definition.Tuning{}
+	for _, node := range nodes {
+		if definition.IsCurrentHost(node.Hostname) {
+			continue
+		}
+
+		tunings, err := getNodeTunings(*node)
+		if err != nil {
+			log.Errorf("failed to get tunings from node %s: %s", node.Name, err.Error())
+			continue
+		}
+
+		nodeTunings[node.Name] = tunings
+	}
+
+	return nodeTunings, nil
+}
+
+func getNodeTunings(node definition.Node) ([]v1.Tuning, error) {
+	h := http.GetGlobalHelper()
+	resp, err := h.R().
+		SetResult(&api.TuningListData{}).
+		SetHeader("Authorization", node.GetBearerToken()).
+		Get(node.GetTuningUrl())
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsError() {
+		return nil, fmt.Errorf(
+			"failed to get tunings from %s: %d %s",
+			node.Hostname,
+			resp.StatusCode(),
+			string(resp.Body()),
+		)
+	}
+
+	tuningList := resp.Result().(*api.TuningListData)
+	return tuningList.Data, nil
+}
+
+func tuningKey(item definition.Tuning) string {
+	return item.Name + "|" + fmt.Sprintf("%v", item.Value) + "|" + strconv.FormatBool(item.Enabled)
+}
+
+func setTunings(mergedMap map[string]definition.Tuning, tunings []definition.Tuning) {
+	for _, tuning := range tunings {
+		key := tuningKey(tuning)
+		existing, found := mergedMap[key]
+		if found {
+			existing.Hosts = append(existing.Hosts, tuning.Hosts...)
+			mergedMap[key] = existing
+		} else {
+			mergedMap[key] = tuning
+		}
+	}
+}
+
+func aggregateTunings(nodeToTuning map[string][]definition.Tuning) []definition.Tuning {
+	mergedMap := make(map[string]definition.Tuning)
+	for _, tunings := range nodeToTuning {
+		setTunings(mergedMap, tunings)
+	}
+
+	tunings := []definition.Tuning{}
+	for _, item := range mergedMap {
+		tunings = append(tunings, item)
+	}
+
+	return tunings
 }
 
 func SyncTunings() {

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -889,7 +889,7 @@ func ReadTuning(parameterName string) (string, error) {
 
 	keyValue := strings.Split(string(b), "'")
 	if len(keyValue) < 2 {
-		return "", cuberr.TuningParamNotFound
+		return "", cuberr.TuningNotFound
 	}
 
 	return keyValue[1], nil
@@ -1014,10 +1014,49 @@ func IsTuningDeleted(tuning definition.Tuning) bool {
 		return false
 	}
 
-	if !errors.Is(err, cuberr.TuningParamNotFound) {
+	if !errors.Is(err, cuberr.TuningNotFound) {
 		log.Errorf("failed to check if tuning is deleted: %s", err.Error())
 		return false
 	}
 
 	return true
+}
+
+func ListNodeTunings(opts definition.ListTuningOptions) ([]definition.Tuning, error) {
+	if opts.AllNodes {
+		return definition.ListCurrentTunings(), nil
+	}
+
+	return nil, nil
+}
+
+func SyncTunings() {
+	for _, tuning := range definition.ListTuningSpecs() {
+		value, err := ReadTuning(tuning.Name)
+		if err == nil {
+			checkAndUpdateTuning(tuning.Name, value)
+		}
+
+		if errors.Is(err, cuberr.TuningNotFound) {
+			setDefaultTuning(tuning)
+		}
+	}
+}
+
+func checkAndUpdateTuning(key, value string) {
+	tuning := definition.GetCurrentTuning(key)
+	if tuning.Value == value {
+		return
+	}
+
+	tuning.Value = value
+	definition.SetCurrentTuning(tuning)
+}
+
+func setDefaultTuning(tuning definition.TuningSpec) {
+	definition.SetCurrentTuning(definition.Tuning{
+		Enabled: true,
+		Name:    tuning.Name,
+		Value:   tuning.ExampleValue.Default,
+	})
 }

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -114,7 +114,7 @@ var (
 	BarbicanDebugEnabledSpec = &definition.TuningSpec{
 		Name:        BarbicanDebugEnabled,
 		Description: "Set to true to enable barbican verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -123,7 +123,7 @@ var (
 	CephDebugEnabledSpec = &definition.TuningSpec{
 		Name:        CephDebugEnabled,
 		Description: "Set to true to enable ceph debug logs.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -132,7 +132,7 @@ var (
 	CephMirrorMetaSyncSpec = &definition.TuningSpec{
 		Name:        CephMirrorMetaSync,
 		Description: "Set to true to enable automatically volume metadata sync.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: true,
 		},
@@ -141,7 +141,7 @@ var (
 	CinderBackupAccountSpec = &definition.TuningSpec{
 		Name:        CinderBackupAccount,
 		Description: "Set cinder backup storage account.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -150,7 +150,7 @@ var (
 	CinderBackupEndpointSpec = &definition.TuningSpec{
 		Name:        CinderBackupEndpoint,
 		Description: "Set cinder backup storage endpoint.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -159,7 +159,7 @@ var (
 	CinderBackupOverrideSpec = &definition.TuningSpec{
 		Name:        CinderBackupOverride,
 		Description: "Enable override cinder backup configurations.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -168,7 +168,7 @@ var (
 	CinderBackupPoolSpec = &definition.TuningSpec{
 		Name:        CinderBackupPool,
 		Description: "Set cinder backup storage pool.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -177,7 +177,7 @@ var (
 	CinderBackupSecretSpec = &definition.TuningSpec{
 		Name:        CinderBackupSecret,
 		Description: "Set cinder backup storage account secret.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -186,7 +186,7 @@ var (
 	CinderBackupTypeSpec = &definition.TuningSpec{
 		Name:        CinderBackupType,
 		Description: "Set cinder backup storage type <cube-storage|cube-swift>.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -195,7 +195,7 @@ var (
 	CinderDebugEnabledSpec = &definition.TuningSpec{
 		Name:        CinderDebugEnabled,
 		Description: "Set to true to enable cinder verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -204,7 +204,7 @@ var (
 	CinderExternalAccountSpec = &definition.TuningSpec{
 		Name:        CinderExternalAccount,
 		Description: "Set cinder external storage account.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -213,7 +213,7 @@ var (
 	CinderExternalDriverSpec = &definition.TuningSpec{
 		Name:        CinderExternalDriver,
 		Description: "Set cinder external storage type name <cube|purestorage>.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -222,7 +222,7 @@ var (
 	CinderExternalEndpointSpec = &definition.TuningSpec{
 		Name:        CinderExternalEndpoint,
 		Description: "Set cinder external storage endpoint.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -231,7 +231,7 @@ var (
 	CinderExternalNameSpec = &definition.TuningSpec{
 		Name:        CinderExternalName,
 		Description: "Set cinder external storage rule name.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -240,7 +240,7 @@ var (
 	CinderExternalPoolSpec = &definition.TuningSpec{
 		Name:        CinderExternalPool,
 		Description: "Set cinder external storage pool.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -249,7 +249,7 @@ var (
 	CinderExternalSecretSpec = &definition.TuningSpec{
 		Name:        CinderExternalSecret,
 		Description: "Set cinder external storage account secret.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -258,7 +258,7 @@ var (
 	CubesysAlertLevelSpec = &definition.TuningSpec{
 		Name:        CubesysAlertLevel,
 		Description: "Set health alert sensible level. (0: default, 1: highly sensitive)",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -269,7 +269,7 @@ var (
 	CubesysAlertLevelSSpec = &definition.TuningSpec{
 		Name:        CubesysAlertLevelS,
 		Description: "Set health alert sensible level for service %s. (0: default, 1: highly sensitive)",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -280,7 +280,7 @@ var (
 	CubesysConntableMaxSpec = &definition.TuningSpec{
 		Name:        CubesysConntableMax,
 		Description: "Set max connection table size.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 262144,
 			Min:     0,
@@ -291,7 +291,7 @@ var (
 	CubesysLogDefaultRetentionSpec = &definition.TuningSpec{
 		Name:        CubesysLogDefaultRetention,
 		Description: "Set log file retention policy in days.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 14,
 			Min:     0,
@@ -302,7 +302,7 @@ var (
 	CubesysProviderExtraSpec = &definition.TuningSpec{
 		Name:        CubesysProviderExtra,
 		Description: "Set extra provider interfaces ('pvd-' prefix and <= 15 chars) [IF.2:pvd-xxx,eth2:pvd-yyy,...].",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -311,7 +311,7 @@ var (
 	CyborgDebugEnabledSpec = &definition.TuningSpec{
 		Name:        CyborgDebugEnabled,
 		Description: "Set to true to enable cyborg verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -320,7 +320,7 @@ var (
 	DebugEnableCoreDumpSSpec = &definition.TuningSpec{
 		Name:        DebugEnableCoreDumpS,
 		Description: "Enable core dump for process %s",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -329,7 +329,7 @@ var (
 	DebugEnableKdumpSpec = &definition.TuningSpec{
 		Name:        DebugEnableKdump,
 		Description: "Enable kdump to collect dump from kernel panic",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -338,7 +338,7 @@ var (
 	DebugLevelSSpec = &definition.TuningSpec{
 		Name:        DebugLevelS,
 		Description: "Set debug level for process %s",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -349,7 +349,7 @@ var (
 	DebugMaxCoreDumpSpec = &definition.TuningSpec{
 		Name:        DebugMaxCoreDump,
 		Description: "Set the total number of core files before oldest are removed",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -360,7 +360,7 @@ var (
 	DesignateDebugEnabledSpec = &definition.TuningSpec{
 		Name:        DesignateDebugEnabled,
 		Description: "Set to true to enable designate verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -369,7 +369,7 @@ var (
 	GlanceDebugEnabledSpec = &definition.TuningSpec{
 		Name:        GlanceDebugEnabled,
 		Description: "Set to true to enable glance verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -378,7 +378,7 @@ var (
 	GlanceExportRpSpec = &definition.TuningSpec{
 		Name:        GlanceExportRp,
 		Description: "glance export retention policy in copies.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 3,
 			Min:     0,
@@ -389,7 +389,7 @@ var (
 	HeatDebugEnabledSpec = &definition.TuningSpec{
 		Name:        HeatDebugEnabled,
 		Description: "Set to true to enable heat verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -398,7 +398,7 @@ var (
 	InfluxdbCuratorRpSpec = &definition.TuningSpec{
 		Name:        InfluxdbCuratorRp,
 		Description: "influxdb curator retention policy in days.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 7,
 			Min:     0,
@@ -409,7 +409,7 @@ var (
 	IronicDebugEnabledSpec = &definition.TuningSpec{
 		Name:        IronicDebugEnabled,
 		Description: "Set to true to enable ironic verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -418,7 +418,7 @@ var (
 	IronicDeployServerSpec = &definition.TuningSpec{
 		Name:        IronicDeployServer,
 		Description: "Set to true to enable ironic deploy server (dhcp/tftp/pxe/http).",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -427,7 +427,7 @@ var (
 	KapacitorAlertCheckEnabledSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertCheckEnabled,
 		Description: "Set true to enable kapacitor alert check.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -436,7 +436,7 @@ var (
 	KapacitorAlertCheckEventIdSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertCheckEventId,
 		Description: "Set kapacitor alert check eventid.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "SYS00002W",
 		},
@@ -445,7 +445,7 @@ var (
 	KapacitorAlertCheckIntervalSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertCheckInterval,
 		Description: "Set kapacitor alert check interval (default to 60m).",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "60m",
 		},
@@ -454,7 +454,7 @@ var (
 	KapacitorAlertExtraPrefixSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertExtraPrefix,
 		Description: "Set kapacitor alert message prefix.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "Cube",
 		},
@@ -463,7 +463,7 @@ var (
 	KapacitorAlertFlowBaseSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertFlowBase,
 		Description: "Set kapacitor alert base for abnormal flow.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "7d",
 		},
@@ -472,7 +472,7 @@ var (
 	KapacitorAlertFlowThresholdSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertFlowThreshold,
 		Description: "Set kapacitor alert threshold for abnormal flow.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 30,
 			Min:     0,
@@ -483,7 +483,7 @@ var (
 	KapacitorAlertFlowUnitSpec = &definition.TuningSpec{
 		Name:        KapacitorAlertFlowUnit,
 		Description: "Set kapacitor alert unit for abnormal flow.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "5m",
 		},
@@ -492,7 +492,7 @@ var (
 	KeystoneDebugEnabledSpec = &definition.TuningSpec{
 		Name:        KeystoneDebugEnabled,
 		Description: "Set to true to enable keystone verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -501,7 +501,7 @@ var (
 	ManilaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        ManilaDebugEnabled,
 		Description: "Set to true to enable manila verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -510,7 +510,7 @@ var (
 	ManilaVolumeTypeSpec = &definition.TuningSpec{
 		Name:        ManilaVolumeType,
 		Description: "Set manila backend volume type.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "CubeStorage",
 		},
@@ -519,7 +519,7 @@ var (
 	MasakariHostEvacuateAllSpec = &definition.TuningSpec{
 		Name:        MasakariHostEvacuateAll,
 		Description: "Set to true to enable evacuate all instances when host goes down.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: true,
 		},
@@ -528,7 +528,7 @@ var (
 	MasakariWaitPeriodSpec = &definition.TuningSpec{
 		Name:        MasakariWaitPeriod,
 		Description: "Set wait period after service update",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -539,7 +539,7 @@ var (
 	MonascaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        MonascaDebugEnabled,
 		Description: "Set to true to enable monasca verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -548,7 +548,7 @@ var (
 	MysqlBackupCuratorRpSpec = &definition.TuningSpec{
 		Name:        MysqlBackupCuratorRp,
 		Description: "mysql backup retention policy in weeks.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 14,
 			Min:     0,
@@ -559,7 +559,7 @@ var (
 	NetIfMtuNameSpec = &definition.TuningSpec{
 		Name:        NetIfMtuName,
 		Description: "Set interface MTU (MTU of parent interface must be greater than its VLAN interface).",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 1500,
 			Min:     68,
@@ -570,7 +570,7 @@ var (
 	NetIpv4TcpSyncookiesSpec = &definition.TuningSpec{
 		Name:        NetIpv4TcpSyncookies,
 		Description: "Turn on the Linux SYN cookies implementation.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: true,
 		},
@@ -579,7 +579,7 @@ var (
 	NetLacpDefaultRateSpec = &definition.TuningSpec{
 		Name:        NetLacpDefaultRate,
 		Description: "Set default LACP rate (fast/slow).",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "fast",
 		},
@@ -588,7 +588,7 @@ var (
 	NetLacpDefaultXmitSpec = &definition.TuningSpec{
 		Name:        NetLacpDefaultXmit,
 		Description: "Set default LACP transmit hash policy (layer2/layer2+3/layer3+4).",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "layer3+4",
 		},
@@ -597,7 +597,7 @@ var (
 	NeutronDebugEnabledSpec = &definition.TuningSpec{
 		Name:        NeutronDebugEnabled,
 		Description: "Set to true to enable neutron verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -606,7 +606,7 @@ var (
 	NovaControlHostMemorySpec = &definition.TuningSpec{
 		Name:        NovaControlHostMemory,
 		Description: "Amount of memory in MB to reserve for the control host.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -617,7 +617,7 @@ var (
 	NovaControlHostVcpuSpec = &definition.TuningSpec{
 		Name:        NovaControlHostVcpu,
 		Description: "Amount of vcpu to reserve for the control host.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -628,7 +628,7 @@ var (
 	NovaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        NovaDebugEnabled,
 		Description: "Set to true to enable nova verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -637,7 +637,7 @@ var (
 	NovaGpuTypeSpec = &definition.TuningSpec{
 		Name:        NovaGpuType,
 		Description: "Specify a supported gpu type instances would get.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "",
 		},
@@ -650,7 +650,7 @@ var (
 	NovaOvercommitCpuRatioSpec = &definition.TuningSpec{
 		Name:        NovaOvercommitCpuRatio,
 		Description: "Specify an allowed CPU overcommitted ratio.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "float",
 			Default: 16.0,
 		},
@@ -659,7 +659,7 @@ var (
 	NovaOvercommitDiskRatioSpec = &definition.TuningSpec{
 		Name:        NovaOvercommitDiskRatio,
 		Description: "Specify an allowed disk overcommitted ratio.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "float",
 			Default: 1.0,
 		},
@@ -668,7 +668,7 @@ var (
 	NovaOvercommitRamRatioSpec = &definition.TuningSpec{
 		Name:        NovaOvercommitRamRatio,
 		Description: "Specify an allowed RAM overcommitted ratio.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "float",
 			Default: 1.5,
 		},
@@ -677,7 +677,7 @@ var (
 	NtpDebugEnabledSpec = &definition.TuningSpec{
 		Name:        NtpDebugEnabled,
 		Description: "Set to true to enable ntp verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -686,7 +686,7 @@ var (
 	OctaviaDebugEnabledSpec = &definition.TuningSpec{
 		Name:        OctaviaDebugEnabled,
 		Description: "Set to true to enable octavia verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -695,7 +695,7 @@ var (
 	OctaviaHaSpec = &definition.TuningSpec{
 		Name:        OctaviaHa,
 		Description: "Set to true to enable octavia HA mode.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -704,7 +704,7 @@ var (
 	OpensearchCuratorRpSpec = &definition.TuningSpec{
 		Name:        OpensearchCuratorRp,
 		Description: "opensearch curator retention policy in days.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 7,
 			Min:     0,
@@ -715,7 +715,7 @@ var (
 	OpensearchHeapSizeSpec = &definition.TuningSpec{
 		Name:        OpensearchHeapSize,
 		Description: "Set opensearch heap size in MB.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 1024,
 			Min:     256,
@@ -726,7 +726,7 @@ var (
 	SenlinDebugEnabledSpec = &definition.TuningSpec{
 		Name:        SenlinDebugEnabled,
 		Description: "Set to true to enable senlin verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -735,7 +735,7 @@ var (
 	SkylineDebugEnabledSpec = &definition.TuningSpec{
 		Name:        SkylineDebugEnabled,
 		Description: "Set to true to enable skyline verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -744,7 +744,7 @@ var (
 	SnapshotApplyActionSpec = &definition.TuningSpec{
 		Name:        SnapshotApplyAction,
 		Description: "Set snapshot apply action <apply|revert>.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "apply",
 		},
@@ -753,7 +753,7 @@ var (
 	SnapshotApplyPolicyIgnoreSpec = &definition.TuningSpec{
 		Name:        SnapshotApplyPolicyIgnore,
 		Description: "Set snapshot apply policy ignore <true|false>.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -762,7 +762,7 @@ var (
 	SshdBindToAllInterfacesSpec = &definition.TuningSpec{
 		Name:        SshdBindToAllInterfaces,
 		Description: "Set to true to bind sshd to all interfaces.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -771,7 +771,7 @@ var (
 	SshdSessionInactivitySpec = &definition.TuningSpec{
 		Name:        SshdSessionInactivity,
 		Description: "Set sshd session inactivity timeout in seconds.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "int",
 			Default: 0,
 			Min:     0,
@@ -782,7 +782,7 @@ var (
 	TimeTimezoneSpec = &definition.TuningSpec{
 		Name:        TimeTimezone,
 		Description: "Set system timezone.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "string",
 			Default: "UTC",
 		},
@@ -791,7 +791,7 @@ var (
 	UpdateSecurityAutoUpdateSpec = &definition.TuningSpec{
 		Name:        UpdateSecurityAutoUpdate,
 		Description: "Set to true to enable security autoupdate.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -800,7 +800,7 @@ var (
 	WatcherDebugEnabledSpec = &definition.TuningSpec{
 		Name:        WatcherDebugEnabled,
 		Description: "Set to true to enable watcher verbose log.",
-		TuningLimitation: definition.TuningLimitation{
+		Limitation: definition.TuningLimitation{
 			Type:    "bool",
 			Default: false,
 		},
@@ -1140,7 +1140,7 @@ func SyncTunings() {
 		if err == nil {
 			srcTuning.IsModified = true
 			srcTuning.Description = spec.Description
-			srcTuning.Limitation = spec.TuningLimitation
+			srcTuning.Limitation = spec.Limitation
 			srcTuning.Hosts = []string{definition.Hostname}
 			checkAndUpdateTuning(spec.Name, *srcTuning)
 		}
@@ -1176,9 +1176,9 @@ func setDefaultTuning(tuning definition.TuningSpec) {
 	definition.SetCurrentTuning(definition.Tuning{
 		Enabled:     true,
 		Name:        tuning.Name,
-		Value:       tuning.TuningLimitation.Default,
+		Value:       tuning.Limitation.Default,
 		Hosts:       []string{definition.Hostname},
 		Description: tuning.Description,
-		Limitation:  tuning.TuningLimitation,
+		Limitation:  tuning.Limitation,
 	})
 }

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -69,6 +69,17 @@ func (n *Node) GetMetricUrl(metric, view string) string {
 	return u.String()
 }
 
+func (n *Node) GetTuningUrl() string {
+	u := url.URL{
+		Scheme:   n.Protocol,
+		Host:     n.Address,
+		Path:     fmt.Sprintf("/api/v1/datacenters/%s/tunings", n.DataCenter),
+		RawQuery: "allNodes=false",
+	}
+
+	return u.String()
+}
+
 func IsCurrentHost(hostname string) bool {
 	return Hostname == hostname
 }

--- a/internal/definition/v1/tuning.go
+++ b/internal/definition/v1/tuning.go
@@ -15,6 +15,7 @@ const (
 
 var (
 	tuningSpecs            = sync.Map{}
+	currentTunings         = sync.Map{}
 	CreateRecordIfNotExist = options.Update().SetUpsert(true)
 )
 
@@ -41,12 +42,16 @@ type ExampleValue struct {
 }
 
 type Tuning struct {
-	Enabled bool   `json:"enabled" yaml:"enabled"`
-	Name    string `json:"name" yaml:"name"`
-	Value   string `json:"value" yaml:"value"`
+	Enabled bool        `json:"enabled" yaml:"enabled"`
+	Name    string      `json:"name" yaml:"name"`
+	Value   interface{} `json:"value" yaml:"value"`
 
 	Node   `json:"node,omitempty" yaml:"node,omitempty" bson:"node,omitempty"`
 	Status status.Details `json:"status,omitempty" yaml:"status,omitempty" bson:"status,omitempty"`
+}
+
+type ListTuningOptions struct {
+	AllNodes bool
 }
 
 func SetSpecToTuning(tuningName string, tuningSpec *TuningSpec) {
@@ -62,8 +67,45 @@ func GetRolesToHandleTuning(tuningName string) ([]*Role, bool) {
 	return val.(*TuningSpec).Roles, true
 }
 
-func GetAllTunings() *sync.Map {
+func GetTuningSpecs() *sync.Map {
 	return &tuningSpecs
+}
+
+func ListTuningSpecs() []TuningSpec {
+	specs := []TuningSpec{}
+	tuningSpecs.Range(func(key, value interface{}) bool {
+		specs = append(specs, value.(TuningSpec))
+		return true
+	})
+
+	return specs
+}
+
+func GetCurrentTunings() *sync.Map {
+	return &currentTunings
+}
+
+func GetCurrentTuning(name string) Tuning {
+	val, loaded := currentTunings.Load(name)
+	if !loaded {
+		return Tuning{}
+	}
+
+	return val.(Tuning)
+}
+
+func SetCurrentTuning(tuning Tuning) {
+	currentTunings.Store(tuning.Name, tuning)
+}
+
+func ListCurrentTunings() []Tuning {
+	tunings := []Tuning{}
+	currentTunings.Range(func(key, value interface{}) bool {
+		tunings = append(tunings, value.(Tuning))
+		return true
+	})
+
+	return tunings
 }
 
 func ShouldCurrentRoleHandleTheTuning(tuningName string, roleName string) bool {

--- a/internal/definition/v1/tuning.go
+++ b/internal/definition/v1/tuning.go
@@ -27,18 +27,18 @@ type Policy struct {
 }
 
 type TuningSpec struct {
-	Name             string `json:"name"`
-	TuningLimitation `json:"exampleValue"`
-	Description      string  `json:"description"`
-	Roles            []*Role `json:"roles"`
-	Selector         `json:"selector"`
+	Name        string           `json:"name"`
+	Limitation  TuningLimitation `json:"limitation"`
+	Description string           `json:"description"`
+	Roles       []*Role          `json:"roles"`
+	Selector    `json:"selector"`
 }
 
 type TuningLimitation struct {
 	Type    string      `json:"type"`
 	Default interface{} `json:"default"`
-	Min     interface{} `json:"min"`
-	Max     interface{} `json:"max"`
+	Min     interface{} `json:"min,omitempty"`
+	Max     interface{} `json:"max,omitempty"`
 }
 
 type Tuning struct {

--- a/internal/definition/v1/tuning.go
+++ b/internal/definition/v1/tuning.go
@@ -27,14 +27,14 @@ type Policy struct {
 }
 
 type TuningSpec struct {
-	Name         string `json:"name"`
-	ExampleValue `json:"exampleValue"`
-	Description  string  `json:"description"`
-	Roles        []*Role `json:"roles"`
-	Selector     `json:"selector"`
+	Name             string `json:"name"`
+	TuningLimitation `json:"exampleValue"`
+	Description      string  `json:"description"`
+	Roles            []*Role `json:"roles"`
+	Selector         `json:"selector"`
 }
 
-type ExampleValue struct {
+type TuningLimitation struct {
 	Type    string      `json:"type"`
 	Default interface{} `json:"default"`
 	Min     interface{} `json:"min"`
@@ -42,12 +42,16 @@ type ExampleValue struct {
 }
 
 type Tuning struct {
-	Enabled bool        `json:"enabled" yaml:"enabled"`
-	Name    string      `json:"name" yaml:"name"`
-	Value   interface{} `json:"value" yaml:"value"`
+	Name        string           `json:"name" yaml:"name"`
+	Value       interface{}      `json:"value" yaml:"value"`
+	Hosts       []string         `json:"hosts" yaml:"hosts"`
+	Description string           `json:"description" yaml:"description"`
+	Enabled     bool             `json:"enabled" yaml:"enabled"`
+	IsModified  bool             `json:"isModified" yaml:"isModified"`
+	Limitation  TuningLimitation `json:"limitation" yaml:"limitation"`
 
-	Node   `json:"node,omitempty" yaml:"node,omitempty" bson:"node,omitempty"`
-	Status status.Details `json:"status,omitempty" yaml:"status,omitempty" bson:"status,omitempty"`
+	*Node  `json:"node,omitempty" yaml:"node,omitempty" bson:"node,omitempty"`
+	Status *status.Details `json:"status,omitempty" yaml:"status,omitempty" bson:"status,omitempty"`
 }
 
 type ListTuningOptions struct {
@@ -74,7 +78,8 @@ func GetTuningSpecs() *sync.Map {
 func ListTuningSpecs() []TuningSpec {
 	specs := []TuningSpec{}
 	tuningSpecs.Range(func(key, value interface{}) bool {
-		specs = append(specs, value.(TuningSpec))
+		spec := value.(*TuningSpec)
+		specs = append(specs, *spec)
 		return true
 	})
 
@@ -133,7 +138,7 @@ func (t *Tuning) Bytes() ([]byte, error) {
 }
 
 func (t *Tuning) SetNodeInfo(role, address string) {
-	t.Node = Node{
+	t.Node = &Node{
 		Role:     role,
 		Id:       HostID,
 		Hostname: Hostname,

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -12,9 +12,9 @@ const (
 )
 
 var (
-	ServiceNotFound     = errors.New("service not found")
-	TuningParamNotFound = errors.New("tuning parameter not found")
-	LicensesNotFound    = errors.New("licenses not found")
+	ServiceNotFound  = errors.New("service not found")
+	TuningNotFound   = errors.New("tuning parameter not found")
+	LicensesNotFound = errors.New("licenses not found")
 
 	DataCenterIsNotReady  = errors.New("data center is not set ready")
 	DataCenterIsRepairing = errors.New("data center is repairing")

--- a/internal/operators/v1/node/log-throttling.go
+++ b/internal/operators/v1/node/log-throttling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/status"
 	"github.com/cnf/structhash"
 	"go-micro.dev/v5/cache"
@@ -26,13 +27,13 @@ func convertAction(action string) string {
 	return action
 }
 
-func logWithThrottling(event *registry.Result) {
+func logThrottling(event *registry.Result) {
 	key, err := structhash.Hash(event, 1)
 	if err != nil {
 		return
 	}
 
-	getCtx, getCancel := context.WithTimeout(context.Background(), time.Second*10)
+	getCtx, getCancel := context.WithTimeout(wait.CtxSeconds(10))
 	defer getCancel()
 	_, _, err = logCache.Get(getCtx, key)
 	if err == nil {
@@ -42,7 +43,7 @@ func logWithThrottling(event *registry.Result) {
 		return
 	}
 
-	putCtx, putCancel := context.WithTimeout(context.Background(), time.Second*10)
+	putCtx, putCancel := context.WithTimeout(wait.CtxSeconds(10))
 	defer putCancel()
 	err = logCache.Put(putCtx, key, []byte{}, time.Second*10)
 	if err != nil {

--- a/internal/operators/v1/node/node.go
+++ b/internal/operators/v1/node/node.go
@@ -60,7 +60,7 @@ func (o *Operator) watchAndSyncNodeRoles(watcher *registry.Watcher) {
 	event, err := (*watcher).Next()
 	if err == nil {
 		definition.SyncNodesOfRole()
-		logWithThrottling(event)
+		logThrottling(event)
 		return
 	}
 

--- a/internal/operators/v1/tunings/sync.go
+++ b/internal/operators/v1/tunings/sync.go
@@ -25,22 +25,22 @@ func (o *Operator) operateReq(tuning definition.Tuning) error {
 }
 
 func (o *Operator) deleteTuning(tuning definition.Tuning) error {
-	policy, err := cubecos.GetPolicy()
+	policy, err := cubecos.GetPolicy(cubecos.TuningPolicyFile)
 	if err != nil {
 		log.Errorf("failed to get all tunings: %s", err.Error())
 		return err
 	}
 
 	policy.DeleteTuning(tuning.Name)
-	err = cubecos.ApplyHexTunings(policy.Tunings)
+	err = cubecos.ApplyTunings(policy.Tunings)
 	if err != nil {
 		log.Errorf("failed to delete tunings: %s", err.Error())
 		return err
 	}
 
-	err = cubecos.IsHexTuningDeleted(tuning)
-	if err != nil {
-		log.Errorf("failed to check if tuning %s is deleted: %s", tuning.Name, err.Error())
+	if !cubecos.IsTuningDeleted(tuning) {
+		err := fmt.Errorf("tuning %s is not deleted", tuning.Name)
+		log.Errorf(err.Error())
 		return err
 	}
 
@@ -48,19 +48,19 @@ func (o *Operator) deleteTuning(tuning definition.Tuning) error {
 }
 
 func (o *Operator) applyTuning(tuning definition.Tuning) error {
-	policy, err := cubecos.GetPolicy()
+	policy, err := cubecos.GetPolicy(cubecos.TuningPolicyFile)
 	if err != nil {
 		return err
 	}
 
 	policy.AppendTunings([]definition.Tuning{tuning})
-	err = cubecos.ApplyHexTunings(policy.Tunings)
+	err = cubecos.ApplyTunings(policy.Tunings)
 	if err != nil {
 		log.Errorf("failed to apply tuning %s: %s", tuning.Name, err.Error())
 		return err
 	}
 
-	err = cubecos.IsHexTuningApplied(tuning)
+	err = cubecos.IsTuningApplied(tuning)
 	if err != nil {
 		log.Errorf("failed to check if tuning %s is applied: %s", tuning.Name, err.Error())
 		return err

--- a/internal/operators/v1/tunings/tuning.go
+++ b/internal/operators/v1/tunings/tuning.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/bigstack-oss/cube-cos-api/internal/service"
+	"github.com/fsnotify/fsnotify"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -21,7 +22,8 @@ func init() {
 }
 
 type Operator struct {
-	mongo *mongo.Helper
+	mongo  *mongo.Helper
+	policy *fsnotify.Watcher
 }
 
 func NewOperator() *Operator {
@@ -36,6 +38,11 @@ func (o *Operator) Init() error {
 	o.mongo = mongo.GetGlobalHelper()
 	if o.mongo == nil {
 		return errors.New("mongo helper is not initialized")
+	}
+
+	err := o.initPolicyWatcher()
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -58,6 +65,7 @@ func (o *Operator) Stop() {
 	ReqQueue.ShutDown()
 	o.waitForLastTask()
 	o.mongo.Close()
+	o.policy.Close()
 }
 
 func (o *Operator) waitForLastTask() {

--- a/internal/operators/v1/tunings/watch.go
+++ b/internal/operators/v1/tunings/watch.go
@@ -1,0 +1,51 @@
+package tunings
+
+import (
+	conf "github.com/bigstack-oss/cube-cos-api/internal/config"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/fsnotify/fsnotify"
+	log "go-micro.dev/v5/logger"
+)
+
+func (o *Operator) initPolicyWatcher() error {
+	var err error
+	o.policy, err = fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	err = o.policy.Add(conf.Opts.Spec.Identity.Policy)
+	if err != nil {
+		return err
+	}
+
+	go o.watchChanges()
+	return nil
+}
+
+func (o *Operator) watchChanges() {
+	for {
+		select {
+		case event, ok := <-o.policy.Events:
+			if ok {
+				checkAndSyncTunings(event)
+			}
+		case err, ok := <-o.policy.Errors:
+			if !ok {
+				continue
+			}
+
+			if err != nil {
+				log.Errorf("failed to fetch policy change event: %s", err.Error())
+				continue
+			}
+		}
+	}
+}
+
+func checkAndSyncTunings(event fsnotify.Event) {
+	if event.Has(fsnotify.Write) {
+		log.Infof("tunings: policy file changed, syncing tunings")
+		cubecos.SyncTunings()
+	}
+}

--- a/internal/operators/v1/tunings/watch.go
+++ b/internal/operators/v1/tunings/watch.go
@@ -1,10 +1,20 @@
 package tunings
 
 import (
+	"context"
+	"time"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	conf "github.com/bigstack-oss/cube-cos-api/internal/config"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/cnf/structhash"
 	"github.com/fsnotify/fsnotify"
+	"go-micro.dev/v5/cache"
 	log "go-micro.dev/v5/logger"
+)
+
+var (
+	logCache = cache.NewCache(cache.Expiration(time.Second * 3))
 )
 
 func (o *Operator) initPolicyWatcher() error {
@@ -14,7 +24,7 @@ func (o *Operator) initPolicyWatcher() error {
 		return err
 	}
 
-	err = o.policy.Add(conf.Opts.Spec.Identity.Policy)
+	err = o.policy.Add("/etc")
 	if err != nil {
 		return err
 	}
@@ -34,9 +44,8 @@ func (o *Operator) watchChanges() {
 			if !ok {
 				continue
 			}
-
 			if err != nil {
-				log.Errorf("failed to fetch policy change event: %s", err.Error())
+				log.Errorf("tunings: failed to fetch policy change event: %s", err.Error())
 				continue
 			}
 		}
@@ -44,8 +53,35 @@ func (o *Operator) watchChanges() {
 }
 
 func checkAndSyncTunings(event fsnotify.Event) {
+	if event.Name != conf.Opts.Spec.Identity.Policy {
+		return
+	}
+
 	if event.Has(fsnotify.Write) {
-		log.Infof("tunings: policy file changed, syncing tunings")
+		logThrottling(event)
 		cubecos.SyncTunings()
 	}
+}
+
+func logThrottling(event fsnotify.Event) {
+	key, err := structhash.Hash(event, 1)
+	if err != nil {
+		return
+	}
+
+	getCtx, getCancel := context.WithTimeout(wait.CtxSeconds(10))
+	defer getCancel()
+	_, _, err = logCache.Get(getCtx, key)
+	if err == nil {
+		return
+	}
+
+	putCtx, putCancel := context.WithTimeout(wait.CtxSeconds(10))
+	defer putCancel()
+	err = logCache.Put(putCtx, key, []byte{}, time.Second*3)
+	if err != nil {
+		return
+	}
+
+	log.Infof("tunings: %s changed, syncing tunings", event.Name)
 }

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -74,6 +74,7 @@ func initNodeIdentities() error {
 	definition.AdvertisePort = conf.Opts.Spec.Listen.Port
 	definition.IsGpuEnabled = cubecos.IsGpuEnabled()
 	definition.LogoutRedirectUrl = genLogoutRedirectUrl()
+	cubecos.SyncTunings()
 
 	return nil
 }

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -14,7 +14,7 @@ import (
 
 func initNodeIdentities() error {
 	var err error
-	definition.Hostname, err = os.Hostname()
+	definition.Hostname, err = getHostname()
 	if err != nil {
 		log.Errorf("failed to get hostname: %s", err.Error())
 		return err
@@ -77,6 +77,14 @@ func initNodeIdentities() error {
 	cubecos.SyncTunings()
 
 	return nil
+}
+
+func getHostname() (string, error) {
+	if conf.Opts.Spec.Identity.Os.Hostname != "" {
+		return conf.Opts.Spec.Identity.Os.Hostname, nil
+	}
+
+	return os.Hostname()
 }
 
 func initNodePeerSyncer() {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -30,7 +30,7 @@ type Details struct {
 	MaxPendingDuration int    `json:"maxPendingDuration,omitempty" bson:"maxPendingDuration"`
 	IsFixing           bool   `json:"isFixing" bson:"isFixing"`
 
-	Description string `json:"descriptions" bson:"description"`
+	Description string `json:"description" bson:"description"`
 }
 
 func (s *Details) ClearDesired() {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -12,6 +12,7 @@ const (
 	CheckingAndRepairing = "checkingAndRepairing"
 
 	Completed = "completed"
+	Updated   = "updated"
 	Ok        = "ok"
 	Error     = "error"
 )


### PR DESCRIPTION
### What type of PR is this?

Feat and Refactor

<br/>

### Which issue(s) this PR fixes?

#106 

<br/>

### What this PR does?

- enrich new info for each tuning parameter to match the needs from use cases.

- aggregate the host to the same tuning item by "tuning key + tuning value + isEnabled + isModified"

- simplify the data management by not using the mongo store. instead, let the policy file to be the source of truth.

- based on the file source of truth above, using CDC between file and API to keep the data consistency and increase the request performance.

- add pagination and watch toggle

- add corresponding swagger doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly


https://github.com/user-attachments/assets/a5d68c6a-d54c-4755-989b-964bd7db9965


<br>

2). make sure the mentioned apis can work properly


https://github.com/user-attachments/assets/44c1bd09-a1fe-496f-8919-5c936c2c6bb4


https://github.com/user-attachments/assets/3250fb08-e7fd-4a77-b752-d36995f634cf




 
