### PR TITLE
feat(login): adjust saml sp to connect ui

### DIFF
--- a/configs/cube-cos-api.yaml.template
+++ b/configs/cube-cos-api.yaml.template
@@ -13,10 +13,9 @@ spec:
       system: /etc/settings.sys
     logoutRedirect: "/api/v1/datacenters"
     keycloak:
-      # host: https://10.32.10.180:10443/auth
       host:
         scheme: "https"
-        ip: "10.32.10.180"
+        ip: ""
         port: 10443
         path: "auth"
         tlsInsecureSkipVerify: true

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/micro/plugins/v5/wrapper/ratelimiter/uber v1.0.2
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/shirou/gopsutil/v4 v4.25.1
-	github.com/slack-go/slack v0.16.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3
@@ -126,6 +125,7 @@ require (
 	github.com/russellhaering/goxmldsig v1.3.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
+	github.com/slack-go/slack v0.16.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,12 +57,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250301163609-add028efa876 h1:DJtDWgvA7gv4VrboZomF4ILzif0LLJL5IoqJfJpCY10=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250301163609-add028efa876/go.mod h1:6cCZmuCoNNRXzn/1PhY1nOS3c28zZHN0SB2tdDNRyZE=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250304044043-de007c560e38 h1:hNWnt/C74y1kuxgI7of5+++3vnDdOaus5ROOVWbtemc=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250304044043-de007c560e38/go.mod h1:6cCZmuCoNNRXzn/1PhY1nOS3c28zZHN0SB2tdDNRyZE=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250304045128-bd1c0ea7233a h1:/GXwZzzPvDak0p3jr5xbWLRHvLZ60CHkXsPSbaIShXg=
-github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250304045128-bd1c0ea7233a/go.mod h1:8k2X7hJJIAOKQ6WOQjjiO56Suq1+y7Z8VMLqU0fOjWw=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250304105712-83df70bfc0d8 h1:OZDYqiKWKch/Qb5Ae0i3pWJCrQa2BmktMNQMJUa3egQ=
 github.com/bigstack-oss/bigstack-dependency-go v0.0.0-20250304105712-83df70bfc0d8/go.mod h1:8k2X7hJJIAOKQ6WOQjjiO56Suq1+y7Z8VMLqU0fOjWw=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/saml"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	adapter "github.com/gwatts/gin-adapter"
 	"github.com/micro/plugins/v5/server/http"
 	log "go-micro.dev/v5/logger"
 	"go-micro.dev/v5/server"
@@ -44,7 +43,7 @@ func newHttpServer() (*server.Server, error) {
 func newRouter() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
-	router.Any("/saml/*any", gin.WrapH(saml.SpAuth))
+	router.Any("/saml/*any", saml.ServeAcs())
 	router.Use(gin.Recovery())
 	router.Use(initReqInfo)
 	router.Use(verifyAuthToken())
@@ -96,7 +95,6 @@ func parseToken(c *gin.Context) string {
 }
 
 func conditionalSaml() gin.HandlerFunc {
-	doSamlAuth := adapter.Wrap(saml.SpAuth.RequireAccount)
 	return func(c *gin.Context) {
 		_, found := c.Get("isTokenValid")
 		if found {
@@ -110,8 +108,9 @@ func conditionalSaml() gin.HandlerFunc {
 			return
 		}
 
+		// start SAML auth
 		c.Set("authType", "saml")
-		doSamlAuth(c)
+		saml.DoSamlAuth(c)
 	}
 }
 

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -108,9 +108,8 @@ func conditionalSaml() gin.HandlerFunc {
 			return
 		}
 
-		// start SAML auth
 		c.Set("authType", "saml")
-		saml.DoSamlAuth(c)
+		saml.AuthRequest(c)
 	}
 }
 

--- a/internal/saml/saml.go
+++ b/internal/saml/saml.go
@@ -127,6 +127,85 @@ func GenServiceProviderMetadataUrl(opts Options) url.URL {
 	}
 }
 
