### PR TITLE
Fix the side effect from the SAML CORS implementation 

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -7341,16 +7341,6 @@ const docTemplate = `{
                         "example": "can be any string"
                     },
                     {
-                        "in": "query",
-                        "name": "pageNum",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "The page number of the tunings list",
-                        "example": 1
-                    },
-                    {
                         "$ref": "#/components/parameters/pageSize"
                     },
                     {

--- a/api/docs.json
+++ b/api/docs.json
@@ -7337,16 +7337,6 @@
                         "example": "can be any string"
                     },
                     {
-                        "in": "query",
-                        "name": "pageNum",
-                        "required": false,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "The page number of the tunings list",
-                        "example": 1
-                    },
-                    {
                         "$ref": "#/components/parameters/pageSize"
                     },
                     {

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gophercloud/gophercloud v1.14.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gwatts/gin-adapter v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99/go.mod h1:wJfORR
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gwatts/gin-adapter v1.0.0 h1:TsmmhYTR79/RMTsfYJ2IQvI1F5KZ3ZFJxuQSYEOpyIA=
+github.com/gwatts/gin-adapter v1.0.0/go.mod h1:44AEV+938HsS0mjfXtBDCUZS9vONlF2gwvh8wu4sRYc=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/internal/saml/saml.go
+++ b/internal/saml/saml.go
@@ -163,6 +163,7 @@ func ServeAcs() gin.HandlerFunc {
 func AuthRequest(c *gin.Context) {
 	session, err := SpAuth.Session.GetSession(c.Request)
 	if session != nil {
+		c.Request = c.Request.WithContext(samlsp.ContextWithSession(c.Request.Context(), session))
 		c.Next()
 		return
 	}


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

QA reported: https://github.com/bigstack-oss/cube-cos-ui/issues/177

<br/>

### What this PR does?

Fix the side effect from the SAML CORS implementation.

The symptom is that after the SAML CORS PR, the api can't return the logged in username.

The root cause is that we missed to simulate the logic below from the samlSp source code

<img width="789" alt="Screenshot 2025-03-19 at 4 02 50 AM" src="https://github.com/user-attachments/assets/4289044f-0fe2-40cb-82fa-609627fe2e28" />

<br/>

<br/>

<br/>

after added the code below in the implementation, then we can get the logged in username again

```sh
c.Request = c.Request.WithContext(samlsp.ContextWithSession(c.Request.Context(), session))
``` 


<br/>

### Test results (optional)

1). make sure the mentioned apis can work properly

<img width="956" alt="Screenshot 2025-03-19 at 4 03 05 AM" src="https://github.com/user-attachments/assets/bab00e98-fe63-44fe-ba2b-74aa3c9f7296" />


