### PR TITLE
Add connection trial verification and a new api for the email recipient trial

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4169,11 +4169,13 @@ const docTemplate = `{
                                                     "recipients": [
                                                         {
                                                             "email": "example.user.1@example.com",
-                                                            "note": "example note 1"
+                                                            "note": "example note 1",
+                                                            "isTestable": true
                                                         },
                                                         {
                                                             "email": "example.user.2@example.com",
-                                                            "note": "example note 2"
+                                                            "note": "example note 2",
+                                                            "isTestable": true
                                                         }
                                                     ],
                                                     "senders": [
@@ -4182,7 +4184,8 @@ const docTemplate = `{
                                                             "port": 587,
                                                             "username": "ABBBBBBMJM56DCCCCJR",
                                                             "password": "VBHWEEGEEEEEX0f5NLHDXLESxdZR",
-                                                            "email": "noreply@example.com"
+                                                            "email": "noreply@example.com",
+                                                            "accessVerified": true
                                                         }
                                                     ]
                                                 },
@@ -4405,7 +4408,8 @@ const docTemplate = `{
                                                     "port": 587,
                                                     "username": "example-user",
                                                     "password": "example-password",
-                                                    "email": "noreply@bigstack.co"
+                                                    "email": "noreply@bigstack.co",
+                                                    "accessVerified": true
                                                 }
                                             ],
                                             "msg": "email senders retrieved successfully",
@@ -4754,11 +4758,13 @@ const docTemplate = `{
                                             "data": [
                                                 {
                                                     "email": "example.user.1@example.com",
-                                                    "note": "example email recipient 1"
+                                                    "note": "example email recipient 1",
+                                                    "isTestable": true
                                                 },
                                                 {
                                                     "email": "example.user.2@example.com",
-                                                    "note": "example email recipient 2"
+                                                    "note": "example email recipient 2",
+                                                    "isTestable": true
                                                 }
                                             ],
                                             "msg": "email recipients retrieved successfully",
@@ -4797,6 +4803,87 @@ const docTemplate = `{
             }
         },
         "/api/v1/datacenters/{dataCenter}/settings/email/recipients/{recipientEmail}": {
+            "post": {
+                "operationId": "tryEmailRecipient",
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Try an email recipient",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "recipientEmail",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "recipient email to operate"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Email recipient tried successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TryEmailRecipientResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "recipient not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to try email recipient: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "put": {
                 "operationId": "updateEmailRecipient",
                 "tags": [
@@ -9867,7 +9954,8 @@ const docTemplate = `{
                     "port",
                     "username",
                     "password",
-                    "email"
+                    "email",
+                    "accessVerified"
                 ],
                 "properties": {
                     "host": {
@@ -9884,6 +9972,9 @@ const docTemplate = `{
                     },
                     "email": {
                         "type": "string"
+                    },
+                    "accessVerified": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -9902,7 +9993,8 @@ const docTemplate = `{
                 "type": "object",
                 "required": [
                     "email",
-                    "note"
+                    "note",
+                    "isTestable"
                 ],
                 "properties": {
                     "email": {
@@ -9910,6 +10002,9 @@ const docTemplate = `{
                     },
                     "note": {
                         "type": "string"
+                    },
+                    "isTestable": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -10183,6 +10278,28 @@ const docTemplate = `{
                     },
                     "status": {
                         "type": "string"
+                    }
+                }
+            },
+            "TryEmailRecipientResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "email recipient tried successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -4165,11 +4165,13 @@
                                                     "recipients": [
                                                         {
                                                             "email": "example.user.1@example.com",
-                                                            "note": "example note 1"
+                                                            "note": "example note 1",
+                                                            "isTestable": true
                                                         },
                                                         {
                                                             "email": "example.user.2@example.com",
-                                                            "note": "example note 2"
+                                                            "note": "example note 2",
+                                                            "isTestable": true
                                                         }
                                                     ],
                                                     "senders": [
@@ -4178,7 +4180,8 @@
                                                             "port": 587,
                                                             "username": "ABBBBBBMJM56DCCCCJR",
                                                             "password": "VBHWEEGEEEEEX0f5NLHDXLESxdZR",
-                                                            "email": "noreply@example.com"
+                                                            "email": "noreply@example.com",
+                                                            "accessVerified": true
                                                         }
                                                     ]
                                                 },
@@ -4401,7 +4404,8 @@
                                                     "port": 587,
                                                     "username": "example-user",
                                                     "password": "example-password",
-                                                    "email": "noreply@bigstack.co"
+                                                    "email": "noreply@bigstack.co",
+                                                    "accessVerified": true
                                                 }
                                             ],
                                             "msg": "email senders retrieved successfully",
