### PR TITLE
Chore adjustments for integration, grafana, and health apis

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1752,6 +1752,7 @@ const docTemplate = `{
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "nova",
+                                                    "isRepaired": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -1841,6 +1842,7 @@ const docTemplate = `{
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "cyborg",
+                                                    "isRepaired": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -2065,7 +2067,7 @@ const docTemplate = `{
                                 "haproxy",
                                 "httpd",
                                 "skyline",
-                                "lim",
+                                "api",
                                 "memcache",
                                 "k3s",
                                 "keycloak",
@@ -2156,6 +2158,7 @@ const docTemplate = `{
                                                 "category": "cloud computing",
                                                 "name": "compute",
                                                 "module": "nova",
+                                                "isRepaired": true,
                                                 "history": [
                                                     {
                                                         "time": "2025-02-01T03:00:00+00:00",
@@ -2321,7 +2324,7 @@ const docTemplate = `{
                                 "haproxy",
                                 "httpd",
                                 "skyline",
-                                "lim",
+                                "api",
                                 "memcache",
                                 "k3s",
                                 "keycloak",
@@ -2479,7 +2482,7 @@ const docTemplate = `{
                                                     "isHeaderShortcutEnabled": true,
                                                     "description": "OpenStack Dashboard",
                                                     "isBuiltIn": true,
-                                                    "url": "https://example-datat-center.host/horizon"
+                                                    "url": "https://example-datat-center.host:9999/base/overview"
                                                 },
                                                 {
                                                     "name": "rancher",
@@ -11799,6 +11802,7 @@ const docTemplate = `{
                             "required": [
                                 "category",
                                 "service",
+                                "isRepaired",
                                 "history",
                                 "module"
                             ],
@@ -11808,6 +11812,9 @@ const docTemplate = `{
                                 },
                                 "service": {
                                     "type": "string"
+                                },
+                                "isRepaired": {
+                                    "type": "boolean"
                                 },
                                 "history": {
                                     "type": "array",
@@ -11934,6 +11941,7 @@ const docTemplate = `{
                             "category",
                             "name",
                             "module",
+                            "isRepaired",
                             "history"
                         ],
                         "properties": {
@@ -11945,6 +11953,9 @@ const docTemplate = `{
                             },
                             "module": {
                                 "type": "string"
+                            },
+                            "isRepaired": {
+                                "type": "boolean"
                             },
                             "history": {
                                 "type": "array",

--- a/api/docs.go
+++ b/api/docs.go
@@ -10496,7 +10496,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0"
+                                                "link": "http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top host link successfully",
                                             "status": "ok"
@@ -10593,7 +10594,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/instance?refresh=5m&orgId=1&var-TID=example-instance-id&var-TOP=50&var-TENANT=admin"
+                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/instance?refresh=5m&orgId=1&var-TID=example-instance-id&var-TOP=50&var-TENANT=admin",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top instance link successfully",
                                             "status": "ok"
@@ -10680,7 +10682,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1"
+                                                "link": "http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top host link successfully",
                                             "status": "ok"
@@ -10767,7 +10770,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin"
+                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top instance link successfully",
                                             "status": "ok"
@@ -10854,7 +10858,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m"
+                                                "link": "http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top network link successfully",
                                             "status": "ok"
@@ -10941,7 +10946,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1"
+                                                "link": "http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top storage link successfully",
                                             "status": "ok"
@@ -14723,11 +14729,15 @@ const docTemplate = `{
                     "data": {
                         "type": "object",
                         "required": [
-                            "link"
+                            "link",
+                            "enabled"
                         ],
                         "properties": {
                             "link": {
                                 "type": "string"
+                            },
+                            "enabled": {
+                                "type": "boolean"
                             }
                         }
                     },

--- a/api/docs.json
+++ b/api/docs.json
@@ -1748,6 +1748,7 @@
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "nova",
+                                                    "isRepaired": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -1837,6 +1838,7 @@
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "cyborg",
+                                                    "isRepaired": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -2061,7 +2063,7 @@
                                 "haproxy",
                                 "httpd",
                                 "skyline",
-                                "lim",
+                                "api",
                                 "memcache",
                                 "k3s",
                                 "keycloak",
@@ -2152,6 +2154,7 @@
                                                 "category": "cloud computing",
                                                 "name": "compute",
                                                 "module": "nova",
+                                                "isRepaired": true,
                                                 "history": [
                                                     {
                                                         "time": "2025-02-01T03:00:00+00:00",
@@ -2317,7 +2320,7 @@
                                 "haproxy",
                                 "httpd",
                                 "skyline",
-                                "lim",
+                                "api",
                                 "memcache",
                                 "k3s",
                                 "keycloak",
@@ -2475,7 +2478,7 @@
                                                     "isHeaderShortcutEnabled": true,
                                                     "description": "OpenStack Dashboard",
                                                     "isBuiltIn": true,
-                                                    "url": "https://example-datat-center.host/horizon"
+                                                    "url": "https://example-datat-center.host:9999/base/overview"
                                                 },
                                                 {
                                                     "name": "rancher",
@@ -11795,6 +11798,7 @@
                             "required": [
                                 "category",
                                 "service",
+                                "isRepaired",
                                 "history",
                                 "module"
                             ],
@@ -11804,6 +11808,9 @@
                                 },
                                 "service": {
                                     "type": "string"
+                                },
+                                "isRepaired": {
+                                    "type": "boolean"
                                 },
                                 "history": {
                                     "type": "array",
@@ -11930,6 +11937,7 @@
                             "category",
                             "name",
                             "module",
+                            "isRepaired",
                             "history"
                         ],
                         "properties": {
@@ -11941,6 +11949,9 @@
                             },
                             "module": {
                                 "type": "string"
+                            },
+                            "isRepaired": {
+                                "type": "boolean"
                             },
                             "history": {
                                 "type": "array",

--- a/api/docs.json
+++ b/api/docs.json
@@ -10492,7 +10492,8 @@
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0"
+                                                "link": "http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top host link successfully",
                                             "status": "ok"
@@ -10589,7 +10590,8 @@
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/instance?refresh=5m&orgId=1&var-TID=example-instance-id&var-TOP=50&var-TENANT=admin"
+                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/instance?refresh=5m&orgId=1&var-TID=example-instance-id&var-TOP=50&var-TENANT=admin",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top instance link successfully",
                                             "status": "ok"
@@ -10676,7 +10678,8 @@
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1"
+                                                "link": "http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top host link successfully",
                                             "status": "ok"
@@ -10763,7 +10766,8 @@
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin"
+                                                "link": "http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top instance link successfully",
                                             "status": "ok"
@@ -10850,7 +10854,8 @@
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m"
+                                                "link": "http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top network link successfully",
                                             "status": "ok"
@@ -10937,7 +10942,8 @@
                                         "value": {
                                             "code": 200,
                                             "data": {
-                                                "link": "http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1"
+                                                "link": "http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1",
+                                                "enabled": true
                                             },
                                             "msg": "fetch top storage link successfully",
                                             "status": "ok"
@@ -14719,11 +14725,15 @@
                     "data": {
                         "type": "object",
                         "required": [
-                            "link"
+                            "link",
+                            "enabled"
                         ],
                         "properties": {
                             "link": {
                                 "type": "string"
+                            },
+                            "enabled": {
+                                "type": "boolean"
                             }
                         }
                     },

--- a/internal/api/v1/grafana/handlers.go
+++ b/internal/api/v1/grafana/handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/gin-gonic/gin"
 )
@@ -50,25 +51,67 @@ var (
 )
 
 func forwardHostLink(c *gin.Context) {
-	api.SetStatusOk(c, "fetch host link successfully", v1.Dashboard{Link: genHostLink(c)})
+	api.SetStatusOk(
+		c,
+		"fetch host link successfully",
+		v1.Dashboard{
+			Link:    genHostLink(c),
+			Enabled: true,
+		},
+	)
 }
 
 func forwardInstanceLink(c *gin.Context) {
-	api.SetStatusOk(c, "fetch instance link successfully", v1.Dashboard{Link: genInstanceLink(c)})
+	api.SetStatusOk(
+		c,
+		"fetch instance link successfully",
+		v1.Dashboard{
+			Link:    genInstanceLink(c),
+			Enabled: true,
+		},
+	)
 }
 
 func forwardTopHostLink(c *gin.Context) {
-	api.SetStatusOk(c, "fetch top host link successfully", v1.Dashboard{Link: genTopHostLink()})
+	api.SetStatusOk(
+		c,
+		"fetch top host link successfully",
+		v1.Dashboard{
+			Link:    genTopHostLink(),
+			Enabled: true,
+		},
+	)
 }
 
 func forwardTopInstanceLink(c *gin.Context) {
-	api.SetStatusOk(c, "fetch top instance link successfully", v1.Dashboard{Link: genTopInstanceLink()})
+	api.SetStatusOk(
+		c,
+		"fetch top instance link successfully",
+		v1.Dashboard{
+			Link:    genTopInstanceLink(),
+			Enabled: true,
+		},
+	)
 }
 
 func forwardNetworksLink(c *gin.Context) {
-	api.SetStatusOk(c, "fetch networks link successfully", v1.Dashboard{Link: genNetworksLink()})
+	api.SetStatusOk(
+		c,
+		"fetch networks link successfully",
+		v1.Dashboard{
+			Link:    genNetworksLink(),
+			Enabled: cubecos.IsOvnSFlowEnabled(),
+		},
+	)
 }
 
 func forwardStoragesLink(c *gin.Context) {
-	api.SetStatusOk(c, "fetch storages link successfully", v1.Dashboard{Link: genStoragesLink()})
+	api.SetStatusOk(
+		c,
+		"fetch storages link successfully",
+		v1.Dashboard{
+			Link:    genStoragesLink(),
+			Enabled: true,
+		},
+	)
 }

--- a/internal/api/v1/healths/payload.go
+++ b/internal/api/v1/healths/payload.go
@@ -11,7 +11,7 @@ import (
 )
 
 // M1 TODO: this will be removed once the real data is available in the COS side
-func (h *helper) genFakeHealthSummary() interface{} {
+func (h *helper) genFakeHealthSummary() any {
 	return cubecos.Health{
 		Overall: &cubecos.Overall{
 			Status: status.Details{
@@ -26,16 +26,19 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "link",
-						Status: status.NewOk(),
+						Name:         "link",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("link"),
 					},
 					{
-						Name:   "clock",
-						Status: status.NewOk(),
+						Name:         "clock",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("clock"),
 					},
 					{
-						Name:   "dns",
-						Status: status.NewOk(),
+						Name:         "dns",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("dns"),
 					},
 				},
 			},
@@ -45,12 +48,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "bootstrap",
-						Status: status.NewOk(),
+						Name:         "bootstrap",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("bootstrap"),
 					},
 					{
-						Name:   "license",
-						Status: status.NewOk(),
+						Name:         "license",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("license"),
 					},
 				},
 			},
@@ -60,12 +65,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "etcd",
-						Status: status.NewOk(),
+						Name:         "etcd",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("etcd"),
 					},
 					{
-						Name:   "nodelist",
-						Status: status.NewOk(),
+						Name:         "nodelist",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("nodelist"),
 					},
 				},
 			},
@@ -75,8 +82,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "hacluster",
-						Status: status.NewOk(),
+						Name:         "hacluster",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("hacluster"),
 					},
 				},
 			},
@@ -86,8 +94,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "rabbitmq",
-						Status: status.NewOk(),
+						Name:         "rabbitmq",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("rabbitmq"),
 					},
 				},
 			},
@@ -97,12 +106,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "mysql",
-						Status: status.NewOk(),
+						Name:         "mysql",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("mysql"),
 					},
 					{
-						Name:   "mongodb",
-						Status: status.NewOk(),
+						Name:         "mongodb",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("mongodb"),
 					},
 				},
 			},
@@ -112,12 +123,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "vip",
-						Status: status.NewOk(),
+						Name:         "vip",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("vip"),
 					},
 					{
-						Name:   "haproxy_ha",
-						Status: status.NewOk(),
+						Name:         "haproxy_ha",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("haproxy_ha"),
 					},
 				},
 			},
@@ -127,12 +140,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "k3s",
-						Status: status.NewOk(),
+						Name:         "k3s",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("k3s"),
 					},
 					{
-						Name:   "keycloak",
-						Status: status.NewOk(),
+						Name:         "keycloak",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("keycloak"),
 					},
 				},
 			},
@@ -142,24 +157,34 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "haproxy",
-						Status: status.NewOk(),
+						Name:         "haproxy",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("haproxy"),
 					},
 					{
-						Name:   "httpd",
-						Status: status.NewOk(),
+						Name:         "httpd",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("httpd"),
 					},
 					{
-						Name:   "skyline",
-						Status: status.NewOk(),
+						Name:         "skyline",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("skyline"),
 					},
 					{
-						Name:   "lmi",
-						Status: status.NewOk(),
+						Name:         "lmi",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("lmi"),
 					},
 					{
-						Name:   "memcache",
-						Status: status.NewOk(),
+						Name:         "memcache",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("memcache"),
+					},
+					{
+						Name:         "api",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("api"),
 					},
 				},
 			},
@@ -172,20 +197,24 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				},
 				Modules: []definition.Module{
 					{
-						Name:   "ceph",
-						Status: status.NewOk(),
+						Name:         "ceph",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("ceph"),
 					},
 					{
-						Name:   "ceph_mon",
-						Status: status.NewOk(),
+						Name:         "ceph_mon",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("ceph_mon"),
 					},
 					{
-						Name:   "ceph_mgr",
-						Status: status.NewOk(),
+						Name:         "ceph_mgr",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("ceph_mgr"),
 					},
 					{
-						Name:   "ceph_mds",
-						Status: status.NewOk(),
+						Name:         "ceph_mds",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("ceph_mds"),
 					},
 					{
 						Name: "ceph_osd",
@@ -193,14 +222,17 @@ func (h *helper) genFakeHealthSummary() interface{} {
 							Current:     "ng",
 							Description: "2 osd down",
 						},
+						IsRepairable: cubecos.IsRepairableModule("ceph_osd"),
 					},
 					{
-						Name:   "ceph_rgw",
-						Status: status.NewOk(),
+						Name:         "ceph_rgw",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("ceph_rgw"),
 					},
 					{
-						Name:   "rbd_target",
-						Status: status.NewOk(),
+						Name:         "rbd_target",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("rbd_target"),
 					},
 				},
 			},
@@ -210,12 +242,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "nova",
-						Status: status.NewOk(),
+						Name:         "nova",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("nova"),
 					},
 					{
-						Name:   "cyborg",
-						Status: status.NewOk(),
+						Name:         "cyborg",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("cyborg"),
 					},
 				},
 			},
@@ -225,8 +259,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "neutron",
-						Status: status.NewOk(),
+						Name:         "neutron",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("neutron"),
 					},
 				},
 			},
@@ -236,8 +271,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "octavia",
-						Status: status.NewOk(),
+						Name:         "octavia",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("octavia"),
 					},
 				},
 			},
@@ -247,8 +283,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "cinder",
-						Status: status.NewOk(),
+						Name:         "cinder",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("cinder"),
 					},
 				},
 			},
@@ -258,8 +295,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "manila",
-						Status: status.NewOk(),
+						Name:         "manila",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("manila"),
 					},
 				},
 			},
@@ -269,8 +307,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "swift",
-						Status: status.NewOk(),
+						Name:         "swift",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("swift"),
 					},
 				},
 			},
@@ -280,8 +319,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "ironic",
-						Status: status.NewOk(),
+						Name:         "ironic",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("ironic"),
 					},
 				},
 			},
@@ -291,8 +331,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "designate",
-						Status: status.NewOk(),
+						Name:         "designate",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("designate"),
 					},
 				},
 			},
@@ -302,8 +343,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "rancher",
-						Status: status.NewOk(),
+						Name:         "rancher",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("rancher"),
 					},
 				},
 			},
@@ -313,8 +355,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "heat",
-						Status: status.NewOk(),
+						Name:         "heat",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("heat"),
 					},
 				},
 			},
@@ -324,8 +367,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "masakari",
-						Status: status.NewOk(),
+						Name:         "masakari",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("masakari"),
 					},
 				},
 			},
@@ -335,8 +379,9 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "glance",
-						Status: status.NewOk(),
+						Name:         "glance",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("glance"),
 					},
 				},
 			},
@@ -346,12 +391,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "senlin",
-						Status: status.NewOk(),
+						Name:         "senlin",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("senlin"),
 					},
 					{
-						Name:   "watcher",
-						Status: status.NewOk(),
+						Name:         "watcher",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("watcher"),
 					},
 				},
 			},
@@ -361,12 +408,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "kafka",
-						Status: status.NewOk(),
+						Name:         "kafka",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("kafka"),
 					},
 					{
-						Name:   "zookeeper",
-						Status: status.NewOk(),
+						Name:         "zookeeper",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("zookeeper"),
 					},
 				},
 			},
@@ -376,12 +425,14 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "influxdb",
-						Status: status.NewOk(),
+						Name:         "influxdb",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("influxdb"),
 					},
 					{
-						Name:   "kapacitor",
-						Status: status.NewOk(),
+						Name:         "kapacitor",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("kapacitor"),
 					},
 				},
 			},
@@ -391,16 +442,19 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "monasca",
-						Status: status.NewOk(),
+						Name:         "monasca",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("monasca"),
 					},
 					{
-						Name:   "telegraf",
-						Status: status.NewOk(),
+						Name:         "telegraf",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("telegraf"),
 					},
 					{
-						Name:   "grafana",
-						Status: status.NewOk(),
+						Name:         "grafana",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("grafana"),
 					},
 				},
 			},
@@ -410,24 +464,29 @@ func (h *helper) genFakeHealthSummary() interface{} {
 				Status:   status.NewOk(),
 				Modules: []definition.Module{
 					{
-						Name:   "filebeat",
-						Status: status.NewOk(),
+						Name:         "filebeat",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("filebeat"),
 					},
 					{
-						Name:   "logstash",
-						Status: status.NewOk(),
+						Name:         "logstash",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("logstash"),
 					},
 					{
-						Name:   "opensearch-dashboards",
-						Status: status.NewOk(),
+						Name:         "opensearch-dashboards",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("opensearch-dashboards"),
 					},
 					{
-						Name:   "opensearch",
-						Status: status.NewOk(),
+						Name:         "opensearch",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("opensearch"),
 					},
 					{
-						Name:   "auditbeat",
-						Status: status.NewOk(),
+						Name:         "auditbeat",
+						Status:       status.NewOk(),
+						IsRepairable: cubecos.IsRepairableModule("auditbeat"),
 					},
 				},
 			},
@@ -466,10 +525,11 @@ func (h *helper) genFakeHealthHistoryOfService() []cubecos.HealthStatus {
 		statuses = append(
 			statuses,
 			cubecos.HealthStatus{
-				Category: cubecos.ServiceToCategory[h.service],
-				Name:     h.service,
-				Module:   module.Name,
-				History:  history,
+				Category:     cubecos.ServiceToCategory[h.service],
+				Name:         h.service,
+				Module:       module.Name,
+				IsRepairable: cubecos.IsRepairableModule(module.Name),
+				History:      history,
 			},
 		)
 	}
@@ -503,10 +563,11 @@ func (h *helper) genFakeHealthHistoryOfModule() cubecos.HealthStatus {
 	}
 
 	return cubecos.HealthStatus{
-		Category: cubecos.ServiceToCategory[h.service],
-		Name:     h.service,
-		Module:   h.module,
-		History:  history,
+		Category:     cubecos.ServiceToCategory[h.service],
+		Name:         h.service,
+		Module:       h.module,
+		IsRepairable: cubecos.IsRepairableModule(h.module),
+		History:      history,
 	}
 }
 
@@ -545,12 +606,4 @@ func genForceRepairReq(module definition.Module) *cubecos.Health {
 		},
 	}
 	return h
-}
-
-func convertToLocalTimeZone(t time.Time) string {
-	return fmt.Sprintf(
-		"%s%s",
-		t.String(),
-		definition.LocalTimeZone,
-	)
 }

--- a/internal/cubecos/health.go
+++ b/internal/cubecos/health.go
@@ -17,10 +17,11 @@ type Health struct {
 }
 
 type HealthStatus struct {
-	Category string        `json:"category"`
-	Name     string        `json:"name"`
-	Module   string        `json:"module"`
-	History  []HealthCheck `json:"history"`
+	Category     string        `json:"category"`
+	Name         string        `json:"name"`
+	Module       string        `json:"module"`
+	IsRepairable bool          `json:"isRepairable"`
+	History      []HealthCheck `json:"history"`
 }
 
 type HealthCheck struct {
@@ -89,7 +90,7 @@ func GetUnhealthyServices() ([]definition.Service, error) {
 	for _, service := range OrderSensitiveServices {
 		for _, module := range service.Modules {
 			log.Infof(healthCheck, module.Name)
-			if !module.IsAutoRepairable {
+			if !module.IsRepairable {
 				continue
 			}
 

--- a/internal/cubecos/integrations.go
+++ b/internal/cubecos/integrations.go
@@ -18,9 +18,9 @@ func ListBuiltInIntegrations() []definition.Integration {
 		{
 			Name:                    "openstack",
 			IsHeaderShortcutEnabled: true,
-			Description:             "OpenStack Dashboard",
+			Description:             "OpenStack Skyline Dashboard",
 			IsBuiltIn:               true,
-			Url:                     fmt.Sprintf("https://%s/horizon", definition.DataCenterVip),
+			Url:                     fmt.Sprintf("https://%s:9999/base/overview", definition.DataCenterVip),
 		},
 		{
 			Name:                    "rancher",

--- a/internal/cubecos/modules.go
+++ b/internal/cubecos/modules.go
@@ -8,223 +8,224 @@ var (
 			Name:     "clusterLink",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "link", IsAutoRepairable: false},
-				{Name: "clock", IsAutoRepairable: true},
-				{Name: "dns", IsAutoRepairable: false},
+				{Name: "link", IsRepairable: false},
+				{Name: "clock", IsRepairable: true},
+				{Name: "dns", IsRepairable: false},
 			},
 		},
 		{
 			Name:     "clusterSys",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "bootstrap", IsAutoRepairable: false},
-				{Name: "license", IsAutoRepairable: false},
+				{Name: "bootstrap", IsRepairable: false},
+				{Name: "license", IsRepairable: false},
 			},
 		},
 		{
 			Name:     "clusterSettings",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "etcd", IsAutoRepairable: true},
-				{Name: "nodelist", IsAutoRepairable: false},
+				{Name: "etcd", IsRepairable: true},
+				{Name: "nodelist", IsRepairable: false},
 			},
 		},
 		{
 			Name:     "haCluster",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "hacluster", IsAutoRepairable: true},
+				{Name: "hacluster", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "msgQueue",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "rabbitmq", IsAutoRepairable: true},
+				{Name: "rabbitmq", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "iaasDb",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "mysql", IsAutoRepairable: true},
-				{Name: "mongodb", IsAutoRepairable: true},
+				{Name: "mysql", IsRepairable: true},
+				{Name: "mongodb", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "virtualIp",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "vip", IsAutoRepairable: true},
-				{Name: "haproxy_ha", IsAutoRepairable: true},
+				{Name: "vip", IsRepairable: true},
+				{Name: "haproxy_ha", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "storage",
 			Category: "storage",
 			Modules: []definition.Module{
-				{Name: "ceph", IsAutoRepairable: false},
-				{Name: "ceph_mon", IsAutoRepairable: true},
-				{Name: "ceph_mgr", IsAutoRepairable: true},
-				{Name: "ceph_mds", IsAutoRepairable: true},
-				{Name: "ceph_osd", IsAutoRepairable: true},
-				{Name: "ceph_rgw", IsAutoRepairable: true},
-				{Name: "rbd_target", IsAutoRepairable: false},
+				{Name: "ceph", IsRepairable: false},
+				{Name: "ceph_mon", IsRepairable: true},
+				{Name: "ceph_mgr", IsRepairable: true},
+				{Name: "ceph_mds", IsRepairable: true},
+				{Name: "ceph_osd", IsRepairable: true},
+				{Name: "ceph_rgw", IsRepairable: true},
+				{Name: "rbd_target", IsRepairable: false},
 			},
 		},
 		{
 			Name:     "apiService",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "haproxy", IsAutoRepairable: true},
-				{Name: "httpd", IsAutoRepairable: true},
-				{Name: "skyline", IsAutoRepairable: true},
-				{Name: "lmi", IsAutoRepairable: true},
-				{Name: "memcache", IsAutoRepairable: true},
+				{Name: "haproxy", IsRepairable: true},
+				{Name: "httpd", IsRepairable: true},
+				{Name: "skyline", IsRepairable: true},
+				{Name: "lmi", IsRepairable: true},
+				{Name: "memcache", IsRepairable: true},
+				{Name: "api", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "singleSignOn",
 			Category: "core",
 			Modules: []definition.Module{
-				{Name: "k3s", IsAutoRepairable: true},
-				{Name: "keycloak", IsAutoRepairable: true},
+				{Name: "k3s", IsRepairable: true},
+				{Name: "keycloak", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "network",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "neutron", IsAutoRepairable: true},
+				{Name: "neutron", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "compute",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "nova", IsAutoRepairable: true},
-				{Name: "cyborg", IsAutoRepairable: true},
+				{Name: "nova", IsRepairable: true},
+				{Name: "cyborg", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "bareMetal",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "ironic", IsAutoRepairable: true},
+				{Name: "ironic", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "image",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "glance", IsAutoRepairable: true},
+				{Name: "glance", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "blockStor",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "cinder", IsAutoRepairable: true},
+				{Name: "cinder", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "fileStor",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "manila", IsAutoRepairable: true},
+				{Name: "manila", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "objectStor",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "swift", IsAutoRepairable: false},
+				{Name: "swift", IsRepairable: false},
 			},
 		},
 		{
 			Name:     "orchestration",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "heat", IsAutoRepairable: true},
+				{Name: "heat", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "lbaas",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "octavia", IsAutoRepairable: true},
+				{Name: "octavia", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "dnsaas",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "designate", IsAutoRepairable: true},
+				{Name: "designate", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "k8saas",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "rancher", IsAutoRepairable: false},
+				{Name: "rancher", IsRepairable: false},
 			},
 		},
 		{
 			Name:     "instanceHa",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "masakari", IsAutoRepairable: true},
+				{Name: "masakari", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "businessLogic",
 			Category: "cloud computing",
 			Modules: []definition.Module{
-				{Name: "senlin", IsAutoRepairable: true},
-				{Name: "watcher", IsAutoRepairable: true},
+				{Name: "senlin", IsRepairable: true},
+				{Name: "watcher", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "dataPipe",
 			Category: "infrascope",
 			Modules: []definition.Module{
-				{Name: "zookeeper", IsAutoRepairable: true},
-				{Name: "kafka", IsAutoRepairable: true},
+				{Name: "zookeeper", IsRepairable: true},
+				{Name: "kafka", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "metrics",
 			Category: "infrascope",
 			Modules: []definition.Module{
-				{Name: "monasca", IsAutoRepairable: true},
-				{Name: "telegraf", IsAutoRepairable: true},
-				{Name: "grafana", IsAutoRepairable: true},
+				{Name: "monasca", IsRepairable: true},
+				{Name: "telegraf", IsRepairable: true},
+				{Name: "grafana", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "logAnalytics",
 			Category: "infrascope",
 			Modules: []definition.Module{
-				{Name: "filebeat", IsAutoRepairable: true},
-				{Name: "auditbeat", IsAutoRepairable: true},
-				{Name: "logstash", IsAutoRepairable: true},
-				{Name: "opensearch", IsAutoRepairable: true},
-				{Name: "opensearch-dashboards", IsAutoRepairable: true},
+				{Name: "filebeat", IsRepairable: true},
+				{Name: "auditbeat", IsRepairable: true},
+				{Name: "logstash", IsRepairable: true},
+				{Name: "opensearch", IsRepairable: true},
+				{Name: "opensearch-dashboards", IsRepairable: true},
 			},
 		},
 		{
 			Name:     "notifications",
 			Category: "infrascope",
 			Modules: []definition.Module{
-				{Name: "influxdb", IsAutoRepairable: true},
-				{Name: "kapacitor", IsAutoRepairable: true},
+				{Name: "influxdb", IsRepairable: true},
+				{Name: "kapacitor", IsRepairable: true},
 			},
 		},
 		{
 			Name:               "node",
 			IsInternalViewOnly: true,
 			Modules: []definition.Module{
-				{Name: "node", IsAutoRepairable: false},
+				{Name: "node", IsRepairable: false},
 			},
 		},
 	}
@@ -288,4 +289,13 @@ func IsValidServiceAndModule(service, module string) bool {
 	}
 
 	return false
+}
+
+func IsRepairableModule(module string) bool {
+	m, ok := Modules[module]
+	if !ok {
+		return false
+	}
+
+	return m.IsRepairable
 }

--- a/internal/cubecos/network.go
+++ b/internal/cubecos/network.go
@@ -1,0 +1,19 @@
+package cubecos
+
+import (
+	"os/exec"
+)
+
+func IsOvnSFlowEnabled() bool {
+	_, err := exec.Command("hex_sdk", "ovn_sflow_status").Output()
+	if err == nil {
+		return true
+	}
+
+	result, ok := err.(*exec.ExitError)
+	if !ok {
+		return false
+	}
+
+	return result.ExitCode() == 0
+}

--- a/internal/definition/v1/grafana.go
+++ b/internal/definition/v1/grafana.go
@@ -5,5 +5,6 @@ const (
 )
 
 type Dashboard struct {
-	Link string `json:"link"`
+	Link    string `json:"link"`
+	Enabled bool   `json:"enabled"`
 }

--- a/internal/definition/v1/service.go
+++ b/internal/definition/v1/service.go
@@ -11,10 +11,10 @@ type Service struct {
 }
 
 type Module struct {
-	Name             string          `json:"name" bson:"name"`
-	Status           *status.Details `json:"status,omitempty" bson:"status,omitempty"`
-	IsAutoRepairable bool            `json:"-" bson:"isAutoRepairable"`
-	Description      string          `json:"description,omitempty" bson:"description"`
+	Name         string          `json:"name" bson:"name"`
+	Status       *status.Details `json:"status,omitempty" bson:"status,omitempty"`
+	IsRepairable bool            `json:"-" bson:"isRepairable"`
+	Description  string          `json:"description,omitempty" bson:"description"`
 }
 
 func (s Service) CopyModuleEmptyStruct() Service {


### PR DESCRIPTION
### What type of PR is this?

Chore

<br/>

### Which issue(s) this PR fixes?

#21 #23 #37 

<br/>

### What this PR does?

- healths: add a new field `isRepairable` in the module schema, so that end-user will know the module can't be repaired by api.

- integrations: change the default openstack dashboard from horizon to `skyline`

- grafana: add a new field `enabled` to indicate the dashboard is usable or not, also integrate the network dashboard with ovn sflow's status

- adjust the corresponding doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/e60b07e9-777e-4935-ad3f-7ed68ab51d84


2). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/67d0b16c-8e7c-458c-94af-d92e26f19e93


