### PR TITLE
Add missed time related parameters for healths api, and correct the wrong schema for metrics summary response

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1709,6 +1709,43 @@ const docTemplate = `{
                     },
                     {
                         "$ref": "#/components/parameters/watch"
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00+00:00"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00+00:00"
+                    },
+                    {
+                        "in": "query",
+                        "name": "past",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1h",
+                                "24h",
+                                "7d",
+                                "14d",
+                                "30d"
+                            ]
+                        },
+                        "description": "The past time of the health history to query, click 'try it out' to see a few options, but can specify with the 's'(second), 'm'(minute), 'h'(hour), and 'd'(day) suffix for other time ranges.",
+                        "example": "1d"
                     }
                 ],
                 "responses": {
@@ -8043,7 +8080,7 @@ const docTemplate = `{
                             "examples": {
                                 "example": {
                                     "summary": "Trigger update request",
-                                    "value":  {
+                                    "value": {
                                         "attributes": [
                                             {
                                                 "name": "severity",
@@ -9613,7 +9650,8 @@ const docTemplate = `{
                                                 "role",
                                                 "name",
                                                 "address",
-                                                "usage"
+                                                "cpu",
+                                                "memory"
                                             ],
                                             "properties": {
                                                 "role": {
@@ -9625,66 +9663,57 @@ const docTemplate = `{
                                                 "address": {
                                                     "type": "string"
                                                 },
-                                                "usage": {
+                                                "cpu": {
                                                     "type": "object",
                                                     "required": [
-                                                        "cpu",
-                                                        "memory"
+                                                        "totalCores",
+                                                        "usedCores",
+                                                        "usedPercent",
+                                                        "freeCores",
+                                                        "freePercent"
                                                     ],
                                                     "properties": {
-                                                        "cpu": {
-                                                            "type": "object",
-                                                            "required": [
-                                                                "totalCores",
-                                                                "usedCores",
-                                                                "usedPercent",
-                                                                "freeCores",
-                                                                "freePercent"
-                                                            ],
-                                                            "properties": {
-                                                                "totalCores": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedCores": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedPercent": {
-                                                                    "type": "number"
-                                                                },
-                                                                "freeCores": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "freePercent": {
-                                                                    "type": "number"
-                                                                }
-                                                            }
+                                                        "totalCores": {
+                                                            "type": "integer"
                                                         },
-                                                        "memory": {
-                                                            "type": "object",
-                                                            "required": [
-                                                                "totalMiB",
-                                                                "usedMiB",
-                                                                "usedPercent",
-                                                                "freeMiB",
-                                                                "freePercent"
-                                                            ],
-                                                            "properties": {
-                                                                "totalMiB": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedMiB": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedPercent": {
-                                                                    "type": "number"
-                                                                },
-                                                                "freeMiB": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "freePercent": {
-                                                                    "type": "number"
-                                                                }
-                                                            }
+                                                        "usedCores": {
+                                                            "type": "integer"
+                                                        },
+                                                        "usedPercent": {
+                                                            "type": "number"
+                                                        },
+                                                        "freeCores": {
+                                                            "type": "integer"
+                                                        },
+                                                        "freePercent": {
+                                                            "type": "number"
+                                                        }
+                                                    }
+                                                },
+                                                "memory": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "totalMiB",
+                                                        "usedMiB",
+                                                        "usedPercent",
+                                                        "freeMiB",
+                                                        "freePercent"
+                                                    ],
+                                                    "properties": {
+                                                        "totalMiB": {
+                                                            "type": "integer"
+                                                        },
+                                                        "usedMiB": {
+                                                            "type": "integer"
+                                                        },
+                                                        "usedPercent": {
+                                                            "type": "number"
+                                                        },
+                                                        "freeMiB": {
+                                                            "type": "integer"
+                                                        },
+                                                        "freePercent": {
+                                                            "type": "number"
                                                         }
                                                     }
                                                 }

--- a/api/docs.json
+++ b/api/docs.json
@@ -1705,6 +1705,43 @@
                     },
                     {
                         "$ref": "#/components/parameters/watch"
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                        "example": "2025-01-01T01:00:00+00:00"
+                    },
+                    {
+                        "in": "query",
+                        "name": "stop",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
+                        "example": "2025-01-01T01:00:00+00:00"
+                    },
+                    {
+                        "in": "query",
+                        "name": "past",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1h",
+                                "24h",
+                                "7d",
+                                "14d",
+                                "30d"
+                            ]
+                        },
+                        "description": "The past time of the health history to query, click 'try it out' to see a few options, but can specify with the 's'(second), 'm'(minute), 'h'(hour), and 'd'(day) suffix for other time ranges.",
+                        "example": "1d"
                     }
                 ],
                 "responses": {
@@ -8039,7 +8076,7 @@
                             "examples": {
                                 "example": {
                                     "summary": "Trigger update request",
-                                    "value":  {
+                                    "value": {
                                         "attributes": [
                                             {
                                                 "name": "severity",
@@ -9609,7 +9646,8 @@
                                                 "role",
                                                 "name",
                                                 "address",
-                                                "usage"
+                                                "cpu",
+                                                "memory"
                                             ],
                                             "properties": {
                                                 "role": {
@@ -9621,66 +9659,57 @@
                                                 "address": {
                                                     "type": "string"
                                                 },
-                                                "usage": {
+                                                "cpu": {
                                                     "type": "object",
                                                     "required": [
-                                                        "cpu",
-                                                        "memory"
+                                                        "totalCores",
+                                                        "usedCores",
+                                                        "usedPercent",
+                                                        "freeCores",
+                                                        "freePercent"
                                                     ],
                                                     "properties": {
-                                                        "cpu": {
-                                                            "type": "object",
-                                                            "required": [
-                                                                "totalCores",
-                                                                "usedCores",
-                                                                "usedPercent",
-                                                                "freeCores",
-                                                                "freePercent"
-                                                            ],
-                                                            "properties": {
-                                                                "totalCores": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedCores": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedPercent": {
-                                                                    "type": "number"
-                                                                },
-                                                                "freeCores": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "freePercent": {
-                                                                    "type": "number"
-                                                                }
-                                                            }
+                                                        "totalCores": {
+                                                            "type": "integer"
                                                         },
-                                                        "memory": {
-                                                            "type": "object",
-                                                            "required": [
-                                                                "totalMiB",
-                                                                "usedMiB",
-                                                                "usedPercent",
-                                                                "freeMiB",
-                                                                "freePercent"
-                                                            ],
-                                                            "properties": {
-                                                                "totalMiB": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedMiB": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "usedPercent": {
-                                                                    "type": "number"
-                                                                },
-                                                                "freeMiB": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "freePercent": {
-                                                                    "type": "number"
-                                                                }
-                                                            }
+                                                        "usedCores": {
+                                                            "type": "integer"
+                                                        },
+                                                        "usedPercent": {
+                                                            "type": "number"
+                                                        },
+                                                        "freeCores": {
+                                                            "type": "integer"
+                                                        },
+                                                        "freePercent": {
+                                                            "type": "number"
+                                                        }
+                                                    }
+                                                },
+                                                "memory": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "totalMiB",
+                                                        "usedMiB",
+                                                        "usedPercent",
+                                                        "freeMiB",
+                                                        "freePercent"
+                                                    ],
+                                                    "properties": {
+                                                        "totalMiB": {
+                                                            "type": "integer"
+                                                        },
+                                                        "usedMiB": {
+                                                            "type": "integer"
+                                                        },
+                                                        "usedPercent": {
+                                                            "type": "number"
+                                                        },
+                                                        "freeMiB": {
+                                                            "type": "integer"
+                                                        },
+                                                        "freePercent": {
+                                                            "type": "number"
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

#23 #45 

<br/>

### What this PR does?

- add missed time related parameters for healths api

- correct the wrong schema for metrics summary response

<br/>

### Test results (optional)

1). add missed time related parameters for healths api (start, stop, and past)

<img width="1394" alt="Screenshot 2025-03-11 at 4 10 42 AM" src="https://github.com/user-attachments/assets/2003a931-1d20-44f9-8840-095d79a21a2a" />

<br/>

<br/>

2). correct the wrong schema for metrics summary response

<img width="1365" alt="Screenshot 2025-03-11 at 4 12 26 AM" src="https://github.com/user-attachments/assets/6188778f-54b5-47ce-94b9-6af876cfdaf3" />

