### PR TITLE
Fix the incorrect time format in the node details

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2567,7 +2567,7 @@ const docTemplate = `{
                                                             "by": "Bigstack co., ltd.",
                                                             "to": "*",
                                                             "hardware": "*",
-                                                            "date": "2025-02-04 09:54:45 UTC"
+                                                            "date": "2025-02-04T17:54:45+08:00"
                                                         },
                                                         "quantity": {
                                                             "type": "",
@@ -2580,7 +2580,7 @@ const docTemplate = `{
                                                             "meanTimeToRecovery": ""
                                                         },
                                                         "expiry": {
-                                                            "date": "2025-04-05 09:54:45 UTC",
+                                                            "date": "2025-04-05T17:54:45+08:00",
                                                             "days": 58
                                                         }
                                                     }
@@ -4052,7 +4052,7 @@ const docTemplate = `{
                                                                 "by": "Bigstack co., ltd.",
                                                                 "to": "bigstack",
                                                                 "hardware": "*",
-                                                                "date": "2025-01-23 06:51:50 UTC"
+                                                                "date": "2025-02-04T17:54:45+08:00"
                                                             },
                                                             "quantity": {
                                                                 "type": "",
@@ -4065,7 +4065,7 @@ const docTemplate = `{
                                                                 "meanTimeToRecovery": ""
                                                             },
                                                             "expiry": {
-                                                                "date": "2025-03-24 06:51:50 UTC",
+                                                                "date": "2025-04-05T17:54:45+08:00",
                                                                 "days": 44
                                                             }
                                                         },

--- a/api/docs.json
+++ b/api/docs.json
@@ -2563,7 +2563,7 @@
                                                             "by": "Bigstack co., ltd.",
                                                             "to": "*",
                                                             "hardware": "*",
-                                                            "date": "2025-02-04 09:54:45 UTC"
+                                                            "date": "2025-02-04T17:54:45+08:00"
                                                         },
                                                         "quantity": {
                                                             "type": "",
@@ -2576,7 +2576,7 @@
                                                             "meanTimeToRecovery": ""
                                                         },
                                                         "expiry": {
-                                                            "date": "2025-04-05 09:54:45 UTC",
+                                                            "date": "2025-04-05T17:54:45+08:00",
                                                             "days": 58
                                                         }
                                                     }
@@ -4048,7 +4048,7 @@
                                                                 "by": "Bigstack co., ltd.",
                                                                 "to": "bigstack",
                                                                 "hardware": "*",
-                                                                "date": "2025-01-23 06:51:50 UTC"
+                                                                "date": "2025-02-04T17:54:45+08:00"
                                                             },
                                                             "quantity": {
                                                                 "type": "",
@@ -4061,7 +4061,7 @@
                                                                 "meanTimeToRecovery": ""
                                                             },
                                                             "expiry": {
-                                                                "date": "2025-03-24 06:51:50 UTC",
+                                                                "date": "2025-04-05T17:54:45+08:00",
                                                                 "days": 44
                                                             }
                                                         },

--- a/internal/cubecos/licenses.go
+++ b/internal/cubecos/licenses.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	log "go-micro.dev/v5/logger"
@@ -55,27 +56,37 @@ func ListLicenses() ([]definition.License, error) {
 
 func convertRawLicensesToApiLicenses(rawLicenses []definition.RawLicense) []definition.License {
 	licenses := []definition.License{}
-
 	for _, rawLicense := range rawLicenses {
-		licenses = append(
-			licenses,
-			definition.License{
-				Type:     rawLicense.Type,
-				Hostname: rawLicense.Hostname,
-				Serial:   rawLicense.Serial,
-				Issue: definition.Issue{
-					By:       rawLicense.IssueBy,
-					To:       rawLicense.IssueTo,
-					Hardware: rawLicense.Hardware,
-					Date:     rawLicense.Date,
-				},
-				Expiry: definition.Expiry{
-					Date: rawLicense.Expiry,
-					Days: rawLicense.Days,
-				},
-			},
-		)
+		licenses = append(licenses, genApiLicense(rawLicense))
 	}
 
 	return licenses
+}
+
+func genApiLicense(rawLicense definition.RawLicense) definition.License {
+	issueDate, err := time.Parse("2006-01-02 15:04:05 MST", rawLicense.Date)
+	if err != nil {
+		rawLicense.Date = "unknown issue date"
+	}
+
+	expiry, err := time.Parse("2006-01-02 15:04:05 MST", rawLicense.Expiry)
+	if err != nil {
+		rawLicense.Expiry = "unknown expiry date"
+	}
+
+	return definition.License{
+		Type:     rawLicense.Type,
+		Hostname: rawLicense.Hostname,
+		Serial:   rawLicense.Serial,
+		Issue: definition.Issue{
+			By:       rawLicense.IssueBy,
+			To:       rawLicense.IssueTo,
+			Hardware: rawLicense.Hardware,
+			Date:     issueDate.In(definition.LocalTimeFixedZone).Format(time.RFC3339),
+		},
+		Expiry: definition.Expiry{
+			Date: expiry.In(definition.LocalTimeFixedZone).Format(time.RFC3339),
+			Days: rawLicense.Days,
+		},
+	}
 }


### PR DESCRIPTION
### What type of PR is this?

Chore

<br/>

### Which issue(s) this PR fixes?

#25 

<br/>

### What this PR does?

- fix the incorrect time format from node's license expiry.date and issue.date

- adjust the corresponding swagger doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

<img width="1548" alt="Screenshot 2025-03-05 at 9 08 42 PM" src="https://github.com/user-attachments/assets/53ff2e85-9b54-413a-bf2c-f9040cae40f2" />

<br>

2). make sure the mentioned apis can work properly

<img width="936" alt="Screenshot 2025-03-05 at 9 08 06 PM" src="https://github.com/user-attachments/assets/e66cf977-2f4c-4999-805b-38d9f26532bd" />






 
