### PR TITLE
ci(merge): add ci for fast forward merge

### DIFF
--- a/.github/workflows/fast-forward-merge.yaml
+++ b/.github/workflows/fast-forward-merge.yaml
@@ -1,0 +1,23 @@
+name: Fast Forward Merge
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  merge:
+    if: ${{ github.event.label.name == 'done' && github.event.pull_request.mergeable == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out PR Target Branch
+        uses: actions/checkout@v4
+      - name: Merge
+        run: |
+          TOPIC_BRANCH=${{ github.head_ref }}
+          git pull origin $TOPIC_BRANCH
+          git checkout $TOPIC_BRANCH
+          git checkout @{-1}
+          git branch
+          git merge --ff-only $TOPIC_BRANCH
+          git push


### PR DESCRIPTION
### What type of PR is this?

ci

### Which issue(s) this PR fixes?

- Currently, we could not maintain the linear history and signed commits at the same time without using squash

### What this PR does?

- Add the workflow to perform fast forward merge

### Test results (optional)
