### PR TITLE
Add a POST API to request support file creation on a node or multiple nodes

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -9521,7 +9521,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/example-node-0/triggers": {
+        "/api/v1/datacenters/{dataCenter}/triggers": {
             "get": {
                 "operationId": "getTriggers",
                 "tags": [
@@ -9789,7 +9789,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/example-node-0/triggers/{triggerName}": {
+        "/api/v1/datacenters/{dataCenter}/triggers/{triggerName}": {
             "get": {
                 "operationId": "getTrigger",
                 "tags": [
@@ -10169,6 +10169,134 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to request trigger update: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/supportFiles": {
+            "post": {
+                "operationId": "createSupportFiles",
+                "tags": [
+                    "Support Files"
+                ],
+                "summary": "Create one or more support files",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateSupportFilesRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Support file creation request",
+                                    "value": {
+                                        "hosts": [
+                                            "example-node-0"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Support file creation request received",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreateSupportFilesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Support file creation response",
+                                        "value": {
+                                            "code": 202,
+                                            "msg": "support file creation request received",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid host found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to request support file creation: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -13720,6 +13848,39 @@ const docTemplate = `{
                 }
             },
             "UpdateTriggerResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CreateSupportFilesRequest": {
+                "type": "object",
+                "required": [
+                    "hosts"
+                ],
+                "properties": {
+                    "hosts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "CreateSupportFilesResponse": {
                 "type": "object",
                 "required": [
                     "code",

--- a/api/docs.json
+++ b/api/docs.json
@@ -9517,7 +9517,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/example-node-0/triggers": {
+        "/api/v1/datacenters/{dataCenter}/triggers": {
             "get": {
                 "operationId": "getTriggers",
                 "tags": [
@@ -9785,7 +9785,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/example-node-0/triggers/{triggerName}": {
+        "/api/v1/datacenters/{dataCenter}/triggers/{triggerName}": {
             "get": {
                 "operationId": "getTrigger",
                 "tags": [
@@ -10165,6 +10165,134 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to request trigger update: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/supportFiles": {
+            "post": {
+                "operationId": "createSupportFiles",
+                "tags": [
+                    "Support Files"
+                ],
+                "summary": "Create one or more support files",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateSupportFilesRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Support file creation request",
+                                    "value": {
+                                        "hosts": [
+                                            "example-node-0"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Support file creation request received",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreateSupportFilesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Support file creation response",
+                                        "value": {
+                                            "code": 202,
+                                            "msg": "support file creation request received",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid host found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to request support file creation: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -13716,6 +13844,39 @@
                 }
             },
             "UpdateTriggerResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CreateSupportFilesRequest": {
+                "type": "object",
+                "required": [
+                    "hosts"
+                ],
+                "properties": {
+                    "hosts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "CreateSupportFilesResponse": {
                 "type": "object",
                 "required": [
                     "code",

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -51,8 +51,6 @@ func RegisterHandlersToRoles(module string, handlers []Handler, rolesToRegister 
 			ComputeHandlers[module] = handlers
 		case definition.RoleStorage:
 			StorageHandlers[module] = handlers
-		case definition.RoleNetwork:
-			NetworkHandlers[module] = handlers
 		case definition.RoleModerator:
 			ModeratorHandlers[module] = handlers
 		case definition.RoleEdgeCore:
@@ -86,8 +84,6 @@ func GetGroupHandlersByRole(role string) map[string][]Handler {
 		return ComputeHandlers
 	case definition.RoleStorage:
 		return StorageHandlers
-	case definition.RoleNetwork:
-		return NetworkHandlers
 	case definition.RoleControlConverged:
 		return GenControlConvergedHandlers()
 	case definition.RoleModerator:

--- a/internal/api/v1/nodes/helper.go
+++ b/internal/api/v1/nodes/helper.go
@@ -142,10 +142,10 @@ func (h *helper) getNode() (*definition.Node, error) {
 		return node, nil
 	}
 
-	return h.delegateToOtherNode(node)
+	return h.askFromOtherNode(node)
 }
 
-func (h *helper) delegateToOtherNode(node *definition.Node) (*definition.Node, error) {
+func (h *helper) askFromOtherNode(node *definition.Node) (*definition.Node, error) {
 	helper := http.GetGlobalHelper()
 	resp, err := helper.R().
 		SetResult(&api.NodeData{}).

--- a/internal/api/v1/supportfiles/check.go
+++ b/internal/api/v1/supportfiles/check.go
@@ -1,0 +1,1 @@
+package supportfiles

--- a/internal/api/v1/supportfiles/delegate.go
+++ b/internal/api/v1/supportfiles/delegate.go
@@ -14,7 +14,7 @@ var (
 )
 
 func (h *helper) delegateSupportFileReq() {
-	h.SupportFile.Group = v1.TimeLocal()
+	h.SupportFile.Comment = v1.TimeLocal()
 	for _, role := range h.SupportFile.Roles {
 		for _, node := range role.Nodes {
 			h.SupportFile.InitCreateStatus()
@@ -25,7 +25,7 @@ func (h *helper) delegateSupportFileReq() {
 
 			err := h.delegateToOtherNode(node)
 			if err != nil {
-				log.Errorf("failed to delegate %s to %s: %s", h.SupportFile.Name, node.Name, err.Error())
+				log.Errorf("supportFiles: failed to delegate %s to %s: %s", h.SupportFile.Name, node.Name, err.Error())
 			}
 		}
 	}

--- a/internal/api/v1/supportfiles/delegate.go
+++ b/internal/api/v1/supportfiles/delegate.go
@@ -1,0 +1,55 @@
+package supportfiles
+
+import (
+	"errors"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/bigstack-oss/cube-cos-api/internal/operators/v1/supportfiles"
+	log "go-micro.dev/v5/logger"
+)
+
+var (
+	reqQueue = supportfiles.ReqQueue
+)
+
+func (h *helper) delegateSupportFileReq() {
+	h.SupportFile.Group = v1.TimeLocal()
+	for _, role := range h.SupportFile.Roles {
+		for _, node := range role.Nodes {
+			h.SupportFile.InitCreateStatus()
+			if node.IsLocal() {
+				delegateToLocal(h.SupportFile.GenTask(*node))
+				continue
+			}
+
+			err := h.delegateToOtherNode(node)
+			if err != nil {
+				log.Errorf("failed to delegate %s to %s: %s", h.SupportFile.Name, node.Name, err.Error())
+			}
+		}
+	}
+}
+
+func delegateToLocal(supportFile v1.SupportFile) {
+	addReqRecord(supportFile)
+	reqQueue.Add(&supportFile)
+}
+
+func (h *helper) delegateToOtherNode(node *v1.Node) error {
+	url := node.CreateSupportFileUrl(h.SupportFile)
+	body := h.SupportFile.GenTask(*node)
+	http := http.GetGlobalHelper()
+	resp, err := http.R().SetHeader(node.GenAuthHeader()).SetBody(body).Post(url)
+	if err != nil {
+		log.Errorf("failed to create support file %s to %s: %s", h.SupportFile.Name, node.Id, err.Error())
+		return err
+	}
+
+	if resp.IsError() {
+		log.Errorf("failed to create support file %s to %s: %d %s", h.SupportFile.Name, node.Hostname, string(resp.Body()))
+		return errors.New(string(resp.Body()))
+	}
+
+	return nil
+}

--- a/internal/api/v1/supportfiles/handlers.go
+++ b/internal/api/v1/supportfiles/handlers.go
@@ -60,10 +60,11 @@ func createSupportFile(c *gin.Context) {
 		return
 	}
 
+	h.delegateSupportFileReq()
 	api.SetStatusOk(
 		c,
 		"created support file successfully",
-		"",
+		nil,
 	)
 }
 

--- a/internal/api/v1/supportfiles/handlers.go
+++ b/internal/api/v1/supportfiles/handlers.go
@@ -22,7 +22,7 @@ var Handlers = []api.Handler{
 	{
 		Version: api.V1,
 		Method:  "PATCH",
-		Path:    "/supportFiles/task/:id",
+		Path:    "/supportFiles/tasks/:id",
 		Func:    updateSupportFileTask,
 	},
 	{
@@ -61,10 +61,9 @@ func createSupportFile(c *gin.Context) {
 	}
 
 	h.delegateSupportFileReq()
-	api.SetStatusOk(
+	api.SetStatusAccepted(
 		c,
-		"created support file successfully",
-		nil,
+		"support file creation request received",
 	)
 }
 

--- a/internal/api/v1/supportfiles/handlers.go
+++ b/internal/api/v1/supportfiles/handlers.go
@@ -22,8 +22,8 @@ var Handlers = []api.Handler{
 	{
 		Version: api.V1,
 		Method:  "PATCH",
-		Path:    "/supportFiles/:id",
-		Func:    updateSupportFile,
+		Path:    "/supportFiles/task/:id",
+		Func:    updateSupportFileTask,
 	},
 	{
 		Version: api.V1,
@@ -68,7 +68,7 @@ func createSupportFile(c *gin.Context) {
 	)
 }
 
-func updateSupportFile(c *gin.Context) {
+func updateSupportFileTask(c *gin.Context) {
 	h, err := initReqHandler(c, "updateSupportFileTask")
 	if err != nil {
 		log.Infof("supportFiles(%s): failed to init req helper: %v", h.handler, err)

--- a/internal/api/v1/supportfiles/handlers.go
+++ b/internal/api/v1/supportfiles/handlers.go
@@ -1,0 +1,110 @@
+package supportfiles
+
+import (
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
+)
+
+var Handlers = []api.Handler{
+	{
+		Version: api.V1,
+		Method:  "GET",
+		Path:    "/supportFiles",
+		Func:    listSupportFiles,
+	},
+	{
+		Version: api.V1,
+		Method:  "POST",
+		Path:    "/supportFiles",
+		Func:    createSupportFile,
+	},
+	{
+		Version: api.V1,
+		Method:  "PATCH",
+		Path:    "/supportFiles/:id",
+		Func:    updateSupportFile,
+	},
+	{
+		Version: api.V1,
+		Method:  "GET",
+		Path:    "/supportFiles/:id",
+		Func:    getSupportFile,
+	},
+	{
+		Version: api.V1,
+		Method:  "DELETE",
+		Path:    "/supportFiles/:id",
+		Func:    deleteSupportFile,
+	},
+}
+
+func listSupportFiles(c *gin.Context) {
+	h, err := initReqHandler(c, "listSupportFiles")
+	if err != nil {
+		log.Infof("supportFiles(%s): failed to init req helper: %v", h.handler, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"retrieved support files successfully",
+		"",
+	)
+}
+
+func createSupportFile(c *gin.Context) {
+	h, err := initReqHandler(c, "createSupportFile")
+	if err != nil {
+		log.Infof("supportFiles(%s): failed to init req helper: %v", h.handler, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"created support file successfully",
+		"",
+	)
+}
+
+func updateSupportFile(c *gin.Context) {
+	h, err := initReqHandler(c, "updateSupportFileTask")
+	if err != nil {
+		log.Infof("supportFiles(%s): failed to init req helper: %v", h.handler, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"updated support file task successfully",
+		"",
+	)
+}
+
+func getSupportFile(c *gin.Context) {
+	h, err := initReqHandler(c, "getSupportFile")
+	if err != nil {
+		log.Infof("supportFiles(%s): failed to init req helper: %v", h.handler, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"retrieved support file successfully",
+		"",
+	)
+}
+
+func deleteSupportFile(c *gin.Context) {
+	h, err := initReqHandler(c, "deleteSupportFile")
+	if err != nil {
+		log.Infof("supportFiles(%s): failed to init req helper: %v", h.handler, err)
+		return
+	}
+
+	api.SetStatusOk(
+		c,
+		"deleted support file successfully",
+		"",
+	)
+}

--- a/internal/api/v1/supportfiles/helper.go
+++ b/internal/api/v1/supportfiles/helper.go
@@ -12,7 +12,8 @@ type helper struct {
 	handler string
 
 	keyword string
-	hosts   []string
+	v1.SupportFile
+	v1.SupportFileRequest
 	v1.Page
 	v1.Period
 
@@ -42,7 +43,7 @@ func initListHelper(h *helper) (*helper, error) {
 }
 
 func initCreateHelper(h *helper) (*helper, error) {
-	return h, nil
+	return h, h.parseHosts()
 }
 
 func initGetHelper(h *helper) (*helper, error) {

--- a/internal/api/v1/supportfiles/helper.go
+++ b/internal/api/v1/supportfiles/helper.go
@@ -29,10 +29,10 @@ func initReqHandler(c *gin.Context, handler string) (*helper, error) {
 		return initCreateHelper(&h)
 	case "getSupportFile":
 		return initGetHelper(&h)
-	case "updateSupportFile":
-		return initUpdateHelper(&h)
 	case "deleteSupportFile":
 		return initDeleteHelper(&h)
+	case "updateSupportFileTask":
+		return initUpdateHelper(&h)
 	}
 
 	return nil, errors.New("handler not found")

--- a/internal/api/v1/supportfiles/helper.go
+++ b/internal/api/v1/supportfiles/helper.go
@@ -1,0 +1,58 @@
+package supportfiles
+
+import (
+	"errors"
+
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+)
+
+type helper struct {
+	c       *gin.Context
+	handler string
+
+	keyword string
+	hosts   []string
+	v1.Page
+	v1.Period
+
+	watch bool
+}
+
+func initReqHandler(c *gin.Context, handler string) (*helper, error) {
+	h := helper{c: c, handler: handler}
+	switch h.handler {
+	case "listSupportFiles":
+		return initListHelper(&h)
+	case "createSupportFile":
+		return initCreateHelper(&h)
+	case "getSupportFile":
+		return initGetHelper(&h)
+	case "updateSupportFile":
+		return initUpdateHelper(&h)
+	case "deleteSupportFile":
+		return initDeleteHelper(&h)
+	}
+
+	return nil, errors.New("handler not found")
+}
+
+func initListHelper(h *helper) (*helper, error) {
+	return h, nil
+}
+
+func initCreateHelper(h *helper) (*helper, error) {
+	return h, nil
+}
+
+func initGetHelper(h *helper) (*helper, error) {
+	return h, nil
+}
+
+func initUpdateHelper(h *helper) (*helper, error) {
+	return h, nil
+}
+
+func initDeleteHelper(h *helper) (*helper, error) {
+	return h, nil
+}

--- a/internal/api/v1/supportfiles/parse.go
+++ b/internal/api/v1/supportfiles/parse.go
@@ -1,0 +1,11 @@
+package supportfiles
+
+func (h *helper) parseHosts() error {
+	err := h.c.ShouldBindJSON(&h.SupportFileRequest)
+	if err != nil {
+		return err
+	}
+
+	h.SupportFile.SetRoleByHosts(h.SupportFileRequest.Hosts)
+	return nil
+}

--- a/internal/api/v1/supportfiles/record.go
+++ b/internal/api/v1/supportfiles/record.go
@@ -1,0 +1,1 @@
+package supportfiles

--- a/internal/api/v1/supportfiles/record.go
+++ b/internal/api/v1/supportfiles/record.go
@@ -29,10 +29,10 @@ func addReqRecord(supportFile v1.SupportFile) {
 func genUpsertPayload(supportFile v1.SupportFile) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"id":     supportFile.Id,
-			"name":   supportFile.Name,
-			"group":  supportFile.Group,
-			"status": supportFile.Status,
+			"id":      supportFile.Id,
+			"name":    supportFile.Name,
+			"comment": supportFile.Comment,
+			"status":  supportFile.Status,
 		},
 	}
 }

--- a/internal/api/v1/supportfiles/record.go
+++ b/internal/api/v1/supportfiles/record.go
@@ -1,1 +1,38 @@
 package supportfiles
+
+import (
+	cubeMongo "github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	log "go-micro.dev/v5/logger"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func addReqRecord(supportFile v1.SupportFile) {
+	h := cubeMongo.GetGlobalHelper()
+	err := h.UpdateOne(
+		v1.SupportFileDB,
+		v1.SupportFileReqCollection,
+		bson.M{"id": supportFile.Id},
+		genUpsertPayload(supportFile),
+		options.Update().SetUpsert(true),
+	)
+	if err != nil {
+		log.Errorf(
+			"failed to sync tuning record for %s (%s)",
+			supportFile.Name,
+			err.Error(),
+		)
+	}
+}
+
+func genUpsertPayload(supportFile v1.SupportFile) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"id":     supportFile.Id,
+			"name":   supportFile.Name,
+			"group":  supportFile.Group,
+			"status": supportFile.Status,
+		},
+	}
+}

--- a/internal/api/v1/supportfiles/supportfiles.go
+++ b/internal/api/v1/supportfiles/supportfiles.go
@@ -1,0 +1,1 @@
+package supportfiles

--- a/internal/cubecos/cluster.go
+++ b/internal/cubecos/cluster.go
@@ -58,3 +58,7 @@ func GetDataCenterVersion() (string, error) {
 
 	return fmt.Sprintf("%s %s", desc, version), nil
 }
+
+func GetDataCenterNumericVersion() (string, error) {
+	return ReadSettingSys(SysProductVersion)
+}

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -2,11 +2,14 @@ package cubecos
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -45,6 +48,10 @@ func findLastFile(files []os.DirEntry) (string, error) {
 			continue
 		}
 
+		if !isSupportFile(file.Name()) {
+			continue
+		}
+
 		info, err := file.Info()
 		if err != nil {
 			continue
@@ -61,4 +68,9 @@ func findLastFile(files []os.DirEntry) (string, error) {
 	}
 
 	return filepath.Join("/var/support", fileName), nil
+}
+
+func isSupportFile(file string) bool {
+	return strings.HasPrefix(file, fmt.Sprintf("CUBE_%s", v1.DataCenterVersion)) &&
+		strings.HasSuffix(file, fmt.Sprintf("%s.support", v1.Hostname))
 }

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -1,20 +1,27 @@
 package cubecos
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	log "go-micro.dev/v5/logger"
 )
 
-func CreateSupportFile() error {
-	out, err := exec.Command("hex_config", "create_support_file").CombinedOutput()
+func CreateSupportFile(supportFile v1.SupportFile) error {
+	path, err := CreateSupportCommentFile(supportFile.Comment)
+	if err != nil {
+		log.Errorf("supportFile: failed to create support comment file: %s", err.Error())
+		return err
+	}
+
+	out, err := exec.Command("hex_config", "create_support_file", path).CombinedOutput()
 	if err != nil {
 		log.Errorf("supportFile: failed to create support file: %s", string(out))
 		return err
@@ -23,8 +30,25 @@ func CreateSupportFile() error {
 	return nil
 }
 
-func GetNewSupportFile() (string, error) {
-	files, err := os.ReadDir("/var/support")
+func CreateSupportCommentFile(comment string) (string, error) {
+	randomSize := make([]byte, 8)
+	_, err := rand.Read(randomSize)
+	if err != nil {
+		return "", err
+	}
+
+	randomStr := hex.EncodeToString(randomSize)
+	filePath := filepath.Join("/tmp/support-comment-file", randomStr)
+	err = os.WriteFile(filePath, []byte(comment), 0644)
+	if err != nil {
+		return "", err
+	}
+
+	return filePath, nil
+}
+
+func GetSupportFileByComment(comment string) (string, error) {
+	files, err := os.ReadDir(v1.DefaultSupportFileDir)
 	if err != nil {
 		log.Errorf("supportFile: failed to read support file directory: %s", err.Error())
 		return "", err
@@ -36,13 +60,16 @@ func GetNewSupportFile() (string, error) {
 		return "", err
 	}
 
-	return findLastFile(files)
+	file, err := findSupportFile(files, comment)
+	if err != nil {
+		log.Errorf("supportFile: %v", err)
+		return "", err
+	}
+
+	return filepath.Join("/var/support", file.Name()), nil
 }
 
-func findLastFile(files []os.DirEntry) (string, error) {
-	fileName := ""
-	fileTime := time.Time{}
-
+func findSupportFile(files []os.DirEntry, comment string) (os.DirEntry, error) {
 	for _, file := range files {
 		if file.IsDir() {
 			continue
@@ -52,22 +79,17 @@ func findLastFile(files []os.DirEntry) (string, error) {
 			continue
 		}
 
-		info, err := file.Info()
+		content, err := os.ReadFile(filepath.Join(v1.DefaultSupportFileDir, file.Name()))
 		if err != nil {
 			continue
 		}
 
-		if info.ModTime().After(fileTime) {
-			fileTime = info.ModTime()
-			fileName = file.Name()
+		if string(content) == comment {
+			return file, nil
 		}
 	}
 
-	if fileName == "" {
-		return "", errors.New("no support file found")
-	}
-
-	return filepath.Join("/var/support", fileName), nil
+	return nil, errors.New("no support file found")
 }
 
 func isSupportFile(file string) bool {

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -1,0 +1,64 @@
+package cubecos
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	log "go-micro.dev/v5/logger"
+)
+
+func CreateSupportFile() error {
+	out, err := exec.Command("hex_config", "create_support_file").CombinedOutput()
+	if err != nil {
+		log.Errorf("supportFile: failed to create support file: %s", string(out))
+		return err
+	}
+
+	return nil
+}
+
+func GetNewSupportFile() (string, error) {
+	files, err := os.ReadDir("/var/support")
+	if err != nil {
+		log.Errorf("supportFile: failed to read support file directory: %s", err.Error())
+		return "", err
+	}
+
+	if len(files) == 0 {
+		err := errors.New("no support file found")
+		log.Errorf("supportFile: %v", err)
+		return "", err
+	}
+
+	return findLastFile(files)
+}
+
+func findLastFile(files []os.DirEntry) (string, error) {
+	fileName := ""
+	fileTime := time.Time{}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		info, err := file.Info()
+		if err != nil {
+			continue
+		}
+
+		if info.ModTime().After(fileTime) {
+			fileTime = info.ModTime()
+			fileName = file.Name()
+		}
+	}
+
+	if fileName == "" {
+		return "", errors.New("no support file found")
+	}
+
+	return filepath.Join("/var/support", fileName), nil
+}

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -37,8 +37,13 @@ func CreateSupportCommentFile(comment string) (string, error) {
 		return "", err
 	}
 
+	err = os.MkdirAll(v1.DefaultSupportFileTmpDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
 	randomStr := hex.EncodeToString(randomSize)
-	filePath := filepath.Join("/tmp/support-comment-file", randomStr)
+	filePath := filepath.Join(v1.DefaultSupportFileTmpDir, randomStr)
 	err = os.WriteFile(filePath, []byte(comment), 0644)
 	if err != nil {
 		return "", err
@@ -79,7 +84,7 @@ func findSupportFile(files []os.DirEntry, comment string) (os.DirEntry, error) {
 			continue
 		}
 
-		content, err := os.ReadFile(filepath.Join(v1.DefaultSupportFileDir, file.Name()))
+		content, err := GetSupportFileComment(file.Name())
 		if err != nil {
 			continue
 		}
@@ -92,7 +97,17 @@ func findSupportFile(files []os.DirEntry, comment string) (os.DirEntry, error) {
 	return nil, errors.New("no support file found")
 }
 
+func GetSupportFileComment(file string) (string, error) {
+	filePath := filepath.Join(v1.DefaultSupportFileDir, file)
+	out, err := exec.Command("hex_config", "get_support_file_comment", filePath).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}
+
 func isSupportFile(file string) bool {
-	return strings.HasPrefix(file, fmt.Sprintf("CUBE_%s", v1.DataCenterVersion)) &&
+	return strings.HasPrefix(file, fmt.Sprintf("CUBE_%s", v1.DataCenterNumericVersion)) &&
 		strings.HasSuffix(file, fmt.Sprintf("%s.support", v1.Hostname))
 }

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -153,6 +153,14 @@ func (n *Node) PatchTriggerTaskUrl(trigger trigger.Options) string {
 	return u.String()
 }
 
+func (n *Node) CreateSupportFileUrl(supportFile SupportFile) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportfiles", DataCenterName)
+	return u.String()
+}
+
 func (n *Node) PatchSupportFileTaskUrl(supportFile SupportFile) string {
 	u := url.URL{}
 	u.Scheme = n.Protocol

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -17,21 +17,22 @@ const (
 )
 
 var (
-	HostID            string
-	Hostname          string
-	DataCenterName    string
-	DataCenterVersion string
-	DataCenterVip     string
-	ListenIp          string
-	ListenAddr        string
-	ListenPort        int
-	AdvertiseIp       string
-	AdvertiseAddr     string
-	AdvertisePort     int
-	MgmtNet           string
-	MgmtIP            string
-	IsHaEnabled       bool
-	IsGpuEnabled      bool
+	HostID                   string
+	Hostname                 string
+	DataCenterName           string
+	DataCenterVersion        string
+	DataCenterNumericVersion string
+	DataCenterVip            string
+	ListenIp                 string
+	ListenAddr               string
+	ListenPort               int
+	AdvertiseIp              string
+	AdvertiseAddr            string
+	AdvertisePort            int
+	MgmtNet                  string
+	MgmtIP                   string
+	IsHaEnabled              bool
+	IsGpuEnabled             bool
 )
 
 type Node struct {
@@ -157,7 +158,7 @@ func (n *Node) CreateSupportFileUrl(supportFile SupportFile) string {
 	u := url.URL{}
 	u.Scheme = n.Protocol
 	u.Host = n.Address
-	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportfiles", DataCenterName)
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportFiles", DataCenterName)
 	return u.String()
 }
 
@@ -165,7 +166,7 @@ func (n *Node) PatchSupportFileTaskUrl(supportFile SupportFile) string {
 	u := url.URL{}
 	u.Scheme = n.Protocol
 	u.Host = n.Address
-	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportfiles/tasks/%s", DataCenterName, supportFile.Id)
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportFiles/tasks/%s", DataCenterName, supportFile.Id)
 	return u.String()
 }
 

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -153,6 +153,14 @@ func (n *Node) PatchTriggerTaskUrl(trigger trigger.Options) string {
 	return u.String()
 }
 
+func (n *Node) PatchSupportFileTaskUrl(supportFile SupportFile) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportfiles/tasks/%s", DataCenterName, supportFile.Id)
+	return u.String()
+}
+
 func (n *Node) IsLocal() bool {
 	return n.Address == AdvertiseAddr && n.Role == CurrentRole
 }

--- a/internal/definition/v1/roles.go
+++ b/internal/definition/v1/roles.go
@@ -10,7 +10,6 @@ const (
 	RoleControl          = "control"
 	RoleCompute          = "compute"
 	RoleStorage          = "storage"
-	RoleNetwork          = "network"
 	RoleControlConverged = "control-converged"
 	RoleModerator        = "moderator"
 	RoleEdgeCore         = "edge-core"
@@ -18,13 +17,12 @@ const (
 
 var (
 	CurrentRole string
-	Roles       = []string{RoleControl, RoleCompute, RoleStorage, RoleNetwork, RoleControlConverged, RoleModerator, RoleEdgeCore}
+	Roles       = []string{RoleControl, RoleCompute, RoleStorage, RoleControlConverged, RoleModerator, RoleEdgeCore}
 	update      = sync.Mutex{}
 
 	ControlRole          = newControlRole()
 	ComputeRole          = newComputeRole()
 	StorageRole          = newStorageRole()
-	NetworkRole          = newNetworkRole()
 	ControlConvergedRole = newControlConvergeRole()
 	ModeratorRole        = newModeratorRole()
 	EdgeCoreRole         = newEdgeCoreRole()
@@ -33,7 +31,6 @@ var (
 		ControlRole,
 		ComputeRole,
 		StorageRole,
-		NetworkRole,
 		ControlConvergedRole,
 		ModeratorRole,
 		EdgeCoreRole,
@@ -43,7 +40,6 @@ var (
 		ControlRole,
 		ComputeRole,
 		StorageRole,
-		NetworkRole,
 		ControlConvergedRole,
 	}
 
@@ -91,10 +87,6 @@ func newStorageRole() *Role {
 	return &Role{Name: RoleStorage}
 }
 
-func newNetworkRole() *Role {
-	return &Role{Name: RoleNetwork}
-}
-
 func newControlConvergeRole() *Role {
 	return &Role{Name: RoleControlConverged}
 }
@@ -121,10 +113,6 @@ func GetComputeRole() *Role {
 
 func GetStorageRole() *Role {
 	return StorageRole
-}
-
-func GetNetworkRole() *Role {
-	return NetworkRole
 }
 
 func GetControlConvergeRole() *Role {
@@ -215,8 +203,6 @@ func getRole(name string) *Role {
 		return ComputeRole
 	case RoleStorage:
 		return StorageRole
-	case RoleNetwork:
-		return NetworkRole
 	case RoleControlConverged:
 		return ControlConvergedRole
 	case RoleModerator:

--- a/internal/definition/v1/supportfiles.go
+++ b/internal/definition/v1/supportfiles.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	DefaultSupportFileDir    = "/var/support"
 	SupportFiles             = "supportfiles"
 	SupportFileDB            = "supportfiles"
 	SupportFileReqCollection = "requests"
@@ -18,7 +19,7 @@ type SupportFileRequest struct {
 type SupportFile struct {
 	Id          string `json:"id" bson:"id"`
 	Name        string `json:"name" bson:"name"`
-	Group       string `json:"group" bson:"group"`
+	Comment     string `json:"comment" bson:"comment"`
 	Roles       []Role `json:"roles" bson:"roles"`
 	Node        `json:"node" bson:"node"`
 	SizeMiB     float64            `json:"sizeMiB" bson:"sizeMiB"`
@@ -54,10 +55,11 @@ func (s *SupportFile) GenTaskUpdate() SupportFile {
 
 func (s *SupportFile) GenTask(node Node) SupportFile {
 	return SupportFile{
-		Id:     s.Id,
-		Name:   s.Name,
-		Node:   node,
-		Status: s.Status,
+		Id:      s.Id,
+		Name:    s.Name,
+		Comment: s.Comment,
+		Node:    node,
+		Status:  s.Status,
 	}
 }
 

--- a/internal/definition/v1/supportfiles.go
+++ b/internal/definition/v1/supportfiles.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"github.com/bigstack-oss/cube-cos-api/internal/status"
+)
+
+const (
+	SupportFileDB            = "supportfiles"
+	SupportFileReqCollection = "requests"
+)
+
+type SupportFile struct {
+	Id          string         `json:"id"`
+	Name        string         `json:"name"`
+	Roles       []Role         `json:"roles"`
+	SizeMiB     float64        `json:"sizeMiB"`
+	Status      status.Details `json:"status"`
+	Description string         `json:"description"`
+}
+
+func (s *SupportFile) SetError() {
+	s.Status.Current = status.Error
+}
+
+func (s *SupportFile) SetCompleted() {
+	s.Status.Current = status.Completed
+}
+
+func (s *SupportFile) GenTaskUpdate() SupportFile {
+	return SupportFile{
+		Id:     s.Id,
+		Name:   s.Name,
+		Status: s.Status,
+	}
+}

--- a/internal/definition/v1/supportfiles.go
+++ b/internal/definition/v1/supportfiles.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	DefaultSupportFileDir    = "/var/support"
+	DefaultSupportFileTmpDir = "/tmp/support-comment-file"
 	SupportFiles             = "supportfiles"
 	SupportFileDB            = "supportfiles"
 	SupportFileReqCollection = "requests"

--- a/internal/definition/v1/supportfiles.go
+++ b/internal/definition/v1/supportfiles.go
@@ -2,20 +2,29 @@ package v1
 
 import (
 	"github.com/bigstack-oss/cube-cos-api/internal/status"
+	"github.com/google/uuid"
 )
 
 const (
+	SupportFiles             = "supportfiles"
 	SupportFileDB            = "supportfiles"
 	SupportFileReqCollection = "requests"
 )
 
+type SupportFileRequest struct {
+	Hosts []string `json:"hosts"`
+}
+
 type SupportFile struct {
-	Id          string         `json:"id"`
-	Name        string         `json:"name"`
-	Roles       []Role         `json:"roles"`
-	SizeMiB     float64        `json:"sizeMiB"`
-	Status      status.Details `json:"status"`
-	Description string         `json:"description"`
+	Id          string `json:"id" bson:"id"`
+	Name        string `json:"name" bson:"name"`
+	Group       string `json:"group" bson:"group"`
+	Roles       []Role `json:"roles" bson:"roles"`
+	Node        `json:"node" bson:"node"`
+	SizeMiB     float64            `json:"sizeMiB" bson:"sizeMiB"`
+	Url         string             `json:"url" bson:"url"`
+	Status      status.SupportFile `json:"status" bson:"status"`
+	Description string             `json:"description" bson:"description"`
 }
 
 func (s *SupportFile) SetError() {
@@ -26,10 +35,53 @@ func (s *SupportFile) SetCompleted() {
 	s.Status.Current = status.Completed
 }
 
+func (s *SupportFile) InitCreateStatus() {
+	s.Id = uuid.New().String()
+	s.Status = status.SupportFile{
+		Current:   status.Creating,
+		Desired:   status.Create,
+		CreatedAt: TimeLocal(),
+	}
+}
+
 func (s *SupportFile) GenTaskUpdate() SupportFile {
 	return SupportFile{
 		Id:     s.Id,
 		Name:   s.Name,
 		Status: s.Status,
+	}
+}
+
+func (s *SupportFile) GenTask(node Node) SupportFile {
+	return SupportFile{
+		Id:     s.Id,
+		Name:   s.Name,
+		Node:   node,
+		Status: s.Status,
+	}
+}
+
+func (s *SupportFile) SetRoleByHosts(hosts []string) {
+	roleNodeMap := make(map[string][]*Node)
+	for _, host := range hosts {
+		node, err := GetNodeByHostname(host)
+		if err != nil {
+			continue
+		}
+
+		roleNodeMap[node.Role] = append(
+			roleNodeMap[node.Role],
+			node,
+		)
+	}
+
+	for role, nodes := range roleNodeMap {
+		s.Roles = append(
+			s.Roles,
+			Role{
+				Name:  role,
+				Nodes: nodes,
+			},
+		)
 	}
 }

--- a/internal/definition/v1/time.go
+++ b/internal/definition/v1/time.go
@@ -21,6 +21,7 @@ var (
 type Period struct {
 	Start string
 	Stop  string
+	Past  string
 }
 
 func TimeUTC(t time.Time) string {

--- a/internal/operators/v1/supportfiles/record.go
+++ b/internal/operators/v1/supportfiles/record.go
@@ -1,0 +1,50 @@
+package supportfiles
+
+import (
+	"errors"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	log "go-micro.dev/v5/logger"
+)
+
+func (o *Operator) handleExit(supportFile v1.SupportFile, err error) {
+	if err != nil {
+		log.Errorf("supportfiles: failed to %s %s: %s", supportFile.Status.Desired, supportFile.Name, err.Error())
+		supportFile.SetError()
+	} else {
+		log.Infof("supportfiles: %s %s successfully", supportFile.Status.Desired, supportFile.Name)
+		supportFile.SetCompleted()
+	}
+
+	err = o.reportToController(supportFile)
+	if err != nil {
+		return
+	}
+}
+
+func (o *Operator) reportToController(supportFile v1.SupportFile) error {
+	node, err := definition.GetOneOfControllerNode()
+	if err != nil {
+		log.Errorf("supportfiles: failed to get controller nodes: %s", err.Error())
+		return err
+	}
+
+	h := http.GetGlobalHelper()
+	resp, err := h.R().
+		SetHeader(node.GenAuthHeader()).
+		SetBody(supportFile.GenTaskUpdate()).
+		Patch(node.PatchSupportFileTaskUrl(supportFile))
+	if err != nil {
+		log.Errorf("supportfiles: failed to send support file %s to %s: %s", supportFile.Name, node.Hostname, err.Error())
+		return err
+	}
+
+	if resp.IsError() {
+		log.Errorf("supportfiles: failed to send support file %s to %s: %v", supportFile.Name, node.Hostname, string(resp.Body()))
+		return errors.New(string(resp.Body()))
+	}
+
+	return nil
+}

--- a/internal/operators/v1/supportfiles/supportfiles.go
+++ b/internal/operators/v1/supportfiles/supportfiles.go
@@ -1,0 +1,67 @@
+package supportfiles
+
+import (
+	"errors"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/bigstack-oss/cube-cos-api/internal/service"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var (
+	ReqQueue workqueue.Interface
+	module   = "supportfiles"
+)
+
+func init() {
+	ReqQueue = workqueue.New()
+	service.RegisterOperator(module, NewOperator())
+}
+
+type Operator struct {
+	mongo *mongo.Helper
+}
+
+func NewOperator() *Operator {
+	return &Operator{}
+}
+
+func (o *Operator) Name() string {
+	return module
+}
+
+func (o *Operator) Init() error {
+	o.mongo = mongo.GetGlobalHelper()
+	if o.mongo == nil {
+		return errors.New("mongo helper is not initialized")
+	}
+
+	return nil
+}
+
+func (o *Operator) Sync() {
+	req, shutdown := ReqQueue.Get()
+	if shutdown {
+		return
+	}
+
+	supportFile := req.(*v1.SupportFile)
+	err := o.operateReq(*supportFile)
+	o.handleExit(*supportFile, err)
+
+	ReqQueue.Done(req)
+}
+
+func (o *Operator) Stop() {
+	ReqQueue.ShutDown()
+	o.waitForLastTask()
+	o.mongo.Close()
+}
+
+func (o *Operator) waitForLastTask() {
+	for ReqQueue.Len() >= 1 {
+		wait.Seconds(1)
+	}
+}

--- a/internal/operators/v1/supportfiles/sync.go
+++ b/internal/operators/v1/supportfiles/sync.go
@@ -23,13 +23,13 @@ func (o *Operator) operateReq(supportFile v1.SupportFile) error {
 }
 
 func (o *Operator) createSupportFile(supportFile *v1.SupportFile) error {
-	err := cubecos.CreateSupportFile()
+	err := cubecos.CreateSupportFile(*supportFile)
 	if err != nil {
 		log.Errorf("supportfiles: failed to create support file: %s", err.Error())
 		return err
 	}
 
-	supportFile.Name, err = cubecos.GetNewSupportFile()
+	supportFile.Name, err = cubecos.GetSupportFileByComment(supportFile.Comment)
 	if err != nil {
 		log.Errorf("supportfiles: failed to get new support file: %s", err.Error())
 		return err

--- a/internal/operators/v1/supportfiles/sync.go
+++ b/internal/operators/v1/supportfiles/sync.go
@@ -1,0 +1,39 @@
+package supportfiles
+
+import (
+	"fmt"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/bigstack-oss/cube-cos-api/internal/status"
+	log "go-micro.dev/v5/logger"
+)
+
+func (o *Operator) operateReq(supportFile v1.SupportFile) error {
+	switch supportFile.Status.Desired {
+	case status.Create:
+		return o.createSupportFile(&supportFile)
+	}
+
+	return fmt.Errorf(
+		"unknown desired action(%s) for support file(%s)",
+		supportFile.Status.Desired,
+		supportFile.Name,
+	)
+}
+
+func (o *Operator) createSupportFile(supportFile *v1.SupportFile) error {
+	err := cubecos.CreateSupportFile()
+	if err != nil {
+		log.Errorf("supportfiles: failed to create support file: %s", err.Error())
+		return err
+	}
+
+	supportFile.Name, err = cubecos.GetNewSupportFile()
+	if err != nil {
+		log.Errorf("supportfiles: failed to get new support file: %s", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/services"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/settings"
+	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/supportfiles"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/tokens"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/triggers"
 	apitunings "github.com/bigstack-oss/cube-cos-api/internal/api/v1/tunings"
@@ -97,6 +98,17 @@ func initNodeApiHandler() {
 		definition.Triggers,
 		triggers.Handlers,
 		definition.RoleControl,
+	)
+
+	api.RegisterHandlersToRoles(
+		definition.SupportFiles,
+		supportfiles.Handlers,
+		definition.RoleControlConverged,
+		definition.RoleControl,
+		definition.RoleCompute,
+		definition.RoleStorage,
+		definition.RoleEdgeCore,
+		definition.RoleModerator,
 	)
 
 	api.RegisterHandlersToRoles(

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -69,6 +69,12 @@ func initNodeIdentities() error {
 		return err
 	}
 
+	definition.DataCenterNumericVersion, err = cubecos.GetDataCenterNumericVersion()
+	if err != nil {
+		log.Errorf("failed to get data center numeric version: %s", err.Error())
+		return err
+	}
+
 	definition.ListenIp = conf.Opts.Spec.Listen.Local
 	definition.ListenPort = conf.Opts.Spec.Listen.Port
 	definition.ListenAddr = genLocalAddr()

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -10,6 +10,7 @@ const (
 	Delete = "delete"
 	Reset  = "reset"
 
+	Creating             = "creating"
 	Pending              = "pending"
 	Updating             = "updating"
 	Repairing            = "repairing"
@@ -47,6 +48,14 @@ type Tuning struct {
 
 	MaxPendingDuration int  `json:"maxPendingDuration,omitempty" bson:"maxPendingDuration"`
 	IsUpdating         bool `json:"isUpdating" bson:"isUpdating"`
+}
+
+type SupportFile struct {
+	Current string `json:"current,omitempty" bson:"current"`
+	Desired string `json:"desired,omitempty" bson:"desired"`
+
+	CreatedAt  string `json:"createdAt,omitzero" bson:"createdAt"`
+	IsCreating bool   `json:"isCreating" bson:"isCreating"`
 }
 
 func (s *Details) ClearDesired() {


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

#137 

<br/>

### What this PR does?

- support file: add a POST API to create support file on a node or multiple nodes

- support file: temporary use `support file comment info` to grouping the cross-nodes support file which are triggered by the same request
(will check with COS devs to see if it's possible to have better adjustment from COS side)

- api doc: adjust the corresponding schema

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/ca8efe3c-36d5-45fd-b485-8fe79c761c4b

<br/>

2). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/0ad3713a-0d30-41bf-9aeb-6c535afba075


