### PR TITLE
Fix the incorrect 'isRepaired' schema to 'isRepairable' in the api doc

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1752,7 +1752,7 @@ const docTemplate = `{
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "nova",
-                                                    "isRepaired": true,
+                                                    "isRepairable": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -1842,7 +1842,7 @@ const docTemplate = `{
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "cyborg",
-                                                    "isRepaired": true,
+                                                    "isRepairable": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -2158,7 +2158,7 @@ const docTemplate = `{
                                                 "category": "cloud computing",
                                                 "name": "compute",
                                                 "module": "nova",
-                                                "isRepaired": true,
+                                                "isRepairable": true,
                                                 "history": [
                                                     {
                                                         "time": "2025-02-01T03:00:00+00:00",
@@ -11913,7 +11913,7 @@ const docTemplate = `{
                             "required": [
                                 "category",
                                 "service",
-                                "isRepaired",
+                                "isRepairable",
                                 "history",
                                 "module"
                             ],
@@ -11924,7 +11924,7 @@ const docTemplate = `{
                                 "service": {
                                     "type": "string"
                                 },
-                                "isRepaired": {
+                                "isRepairable": {
                                     "type": "boolean"
                                 },
                                 "history": {
@@ -12052,7 +12052,7 @@ const docTemplate = `{
                             "category",
                             "name",
                             "module",
-                            "isRepaired",
+                            "isRepairable",
                             "history"
                         ],
                         "properties": {
@@ -12065,7 +12065,7 @@ const docTemplate = `{
                             "module": {
                                 "type": "string"
                             },
-                            "isRepaired": {
+                            "isRepairable": {
                                 "type": "boolean"
                             },
                             "history": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -1748,7 +1748,7 @@
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "nova",
-                                                    "isRepaired": true,
+                                                    "isRepairable": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -1838,7 +1838,7 @@
                                                     "category": "cloud computing",
                                                     "service": "compute",
                                                     "module": "cyborg",
-                                                    "isRepaired": true,
+                                                    "isRepairable": true,
                                                     "history": [
                                                         {
                                                             "time": "2025-02-15T08:44:36+00:00",
@@ -2154,7 +2154,7 @@
                                                 "category": "cloud computing",
                                                 "name": "compute",
                                                 "module": "nova",
-                                                "isRepaired": true,
+                                                "isRepairable": true,
                                                 "history": [
                                                     {
                                                         "time": "2025-02-01T03:00:00+00:00",
@@ -11909,7 +11909,7 @@
                             "required": [
                                 "category",
                                 "service",
-                                "isRepaired",
+                                "isRepairable",
                                 "history",
                                 "module"
                             ],
@@ -11920,7 +11920,7 @@
                                 "service": {
                                     "type": "string"
                                 },
-                                "isRepaired": {
+                                "isRepairable": {
                                     "type": "boolean"
                                 },
                                 "history": {
@@ -12048,7 +12048,7 @@
                             "category",
                             "name",
                             "module",
-                            "isRepaired",
+                            "isRepairable",
                             "history"
                         ],
                         "properties": {
@@ -12061,7 +12061,7 @@
                             "module": {
                                 "type": "string"
                             },
-                            "isRepaired": {
+                            "isRepairable": {
                                 "type": "boolean"
                             },
                             "history": {


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

#23 

<br/>

### What this PR does?

- fix the incorrect 'isRepaired' schema to 'isRepairable' in the api doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

<img width="1430" alt="Screenshot 2025-03-23 at 2 59 44 PM" src="https://github.com/user-attachments/assets/cd7cfa04-82d2-4e7e-9144-7f2697637c85" />
<img width="1445" alt="Screenshot 2025-03-23 at 2 59 51 PM" src="https://github.com/user-attachments/assets/881125dd-c70d-40af-af1a-28bc1f271b3c" />