@@ -4750,11 +4754,13 @@
                                             "data": [
                                                 {
                                                     "email": "example.user.1@example.com",
-                                                    "note": "example email recipient 1"
+                                                    "note": "example email recipient 1",
+                                                    "isTestable": true
                                                 },
                                                 {
                                                     "email": "example.user.2@example.com",
-                                                    "note": "example email recipient 2"
+                                                    "note": "example email recipient 2",
+                                                    "isTestable": true
                                                 }
                                             ],
                                             "msg": "email recipients retrieved successfully",
@@ -4793,6 +4799,87 @@
             }
         },
         "/api/v1/datacenters/{dataCenter}/settings/email/recipients/{recipientEmail}": {
+            "post": {
+                "operationId": "tryEmailRecipient",
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Try an email recipient",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "recipientEmail",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "recipient email to operate"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Email recipient tried successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TryEmailRecipientResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "recipient not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to try email recipient: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "put": {
                 "operationId": "updateEmailRecipient",
                 "tags": [
@@ -9863,7 +9950,8 @@
                     "port",
                     "username",
                     "password",
-                    "email"
+                    "email",
+                    "accessVerified"
                 ],
                 "properties": {
                     "host": {
@@ -9880,6 +9968,9 @@
                     },
                     "email": {
                         "type": "string"
+                    },
+                    "accessVerified": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -9898,7 +9989,8 @@
                 "type": "object",
                 "required": [
                     "email",
-                    "note"
+                    "note",
+                    "isTestable"
                 ],
                 "properties": {
                     "email": {
@@ -9906,6 +9998,9 @@
                     },
                     "note": {
                         "type": "string"
+                    },
+                    "isTestable": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -10179,6 +10274,28 @@
                     },
                     "status": {
                         "type": "string"
+                    }
+                }
+            },
+            "TryEmailRecipientResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "email recipient tried successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
                     }
                 }
             },