+func ServeAcs() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		err := c.Request.ParseForm()
+		if err != nil {
+			SpAuth.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		err = checkTrackedRequest(c)
+		if err != nil {
+			SpAuth.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		assertion, err := getAssertion(c)
+		if err != nil {
+			SpAuth.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		err = createSession(c, assertion)
+		if err != nil {
+			SpAuth.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		api.SetRedirect(
+			c,
+			SpAuth.ServiceProvider.DefaultRedirectURI,
+		)
+	}
+}
+
+func AuthRequest(c *gin.Context) {
+	session, err := SpAuth.Session.GetSession(c.Request)
+	if session != nil {
+		c.Next()
+		return
+	}
+	if err != samlsp.ErrNoSession {
+		SpAuth.OnError(c.Writer, c.Request, err)
+		c.Abort()
+		return
+	}
+
+	// for the request which isn't verified
+	// if we try to redirect when the original request is the ACS URL
+	// we'll end up in a loop.
+	if isAcsPath(c.Request.URL.Path) {
+		api.SetInternalServerError(c, errors.New("this path should not come here (SAML ACS)"))
+		c.Abort()
+		return
+	}
+
+	authReq, err := genAuthRequest()
+	if err != nil {
+		api.SetInternalServerError(c, err)
+		c.Abort()
+		return
+	}
+
+	relayState, err := genRelayState(c, authReq)
+	if err != nil {
+		api.SetInternalServerError(c, err)
+		c.Abort()
+		return
+	}
+
+	redirectURL, err := genRedirectUrl(authReq, relayState)
+	if err != nil {
+		api.SetInternalServerError(c, err)
+		c.Abort()
+		return
+	}
+
+	api.SetUnauthorized(c, errors.New(redirectURL.String()))
+	c.Abort()
+}
+
 func genRootUrl(opts Options) url.URL {
 	return url.URL{
 		Scheme: opts.ServiceProvider.Host.Scheme,
@@ -134,106 +213,74 @@ func genRootUrl(opts Options) url.URL {
 	}
 }
 
-func ServeAcs() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		m := SpAuth
-		err := c.Request.ParseForm()
-		if err != nil {
-			m.OnError(c.Writer, c.Request, err)
-			return
-		}
-
-		possibleRequestIDs := []string{}
-		if m.ServiceProvider.AllowIDPInitiated {
-			possibleRequestIDs = append(possibleRequestIDs, "")
-		}
-
-		trackedRequests := m.RequestTracker.GetTrackedRequests(c.Request)
-		for _, tr := range trackedRequests {
-			possibleRequestIDs = append(possibleRequestIDs, tr.SAMLRequestID)
-		}
-
-		assertion, err := m.ServiceProvider.ParseResponse(c.Request, possibleRequestIDs)
-		if err != nil {
-			m.OnError(c.Writer, c.Request, err)
-			return
-		}
-
-		if trackedRequestIndex := c.Request.Form.Get("RelayState"); trackedRequestIndex != "" {
-			_, err := m.RequestTracker.GetTrackedRequest(c.Request, trackedRequestIndex)
-			if err != nil {
-				if err != http.ErrNoCookie || !m.ServiceProvider.AllowIDPInitiated {
-					m.OnError(c.Writer, c.Request, err)
-					return
-				}
-			} else {
-				if err := m.RequestTracker.StopTrackingRequest(c.Writer, c.Request, trackedRequestIndex); err != nil {
-					m.OnError(c.Writer, c.Request, err)
-					return
-				}
-			}
-		}
-
-		if err := m.Session.CreateSession(c.Writer, c.Request, assertion); err != nil {
-			m.OnError(c.Writer, c.Request, err)
-			return
-		}
-
-		api.SetRedirect(c, m.ServiceProvider.DefaultRedirectURI)
+func checkTrackedRequest(c *gin.Context) error {
+	trackedReqIndex := c.Request.Form.Get("RelayState")
+	if trackedReqIndex == "" {
+		return nil
 	}
+
+	_, err := SpAuth.RequestTracker.GetTrackedRequest(c.Request, trackedReqIndex)
+	if err == nil {
+		return SpAuth.RequestTracker.StopTrackingRequest(
+			c.Writer,
+			c.Request,
+			trackedReqIndex,
+		)
+	}
+
+	if err != http.ErrNoCookie || !SpAuth.ServiceProvider.AllowIDPInitiated {
+		return err
+	}
+
+	return nil
 }
 
-func DoSamlAuth(c *gin.Context) {
-	m := SpAuth
-	session, err := m.Session.GetSession(c.Request)
-
-	if session != nil {
-		// verified
-		c.Next()
-		return
+func getAssertion(c *gin.Context) (*saml.Assertion, error) {
+	reqIds := []string{}
+	if SpAuth.ServiceProvider.AllowIDPInitiated {
+		reqIds = append(reqIds, "")
 	}
 
-	if err == samlsp.ErrNoSession {
-		// not verified
-
-		// If we try to redirect when the original request is the ACS URL we'll
-		// end up in a loop.
-		if c.Request.URL.Path == m.ServiceProvider.AcsURL.Path {
-			api.SetInternalServerError(
-				c,
-				errors.New("this path should not come here (SAML ACS)"),
-			)
-			c.Abort()
-			return
-		}
-
-		binding := saml.HTTPRedirectBinding
-		bindingLocation := m.ServiceProvider.GetSSOBindingLocation(binding)
-		authReq, err := m.ServiceProvider.MakeAuthenticationRequest(bindingLocation, binding, m.ResponseBinding)
-		if err != nil {
-			api.SetInternalServerError(c, err)
-			c.Abort()
-			return
-		}
-
-		relayState, err := m.RequestTracker.TrackRequest(c.Writer, c.Request, authReq.ID)
-		if err != nil {
-			api.SetInternalServerError(c, err)
-			c.Abort()
-			return
-		}
-
-		redirectURL, err := authReq.Redirect(relayState, &m.ServiceProvider)
-		if err != nil {
-			api.SetInternalServerError(c, err)
-			c.Abort()
-			return
-		}
-		api.SetUnauthorized(c, errors.New(redirectURL.String()))
-		c.Abort()
-		return
+	for _, req := range SpAuth.RequestTracker.GetTrackedRequests(c.Request) {
+		reqIds = append(reqIds, req.SAMLRequestID)
 	}
 
-	m.OnError(c.Writer, c.Request, err)
-	c.Abort()
+	return SpAuth.ServiceProvider.ParseResponse(c.Request, reqIds)
+}
+
+func createSession(c *gin.Context, assertion *saml.Assertion) error {
+	return SpAuth.Session.CreateSession(
+		c.Writer,
+		c.Request,
+		assertion,
+	)
+}
+
+func isAcsPath(path string) bool {
+	return path == SpAuth.ServiceProvider.AcsURL.Path
+}
+
+func genAuthRequest() (*saml.AuthnRequest, error) {
+	binding := saml.HTTPRedirectBinding
+	bindingLocation := SpAuth.ServiceProvider.GetSSOBindingLocation(binding)
+	return SpAuth.ServiceProvider.MakeAuthenticationRequest(
+		bindingLocation,
+		binding,
+		SpAuth.ResponseBinding,
+	)
+}
+
+func genRelayState(c *gin.Context, authReq *saml.AuthnRequest) (string, error) {
+	return SpAuth.RequestTracker.TrackRequest(
+		c.Writer,
+		c.Request,
+		authReq.ID,
+	)
+}
+
+func genRedirectUrl(authReq *saml.AuthnRequest, relayState string) (*url.URL, error) {
+	return authReq.Redirect(
+		relayState,
+		&SpAuth.ServiceProvider,
+	)
 }

--- a/internal/saml/saml.go
+++ b/internal/saml/saml.go
@@ -5,14 +5,17 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
+	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -62,12 +65,13 @@ func NewGlobalAuth(opts Options) error {
 
 	spMetadataUrl := GenServiceProviderMetadataUrl(opts)
 	SpAuth, err = samlsp.New(samlsp.Options{
-		EntityID:    spMetadataUrl.String(),
-		URL:         genRootUrl(opts),
-		Key:         keyPair.PrivateKey.(*rsa.PrivateKey),
-		Certificate: keyPair.Leaf,
-		IDPMetadata: idpMetadata,
-		SignRequest: true,
+		EntityID:           spMetadataUrl.String(),
+		URL:                genRootUrl(opts),
+		DefaultRedirectURI: "/",
+		Key:                keyPair.PrivateKey.(*rsa.PrivateKey),
+		Certificate:        keyPair.Leaf,
+		IDPMetadata:        idpMetadata,
+		SignRequest:        true,
 	})
 	if err != nil {
 		log.Errorf("failed to create saml auth: %v", err)
@@ -128,4 +132,108 @@ func genRootUrl(opts Options) url.URL {
 		Scheme: opts.ServiceProvider.Host.Scheme,
 		Host:   fmt.Sprintf("%s:%d", definition.DataCenterVip, opts.ServiceProvider.Host.Port),
 	}
+}
+
+func ServeAcs() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		m := SpAuth
+		err := c.Request.ParseForm()
+		if err != nil {
+			m.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		possibleRequestIDs := []string{}
+		if m.ServiceProvider.AllowIDPInitiated {
+			possibleRequestIDs = append(possibleRequestIDs, "")
+		}
+
+		trackedRequests := m.RequestTracker.GetTrackedRequests(c.Request)
+		for _, tr := range trackedRequests {
+			possibleRequestIDs = append(possibleRequestIDs, tr.SAMLRequestID)
+		}
+
+		assertion, err := m.ServiceProvider.ParseResponse(c.Request, possibleRequestIDs)
+		if err != nil {
+			m.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		if trackedRequestIndex := c.Request.Form.Get("RelayState"); trackedRequestIndex != "" {
+			_, err := m.RequestTracker.GetTrackedRequest(c.Request, trackedRequestIndex)
+			if err != nil {
+				if err != http.ErrNoCookie || !m.ServiceProvider.AllowIDPInitiated {
+					m.OnError(c.Writer, c.Request, err)
+					return
+				}
+			} else {
+				if err := m.RequestTracker.StopTrackingRequest(c.Writer, c.Request, trackedRequestIndex); err != nil {
+					m.OnError(c.Writer, c.Request, err)
+					return
+				}
+			}
+		}
+
+		if err := m.Session.CreateSession(c.Writer, c.Request, assertion); err != nil {
+			m.OnError(c.Writer, c.Request, err)
+			return
+		}
+
+		api.SetRedirect(c, m.ServiceProvider.DefaultRedirectURI)
+	}
+}
+
+func DoSamlAuth(c *gin.Context) {
+	m := SpAuth
+	session, err := m.Session.GetSession(c.Request)
+
+	if session != nil {
+		// verified
+		c.Next()
+		return
+	}
+
+	if err == samlsp.ErrNoSession {
+		// not verified
+
+		// If we try to redirect when the original request is the ACS URL we'll
+		// end up in a loop.
+		if c.Request.URL.Path == m.ServiceProvider.AcsURL.Path {
+			api.SetInternalServerError(
+				c,
+				errors.New("this path should not come here (SAML ACS)"),
+			)
+			c.Abort()
+			return
+		}
+
+		binding := saml.HTTPRedirectBinding
+		bindingLocation := m.ServiceProvider.GetSSOBindingLocation(binding)
+		authReq, err := m.ServiceProvider.MakeAuthenticationRequest(bindingLocation, binding, m.ResponseBinding)
+		if err != nil {
+			api.SetInternalServerError(c, err)
+			c.Abort()
+			return
+		}
+
+		relayState, err := m.RequestTracker.TrackRequest(c.Writer, c.Request, authReq.ID)
+		if err != nil {
+			api.SetInternalServerError(c, err)
+			c.Abort()
+			return
+		}
+
+		redirectURL, err := authReq.Redirect(relayState, &m.ServiceProvider)
+		if err != nil {
+			api.SetInternalServerError(c, err)
+			c.Abort()
+			return
+		}
+		api.SetUnauthorized(c, errors.New(redirectURL.String()))
+		c.Abort()
+		return
+	}
+
+	m.OnError(c.Writer, c.Request, err)
+	c.Abort()
 }


### PR DESCRIPTION
### What type of PR is this?

- feature

### Which issue(s) this PR fixes?

- Connect the login process between API and UI

### What this PR does?

- Currently, the login process would encounter two obstacles, when accessing a resource with the authentication requirement, the redirect issued by the service provider (samlsp) would be blocked by the browsers due to CORS. The second obstacle is that after finishing login, the redirect URL would be API's resource URI, which would redirect the browser to see JSON outputs.
- To tackle the first issue, I tried upgrading Keycloak to have the option to set "Web Origins" for CORS HTTP headers. However, keycloak does not support "Web Origins" options for SAML clients, only support the option for OIDC clients.
  - https://github.com/keycloak/keycloak/issues/30759
  - Hence, I provided our own implementation to do SAML auth (function saml.DoSamlAuth). The implementation mostly came from the one in `saml/samlsp`, but it would send the redirect URL for Keycloak as payload `msg` back in the 401 response, instead of either directly issuing 302 redirect or responding with the login form.
- To tackle the second issue, I added our own implementation to issue the redirect in function saml.ServeAcs. The implementation is also mostly identical to the one in `saml/samlsp`. However, we only supply the default path `/`, instead of the path pointing to an API resource, leading to JSON.

### Test results (optional)
