### PR TITLE
Add Grafana apis for advanced monitoring dashboard forwarding

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2,8 +2,7 @@ package api
 
 import "github.com/swaggo/swag"
 
-const docTemplate = `
-{
+const docTemplate = `{
     "openapi": "3.0.0",
     "info": {
         "description": "",
@@ -10397,6 +10396,476 @@ const docTemplate = `
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to request support file creation: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/hosts/{hostname}": {
+            "get": {
+                "operationId": "fowardToGrafanaHosts",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana hosts dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "hostname",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The hostname of the host to operate",
+                        "example": "example-node-0"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana hosts dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana hosts dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/instances/{instanceId}": {
+            "get": {
+                "operationId": "fowardToGrafanaInstances",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana instances dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "instanceId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The instance ID of the instance to operate",
+                        "example": "example-instance-id"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana instances dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=example-instance-id"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana instances dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/topHosts": {
+            "get": {
+                "operationId": "fowardToGrafanaTopHosts",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana top hosts dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana top hosts dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana top hosts dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/topInstances": {
+            "get": {
+                "operationId": "fowardToGrafanaTopInstances",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana top instances dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana top instances dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana top instances dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/networks": {
+            "get": {
+                "operationId": "fowardToGrafanaNetworks",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana networks dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana networks dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana networks dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/storages": {
+            "get": {
+                "operationId": "fowardToGrafanaStorages",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana storages dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana storages dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana storages dashboard: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -10404,6 +10404,476 @@
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/hosts/{hostname}": {
+            "get": {
+                "operationId": "fowardToGrafanaHosts",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana hosts dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "hostname",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The hostname of the host to operate",
+                        "example": "example-node-0"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana hosts dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana hosts dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/instances/{instanceId}": {
+            "get": {
+                "operationId": "fowardToGrafanaInstances",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana instances dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "instanceId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The instance ID of the instance to operate",
+                        "example": "example-instance-id"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana instances dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=example-instance-id"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana instances dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/topHosts": {
+            "get": {
+                "operationId": "fowardToGrafanaTopHosts",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana top hosts dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana top hosts dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana top hosts dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/topInstances": {
+            "get": {
+                "operationId": "fowardToGrafanaTopInstances",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana top instances dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana top instances dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana top instances dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/networks": {
+            "get": {
+                "operationId": "fowardToGrafanaNetworks",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana networks dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana networks dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana networks dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/grafana/storages": {
+            "get": {
+                "operationId": "fowardToGrafanaStorages",
+                "tags": [
+                    "Grafana"
+                ],
+                "summary": "Forward to Grafana storages dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Forward to Grafana storages dashboard",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to forward Grafana storages dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/configs/cube-cos-api.yaml.template
+++ b/configs/cube-cos-api.yaml.template
@@ -46,6 +46,13 @@ spec:
         source: "file"
         file: /etc/admin-openrc.sh
         enableAutoRenew: true
+    aws:
+      region: auto
+      accessKey: ""
+      secretKey: ""
+      enableStaticCreds: true
+      enableCustomURL: true
+      insecureSkipVerify: true
   store:
     mongodb:
       uri: mongodb://0.0.0.0:27017

--- a/internal/api/v1/grafana/handlers.go
+++ b/internal/api/v1/grafana/handlers.go
@@ -1,0 +1,73 @@
+package grafana
+
+import (
+	"net/http"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	Handlers = []api.Handler{
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/hosts/:hostname",
+			Func:    forwardHostLink,
+		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/instances/:instanceId",
+			Func:    forwardInstanceLink,
+		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/topHosts",
+			Func:    forwardTopHostLink,
+		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/topInstances",
+			Func:    forwardTopInstanceLink,
+		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/networks",
+			Func:    forwardNetworksLink,
+		},
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/storages",
+			Func:    forwardStoragesLink,
+		},
+	}
+)
+
+func forwardHostLink(c *gin.Context) {
+	c.Redirect(http.StatusFound, genHostLink(c))
+}
+
+func forwardInstanceLink(c *gin.Context) {
+	c.Redirect(http.StatusFound, genInstanceLink(c))
+}
+
+func forwardTopHostLink(c *gin.Context) {
+	c.Redirect(http.StatusFound, genTopHostLink())
+}
+
+func forwardTopInstanceLink(c *gin.Context) {
+	c.Redirect(http.StatusFound, genTopInstanceLink())
+}
+
+func forwardNetworksLink(c *gin.Context) {
+	c.Redirect(http.StatusFound, genNetworksLink())
+}
+
+func forwardStoragesLink(c *gin.Context) {
+	c.Redirect(http.StatusFound, genStoragesLink())
+}

--- a/internal/api/v1/grafana/links.go
+++ b/internal/api/v1/grafana/links.go
@@ -1,0 +1,52 @@
+package grafana
+
+import (
+	"fmt"
+
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+)
+
+func genHostLink(c *gin.Context) string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=%s",
+		v1.DataCenterVip,
+		c.Param("hostname"),
+	)
+}
+
+func genInstanceLink(c *gin.Context) string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=%s",
+		v1.DataCenterVip,
+		c.Param("instanceId"),
+	)
+}
+
+func genTopHostLink() string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1",
+		v1.DataCenterVip,
+	)
+}
+
+func genTopInstanceLink() string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin",
+		v1.DataCenterVip,
+	)
+}
+
+func genNetworksLink() string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m",
+		v1.DataCenterVip,
+	)
+}
+
+func genStoragesLink() string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1",
+		v1.DataCenterVip,
+	)
+}

--- a/internal/definition/v1/grafana.go
+++ b/internal/definition/v1/grafana.go
@@ -1,0 +1,5 @@
+package v1
+
+const (
+	Grafana = "grafana"
+)

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/datacenters"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/events"
+	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/grafana"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/healths"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/integrations"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/licenses"
@@ -110,6 +111,13 @@ func initNodeApiHandler() {
 		definition.RoleStorage,
 		definition.RoleEdgeCore,
 		definition.RoleModerator,
+	)
+
+	api.RegisterHandlersToRoles(
+		definition.Grafana,
+		grafana.Handlers,
+		definition.RoleControl,
+		definition.RoleControlConverged,
 	)
 
 	api.RegisterHandlersToRoles(


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

#47 #46 #45 #65 

<br/>

### What this PR does?

- grafana: add the GET apis to forward end-user to

  - Top hosts dashboard

  - Top instances dashboard

  - Host detailed page
 
  - Instance detailed page

  - Network detailed page

  - Storage detailed page

- api doc: adjust the corresponding descriptions for the changes above

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/300836f7-a59e-4407-9764-1275f94c95f4


2). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/81dc0ed7-a6ff-4209-8e5b-6e8db299d52c