--- a/internal/api/v1/settings/handlers.go
+++ b/internal/api/v1/settings/handlers.go
@@ -62,6 +62,12 @@ var Handlers = []api.Handler{
 	},
 	{
 		Version: api.V1,
+		Method:  "POST",
+		Path:    "/settings/email/recipients/:recipientEmail",
+		Func:    tryEmailRecipient,
+	},
+	{
+		Version: api.V1,
 		Method:  "GET",
 		Path:    "/settings/email/recipients",
 		Func:    listEmailRecipients,
@@ -185,7 +191,7 @@ func tryEmailSender(c *gin.Context) {
 		return
 	}
 
-	err = recipient.CheckFormat()
+	err = recipient.CheckEmailFormat()
 	if err != nil {
 		log.Errorf("request(%s): invalid email format: %s", api.GetReqId(c), err.Error())
 		api.SetBadRequest(c, err)
@@ -199,14 +205,21 @@ func tryEmailSender(c *gin.Context) {
 		return
 	}
 	if len(senders) == 0 {
-		log.Error("no email senders found")
 		api.SetBadRequest(c, errors.New("no email senders found"))
 		return
 	}
 
-	err = sendTrialEmail(senders[0], recipient.Email)
+	sender := senders[0]
+	err = sendTrialEmail(sender, recipient.Email)
 	if err != nil {
 		log.Errorf("request(%s): failed to try email sender: %s", api.GetReqId(c), err.Error())
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	err = setSenderAsVerified(sender)
+	if err != nil {
+		log.Errorf("request(%s): failed to enable email trial toggle: %s", api.GetReqId(c), err.Error())
 		api.SetInternalServerError(c, err)
 		return
 	}
@@ -243,11 +256,12 @@ func patchEmailSender(c *gin.Context) {
 
 	err = checkSenderUpdate(c, sender)
 	if err != nil {
-		log.Errorf("request(%s): failed to update email sender: %s", api.GetReqId(c), err.Error())
+		log.Errorf("request(%s): failed to check email sender: %s", api.GetReqId(c), err.Error())
 		api.SetBadRequest(c, err)
 	}
 
 	sender.Host = c.Param("senderHost")
+	sender.ResetAccessVerification()
 	err = updateEmailSender(sender)
 	if err != nil {
 		log.Errorf("request(%s): failed to update email sender: %s", api.GetReqId(c), err.Error())
@@ -291,7 +305,7 @@ func createEmailRecipient(c *gin.Context) {
 		return
 	}
 
-	err = recipient.CheckFormat()
+	err = recipient.CheckEmailFormat()
 	if err != nil {
 		log.Errorf("request(%s): invalid email format: %s", api.GetReqId(c), err.Error())
 		api.SetBadRequest(c, err)
@@ -313,6 +327,44 @@ func createEmailRecipient(c *gin.Context) {
 	api.SetStatusCreated(
 		c,
 		"email recipient created successfully",
+		nil,
+	)
+}
+
+func tryEmailRecipient(c *gin.Context) {
+	recipientEmail := c.Param("recipientEmail")
+	if !isRecipientExist(recipientEmail) {
+		api.SetBadRequest(c, errors.New("recipient not found"))
+		return
+	}
+
+	senders, err := getEmailSenders()
+	if err != nil {
+		log.Errorf("request(%s): failed to get email senders: %s", api.GetReqId(c), err.Error())
+		api.SetInternalServerError(c, err)
+		return
+	}
+	if len(senders) == 0 {
+		api.SetBadRequest(c, errors.New("no email senders found"))
+		return
+	}
+
+	sender := senders[0]
+	if !sender.AccessVerified {
+		api.SetBadRequest(c, errors.New("email sender not verified"))
+		return
+	}
+
+	err = sendTrialEmail(sender, recipientEmail)
+	if err != nil {
+		log.Errorf("request(%s): failed to try email recipient: %s", api.GetReqId(c), err.Error())
+		api.SetInternalServerError(c, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"email recipient tried successfully",
 		nil,
 	)
 }

--- a/internal/api/v1/settings/parse.go
+++ b/internal/api/v1/settings/parse.go
@@ -53,10 +53,10 @@ func parseEmailSender(cursor *mongo.Cursor) ([]email.Sender, error) {
 }
 
 func parseEmailRecipient(cursor *mongo.Cursor) ([]email.Recipient, error) {
+	recipients := []email.Recipient{}
 	ctx, cancel := context.WithTimeout(wait.CtxSeconds(5))
 	defer cancel()
 
-	recipients := []email.Recipient{}
 	for cursor.Next(ctx) {
 		recipient := email.Recipient{}
 		err := cursor.Decode(&recipient)

--- a/internal/api/v1/settings/record.go
+++ b/internal/api/v1/settings/record.go
@@ -112,13 +112,15 @@ func updateEmailSender(sender email.Sender) error {
 		v1.SettingsDB(),
 		email.SenderCollection(),
 		bson.M{"host": sender.Host},
-		bson.M{"$set": bson.M{
-			"host":     sender.Host,
-			"port":     sender.Port,
-			"username": sender.Username,
-			"password": sender.Password,
-			"email":    sender.Email,
-		},
+		bson.M{
+			"$set": bson.M{
+				"host":           sender.Host,
+				"port":           sender.Port,
+				"username":       sender.Username,
+				"password":       sender.Password,
+				"email":          sender.Email,
+				"accessVerified": sender.AccessVerified,
+			},
 		},
 	)
 }
@@ -143,7 +145,7 @@ func insertEmailRecipient(recipient email.Recipient) error {
 
 func getEmailRecipients() ([]email.Recipient, error) {
 	h := mongo.GetGlobalHelper()
-	cursor, err := h.GetQueryCursor(
+	c, err := h.GetQueryCursor(
 		v1.SettingsDB(),
 		email.RecipientCollection(),
 		bson.M{},
@@ -155,8 +157,15 @@ func getEmailRecipients() ([]email.Recipient, error) {
 
 	ctx, cancel := context.WithTimeout(wait.CtxSeconds(5))
 	defer cancel()
-	defer cursor.Close(ctx)
-	return parseEmailRecipient(cursor)
+	defer c.Close(ctx)
+	recipients, err := parseEmailRecipient(c)
+	if err != nil {
+		log.Errorf("failed to parse email recipient (%s)", err.Error())
+		return nil, err
+	}
+
+	syncTrialToggle(&recipients)
+	return recipients, nil
 }
 
 func updateEmailRecipient(recipient email.Recipient) error {

--- a/internal/api/v1/settings/trial.go
+++ b/internal/api/v1/settings/trial.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/email"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/slack"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	v1email "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/email"
 	v1slack "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/slack"
-	"go-micro.dev/v5/logger"
+	log "go-micro.dev/v5/logger"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 func sendTrialEmail(sender v1email.Sender, recipient string) error {
@@ -16,10 +19,10 @@ func sendTrialEmail(sender v1email.Sender, recipient string) error {
 		sender.UserAuth(),
 		sender.Email,
 		[]string{recipient},
-		[]byte("Subject: Trial Email\n\nThis is a trial email from Cube COS."),
+		[]byte("Subject: [Cube COS] A Trial Email From Settings\n\nThis is a trial email from Cube COS."),
 	)
 	if err != nil {
-		logger.Errorf("settings: failed to send trial email (%s)", err.Error())
+		log.Errorf("settings: failed to send trial email (%s)", err.Error())
 		return fmt.Errorf(
 			"failed to send trial email, please make sure the email sender setting is correct",
 		)
@@ -31,7 +34,7 @@ func sendTrialEmail(sender v1email.Sender, recipient string) error {
 func sendTrialSlackMessage(channel v1slack.Channel) error {
 	h, err := slack.NewHelper()
 	if err != nil {
-		logger.Errorf("settings: failed to create slack helper (%s)", err.Error())
+		log.Errorf("settings: failed to create slack helper (%s)", err.Error())
 		return err
 	}
 
@@ -39,4 +42,34 @@ func sendTrialSlackMessage(channel v1slack.Channel) error {
 		channel.URL,
 		"A trial message from Cube COS",
 	)
+}
+
+func setSenderAsVerified(sender v1email.Sender) error {
+	mongo := mongo.GetGlobalHelper()
+	return mongo.UpdateOne(
+		v1.SettingsDB(),
+		v1email.SenderCollection(),
+		bson.M{"host": sender.Host},
+		bson.M{"$set": bson.M{"accessVerified": true}},
+	)
+}
+
+func syncTrialToggle(recipient *[]v1email.Recipient) {
+	senders, err := getEmailSenders()
+	if err != nil {
+		log.Errorf("settings: failed to get email senders (%s)", err.Error())
+		return
+	}
+
+	if len(senders) == 0 {
+		log.Warnf("settings: no email sender found")
+		return
+	}
+	if !senders[0].AccessVerified {
+		return
+	}
+
+	for i := range *recipient {
+		(*recipient)[i].IsTestable = true
+	}
 }

--- a/internal/api/v1/settings/verify.go
+++ b/internal/api/v1/settings/verify.go
@@ -31,7 +31,7 @@ func checkRecipientUpdate(c *gin.Context, recipient email.Recipient) error {
 		return errors.New("recipient email does not match")
 	}
 
-	err := recipient.CheckFormat()
+	err := recipient.CheckEmailFormat()
 	if err != nil {
 		return errors.New("recipient email format is invalid")
 	}

--- a/internal/definition/v1/email/email.go
+++ b/internal/definition/v1/email/email.go
@@ -17,11 +17,12 @@ type Options struct {
 }
 
 type Sender struct {
-	Host     string `json:"host" bson:"host"`
-	Port     int    `json:"port" bson:"port"`
-	Username string `json:"username" bson:"username"`
-	Password string `json:"password" bson:"password"`
-	Email    string `json:"email" bson:"email"`
+	Host           string `json:"host" bson:"host"`
+	Port           int    `json:"port" bson:"port"`
+	Username       string `json:"username" bson:"username"`
+	Password       string `json:"password" bson:"password"`
+	Email          string `json:"email" bson:"email"`
+	AccessVerified bool   `json:"accessVerified" bson:"accessVerified"`
 }
 
 func (s *Sender) Address() string {
@@ -32,12 +33,17 @@ func (s *Sender) UserAuth() smtp.Auth {
 	return smtp.PlainAuth("", s.Username, s.Password, s.Host)
 }
 
-type Recipient struct {
-	Email string `json:"email" bson:"email"`
-	Note  string `json:"note" bson:"note"`
+func (s *Sender) ResetAccessVerification() {
+	s.AccessVerified = false
 }
 
-func (r *Recipient) CheckFormat() error {
+type Recipient struct {
+	Email      string `json:"email" bson:"email"`
+	Note       string `json:"note" bson:"note"`
+	IsTestable bool   `json:"isTestable" bson:"-"`
+}
+
+func (r *Recipient) CheckEmailFormat() error {
 	_, err := mail.ParseAddress(r.Email)
 	return err
 }

--- a/internal/definition/v1/tuning.go
+++ b/internal/definition/v1/tuning.go
@@ -52,6 +52,7 @@ type TuningLimitation struct {
 	Default any    `json:"default"`
 	Min     int    `json:"min,omitempty"`
 	Max     int    `json:"max,omitempty"`
+	Regex   string `json:"regex,omitempty"`
 }
 
 type Tuning struct {


### PR DESCRIPTION
### What type of PR is this?

Feat and Refactor

<br/>

### Which issue(s) this PR fixes?

#50 #51 #52 #53 #122 

<br/>

### What this PR does?

- add 1 new POST API for email recipient connection trial

- add `accessVerified` info in the email sender struct (to let API caller knows if the email server is verified for connection or not)

- add `isTestable` info in the email recipient struct (to let API caller knows if the email receiver can be tested or not)

- add corresponding changes in the swagger doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/0527080a-9f80-40a8-a989-8b774fc0246d


<br>

2). make sure the mentioned apis can work properly

originally, I want to put the recording here, but the testing includes a lot of company 
credential for mail server and slack, so might be not okay to put here.

instead, I put the API commands which were done during developing to prove that I've tested them

make sure the `POST` and `PUT` `/email/senders` will set or reset the `accessVerified` and `isTestable` info in the email sender and recipient schema.

```sh
{
    "code": 200,
    "data": {
        "titlePrefix": "[alert] test notification title prefix 2",
        "email": {
            "recipients": [
                {
                    "email": "... <erased for security> ...",
                    "note": "test email recipient",
                    "isTestable": false
                }
            ],
            "senders": [
                {
                    "host": "... <erased for security> ...",
                    "port": 587,
                    "username": "... <erased for security> ...",
                    "password": "... <erased for security> ...",
                    "email": "noreply.thanks@bigstack.co",
                    "accessVerified": false
                }
            ]
        },
        "slack": {
            "channels": [
                {
                    "name": "test-cos-300-notification",
                    "url": "https://bigstack-tech.slack.com/... <erased for security> ...",
                    "description": "test slack channel"
                },
                {
                    "name": "amqp-alert-p1",
                    "url": "https://hooks.slack.com/services/... <erased for security> ...",
                    "description": "test slack channel"
                },
                {
                    "name": "#test-cos-300-notification",
                    "url": "https://hooks.slack.com/services/... <erased for security> ...",
                    "description": "test slack channel 2"
                }
            ]
        }
    },
    "msg": "all setting retrieved successfully",
    "status": "ok"
}
```

<br/>

make sure the email recipient trial will be rejected if email sender is not tested yet.

```sh
$ curl -k -X POST "https://10.32.10.180:4443/api/v1/datacenters/dell180/settings/email/recipients/bjergsen.zhu@bigstack.co" -H "Authorization: Bearer ${TOKEN}"

{"code":400,"msg":"email sender not verified","status":"bad request"}
```

<br/>

but once the email sender is verified, then email recipient trial will work properly

```sh
$ curl -k -X POST "https://10.32.10.180:4443/api/v1/datacenters/dell180/settings/email/senders/<erased for security>" -H "Authorization: Bearer ${TOKEN}" --data-raw '{"email":"bjergsen.zhu@bigstack.co"}'

{"code":200,"msg":"email sender tried successfully","status":"ok"}
```

```sh
$ curl -k -X POST "https://10.32.10.180:4443/api/v1/datacenters/dell180/settings/email/recipients/bjergsen.zhu@bigstack.co" -H "Authorization: Bearer ${TOKEN}"

{"code":200,"msg":"email recipient tried successfully","status":"ok"}
```
