### PR TITLE
Adjust a GET API to fetch cpu/memory usage time series from a single host

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -712,24 +712,10 @@ const docTemplate = `{
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "$ref": "#/components/parameters/pageSize"
@@ -831,24 +817,10 @@ const docTemplate = `{
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     }
                 ],
                 "responses": {
@@ -1314,24 +1286,10 @@ const docTemplate = `{
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "in": "query",
@@ -1697,24 +1655,10 @@ const docTemplate = `{
                         "$ref": "#/components/parameters/watch"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "in": "query",
@@ -2118,24 +2062,10 @@ const docTemplate = `{
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "$ref": "#/components/parameters/watch"
@@ -3070,7 +3000,7 @@ const docTemplate = `{
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "failed to fetch nodes: internal server error"
+                                            "example": "failed to fetch metrics: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -3096,75 +3026,19 @@ const docTemplate = `{
                         "$ref": "#/components/parameters/dataCenter"
                     },
                     {
-                        "in": "path",
-                        "name": "metricType",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "cpuUsage",
-                                "memoryUsage",
-                                "diskUsage",
-                                "diskBandwidth",
-                                "diskIops",
-                                "diskLatency",
-                                "diskReadIops",
-                                "diskWriteIops",
-                                "networkTrafficIn",
-                                "networkTrafficOut"
-                            ]
-                        },
-                        "description": "The type of metric to query, the value can be 'cpuUsage', 'memoryUsage', 'diskUsage', 'diskBandwidth', 'diskIops', 'diskLatency', 'diskReadIops', 'diskWriteIops', 'networkTrafficIn', or 'networkTrafficOut'.",
-                        "example": 1
+                        "$ref": "#/components/parameters/metricType"
                     },
                     {
-                        "in": "path",
-                        "name": "viewType",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "summary",
-                                "history",
-                                "rank"
-                            ]
-                        },
-                        "description": "The type of view to query, the value can be only 'summary', 'history', or 'rank'.",
-                        "example": 1
+                        "$ref": "#/components/parameters/viewType"
                     },
                     {
-                        "in": "path",
-                        "name": "entityType",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "hosts",
-                                "vms"
-                            ]
-                        },
-                        "description": "The type of entity to query, the value can be 'hosts' or 'vms'",
-                        "example": "hosts"
+                        "$ref": "#/components/parameters/entityType"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "$ref": "#/components/parameters/watch"
@@ -4078,6 +3952,185 @@ const docTemplate = `{
                                                     }
                                                 ]
                                             },
+                                            "msg": "fetch metrics successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "metricType should be cpuUsage, memoryUsage, diskUsage, diskBandwidth, diskIops, diskLatency, diskReadIops, diskWriteIops, networkTrafficIn, or networkTrafficOut"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch metrics: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/metrics/{metricType}/{viewType}/{entityType}/{entityId or Name}": {
+            "get": {
+                "operationId": "getMetricByHostOrVm",
+                "tags": [
+                    "Metrics"
+                ],
+                "summary": "Retrieve the various metrics with different view from single host or single vm",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/metricType"
+                    },
+                    {
+                        "$ref": "#/components/parameters/viewType"
+                    },
+                    {
+                        "$ref": "#/components/parameters/entityType"
+                    },
+                    {
+                        "in": "path",
+                        "name": "entityId or Name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The id or name of the entity to query",
+                        "example": "example-node-0"
+                    },
+                    {
+                        "in": "query",
+                        "name": "past",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1h",
+                                "24h",
+                                "7d",
+                                "14d"
+                            ]
+                        },
+                        "description": "The past time of the health history to query, click 'try it out' to see a few options, but can specify with the 's'(second), 'm'(minute), 'h'(hour), and 'd'(day) suffix for other time ranges.",
+                        "example": "1d"
+                    },
+                    {
+                        "$ref": "#/components/parameters/start"
+                    },
+                    {
+                        "$ref": "#/components/parameters/stop"
+                    },
+                    {
+                        "$ref": "#/components/parameters/watch"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the various metrics with different view from single host or single vm",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/GetCpuUsageHistoryOfHostResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/GetMemoryUsageHistoryOfHostResponse"
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Cpu usage history of host",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "time": "2025-03-24T09:39:00+08:00",
+                                                    "value": 10.9059
+                                                },
+                                                {
+                                                    "time": "2025-03-24T09:40:00+08:00",
+                                                    "value": 10.5089
+                                                },
+                                                {
+                                                    "time": "2025-03-24T09:41:00+08:00",
+                                                    "value": 15.3512
+                                                },
+                                                {
+                                                    "time": "2025-03-24T09:42:00+08:00",
+                                                    "value": 12.3685
+                                                }
+                                            ],
+                                            "msg": "fetch metrics successfully",
+                                            "status": "ok"
+                                        }
+                                    },
+                                    "example2": {
+                                        "summary": "Memory usage history of host",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "time": "2025-03-24T07:06:00+08:00",
+                                                    "value": 55.9796
+                                                },
+                                                {
+                                                    "time": "2025-03-24T07:07:00+08:00",
+                                                    "value": 55.9997
+                                                },
+                                                {
+                                                    "time": "2025-03-24T07:08:00+08:00",
+                                                    "value": 55.9884
+                                                },
+                                                {
+                                                    "time": "2025-03-24T07:09:00+08:00",
+                                                    "value": 55.9449
+                                                }
+                                            ],
                                             "msg": "fetch metrics successfully",
                                             "status": "ok"
                                         }
@@ -11174,6 +11227,77 @@ const docTemplate = `{
                 },
                 "description": "The keyword to search, can be any string",
                 "example": "example-keyword"
+            },
+            "metricType": {
+                "in": "path",
+                "name": "metricType",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "cpuUsage",
+                        "memoryUsage",
+                        "diskUsage",
+                        "diskBandwidth",
+                        "diskIops",
+                        "diskLatency",
+                        "diskReadIops",
+                        "diskWriteIops",
+                        "networkTrafficIn",
+                        "networkTrafficOut"
+                    ]
+                },
+                "description": "The type of metric to query, the value can be 'cpuUsage', 'memoryUsage', 'diskUsage', 'diskBandwidth', 'diskIops', 'diskLatency', 'diskReadIops', 'diskWriteIops', 'networkTrafficIn', or 'networkTrafficOut'.",
+                "example": 1
+            },
+            "viewType": {
+                "in": "path",
+                "name": "viewType",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "summary",
+                        "history",
+                        "rank"
+                    ]
+                },
+                "description": "The type of view to query, the value can be only 'summary', 'history', or 'rank'.",
+                "example": 1
+            },
+            "entityType": {
+                "in": "path",
+                "name": "entityType",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "hosts",
+                        "vms"
+                    ]
+                },
+                "description": "The type of entity to query, the value can be 'hosts' or 'vms'",
+                "example": "hosts"
+            },
+            "start": {
+                "in": "query",
+                "name": "start",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                "example": "2025-01-01T01:00:00+00:00"
+            },
+            "stop": {
+                "in": "query",
+                "name": "stop",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
+                "example": "2025-01-01T01:00:00+00:00"
             }
         },
         "schemas": {
@@ -12825,6 +12949,52 @@ const docTemplate = `{
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "GetCpuUsageHistoryOfHostResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/TimeValuePair"
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "GetMemoryUsageHistoryOfHostResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/TimeValuePair"
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
                     }
                 }
             },
@@ -15586,6 +15756,22 @@ const docTemplate = `{
                                 "type": "boolean"
                             }
                         }
+                    }
+                }
+            },
+            "TimeValuePair": {
+                "type": "object",
+                "required": [
+                    "time",
+                    "value"
+                ],
+                "properties": {
+                    "time": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "value": {
+                        "type": "number"
                     }
                 }
             }

--- a/api/docs.json
+++ b/api/docs.json
@@ -708,24 +708,10 @@
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "$ref": "#/components/parameters/pageSize"
@@ -827,24 +813,10 @@
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     }
                 ],
                 "responses": {
@@ -1310,24 +1282,10 @@
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "in": "query",
@@ -1693,24 +1651,10 @@
                         "$ref": "#/components/parameters/watch"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "in": "query",
@@ -2114,24 +2058,10 @@
                         "example": "1d"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the health history to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the health history to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "$ref": "#/components/parameters/watch"
@@ -3066,7 +2996,7 @@
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "failed to fetch nodes: internal server error"
+                                            "example": "failed to fetch metrics: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -3092,75 +3022,19 @@
                         "$ref": "#/components/parameters/dataCenter"
                     },
                     {
-                        "in": "path",
-                        "name": "metricType",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "cpuUsage",
-                                "memoryUsage",
-                                "diskUsage",
-                                "diskBandwidth",
-                                "diskIops",
-                                "diskLatency",
-                                "diskReadIops",
-                                "diskWriteIops",
-                                "networkTrafficIn",
-                                "networkTrafficOut"
-                            ]
-                        },
-                        "description": "The type of metric to query, the value can be 'cpuUsage', 'memoryUsage', 'diskUsage', 'diskBandwidth', 'diskIops', 'diskLatency', 'diskReadIops', 'diskWriteIops', 'networkTrafficIn', or 'networkTrafficOut'.",
-                        "example": 1
+                        "$ref": "#/components/parameters/metricType"
                     },
                     {
-                        "in": "path",
-                        "name": "viewType",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "summary",
-                                "history",
-                                "rank"
-                            ]
-                        },
-                        "description": "The type of view to query, the value can be only 'summary', 'history', or 'rank'.",
-                        "example": 1
+                        "$ref": "#/components/parameters/viewType"
                     },
                     {
-                        "in": "path",
-                        "name": "entityType",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "hosts",
-                                "vms"
-                            ]
-                        },
-                        "description": "The type of entity to query, the value can be 'hosts' or 'vms'",
-                        "example": "hosts"
+                        "$ref": "#/components/parameters/entityType"
                     },
                     {
-                        "in": "query",
-                        "name": "start",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/start"
                     },
                     {
-                        "in": "query",
-                        "name": "stop",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
-                        "example": "2025-01-01T01:00:00+00:00"
+                        "$ref": "#/components/parameters/stop"
                     },
                     {
                         "$ref": "#/components/parameters/watch"
@@ -4074,6 +3948,185 @@
                                                     }
                                                 ]
                                             },
+                                            "msg": "fetch metrics successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "metricType should be cpuUsage, memoryUsage, diskUsage, diskBandwidth, diskIops, diskLatency, diskReadIops, diskWriteIops, networkTrafficIn, or networkTrafficOut"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch metrics: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/metrics/{metricType}/{viewType}/{entityType}/{entityId or Name}": {
+            "get": {
+                "operationId": "getMetricByHostOrVm",
+                "tags": [
+                    "Metrics"
+                ],
+                "summary": "Retrieve the various metrics with different view from single host or single vm",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/metricType"
+                    },
+                    {
+                        "$ref": "#/components/parameters/viewType"
+                    },
+                    {
+                        "$ref": "#/components/parameters/entityType"
+                    },
+                    {
+                        "in": "path",
+                        "name": "entityId or Name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The id or name of the entity to query",
+                        "example": "example-node-0"
+                    },
+                    {
+                        "in": "query",
+                        "name": "past",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1h",
+                                "24h",
+                                "7d",
+                                "14d"
+                            ]
+                        },
+                        "description": "The past time of the health history to query, click 'try it out' to see a few options, but can specify with the 's'(second), 'm'(minute), 'h'(hour), and 'd'(day) suffix for other time ranges.",
+                        "example": "1d"
+                    },
+                    {
+                        "$ref": "#/components/parameters/start"
+                    },
+                    {
+                        "$ref": "#/components/parameters/stop"
+                    },
+                    {
+                        "$ref": "#/components/parameters/watch"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the various metrics with different view from single host or single vm",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/GetCpuUsageHistoryOfHostResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/GetMemoryUsageHistoryOfHostResponse"
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Cpu usage history of host",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "time": "2025-03-24T09:39:00+08:00",
+                                                    "value": 10.9059
+                                                },
+                                                {
+                                                    "time": "2025-03-24T09:40:00+08:00",
+                                                    "value": 10.5089
+                                                },
+                                                {
+                                                    "time": "2025-03-24T09:41:00+08:00",
+                                                    "value": 15.3512
+                                                },
+                                                {
+                                                    "time": "2025-03-24T09:42:00+08:00",
+                                                    "value": 12.3685
+                                                }
+                                            ],
+                                            "msg": "fetch metrics successfully",
+                                            "status": "ok"
+                                        }
+                                    },
+                                    "example2": {
+                                        "summary": "Memory usage history of host",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "time": "2025-03-24T07:06:00+08:00",
+                                                    "value": 55.9796
+                                                },
+                                                {
+                                                    "time": "2025-03-24T07:07:00+08:00",
+                                                    "value": 55.9997
+                                                },
+                                                {
+                                                    "time": "2025-03-24T07:08:00+08:00",
+                                                    "value": 55.9884
+                                                },
+                                                {
+                                                    "time": "2025-03-24T07:09:00+08:00",
+                                                    "value": 55.9449
+                                                }
+                                            ],
                                             "msg": "fetch metrics successfully",
                                             "status": "ok"
                                         }
@@ -11170,6 +11223,77 @@
                 },
                 "description": "The keyword to search, can be any string",
                 "example": "example-keyword"
+            },
+            "metricType": {
+                "in": "path",
+                "name": "metricType",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "cpuUsage",
+                        "memoryUsage",
+                        "diskUsage",
+                        "diskBandwidth",
+                        "diskIops",
+                        "diskLatency",
+                        "diskReadIops",
+                        "diskWriteIops",
+                        "networkTrafficIn",
+                        "networkTrafficOut"
+                    ]
+                },
+                "description": "The type of metric to query, the value can be 'cpuUsage', 'memoryUsage', 'diskUsage', 'diskBandwidth', 'diskIops', 'diskLatency', 'diskReadIops', 'diskWriteIops', 'networkTrafficIn', or 'networkTrafficOut'.",
+                "example": 1
+            },
+            "viewType": {
+                "in": "path",
+                "name": "viewType",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "summary",
+                        "history",
+                        "rank"
+                    ]
+                },
+                "description": "The type of view to query, the value can be only 'summary', 'history', or 'rank'.",
+                "example": 1
+            },
+            "entityType": {
+                "in": "path",
+                "name": "entityType",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "hosts",
+                        "vms"
+                    ]
+                },
+                "description": "The type of entity to query, the value can be 'hosts' or 'vms'",
+                "example": "hosts"
+            },
+            "start": {
+                "in": "query",
+                "name": "start",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The start time of the event to query, the value should be in RFC3339 format (default is 24 hours ago).",
+                "example": "2025-01-01T01:00:00+00:00"
+            },
+            "stop": {
+                "in": "query",
+                "name": "stop",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The end time of the event to query, the value should be in RFC3339 format (default is now).",
+                "example": "2025-01-01T01:00:00+00:00"
             }
         },
         "schemas": {
@@ -12821,6 +12945,52 @@
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "GetCpuUsageHistoryOfHostResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/TimeValuePair"
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "GetMemoryUsageHistoryOfHostResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/TimeValuePair"
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
                     }
                 }
             },
@@ -15582,6 +15752,22 @@
                                 "type": "boolean"
                             }
                         }
+                    }
+                }
+            },
+            "TimeValuePair": {
+                "type": "object",
+                "required": [
+                    "time",
+                    "value"
+                ],
+                "properties": {
+                    "time": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "value": {
+                        "type": "number"
                     }
                 }
             }

--- a/internal/api/v1/events/resp.go
+++ b/internal/api/v1/events/resp.go
@@ -3,7 +3,7 @@ package events
 import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 
 type data struct {
-	Events            interface{} `json:"events"`
+	Events            any `json:"events"`
 	*definition.Page  `json:"page,omitempty"`
 	*definition.Limit `json:"limit,omitempty"`
 }

--- a/internal/api/v1/healths/watch.go
+++ b/internal/api/v1/healths/watch.go
@@ -14,7 +14,7 @@ import (
 	json "github.com/json-iterator/go"
 )
 
-type dataChan chan interface{}
+type dataChan chan any
 
 type watcher struct {
 	helper
@@ -54,7 +54,7 @@ func streamHealth() {
 	}
 }
 
-func streamHealthByHandlerType(h *helper) (interface{}, error) {
+func streamHealthByHandlerType(h *helper) (any, error) {
 	switch h.handler {
 	case "getHealthSummary":
 		return h.genFakeHealthSummary(), nil
@@ -67,7 +67,7 @@ func streamHealthByHandlerType(h *helper) (interface{}, error) {
 	return nil, errors.New("no internal function supported")
 }
 
-func watchHealth(h *helper, health interface{}) {
+func watchHealth(h *helper, health any) {
 	setChunkedTransfer(h.c)
 	flusher, ok := h.c.Writer.(http.Flusher)
 	if !ok {
@@ -108,7 +108,7 @@ func removeWatcher(watcherToRemove watcher) {
 	}
 }
 
-func sendFirstHealth(c *gin.Context, flusher http.Flusher, health interface{}) {
+func sendFirstHealth(c *gin.Context, flusher http.Flusher, health any) {
 	c.Writer.Write(streamingResp(health))
 	c.Writer.Write([]byte("\n"))
 	flusher.Flush()
@@ -129,7 +129,7 @@ func streamingHealth(c *gin.Context, flusher http.Flusher, watcher watcher) {
 	}
 }
 
-func streamingResp(health interface{}) []byte {
+func streamingResp(health any) []byte {
 	b, err := json.Marshal(gin.H{
 		"code":   http.StatusOK,
 		"status": "ok",

--- a/internal/api/v1/metrics/cpu.go
+++ b/internal/api/v1/metrics/cpu.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 )
 
-func (h *helper) getCpuUsageMetrics() (interface{}, error) {
+func (h *helper) getCpuUsageMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return h.getCpuUsageSummary()
@@ -22,7 +22,7 @@ func (h *helper) getCpuUsageMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getCpuUsageSummary() (interface{}, error) {
+func (h *helper) getCpuUsageSummary() (any, error) {
 	switch h.entityType {
 	case "host":
 		return cubecos.GetCpuSummaryOfHost(h.entityId)
@@ -40,7 +40,7 @@ func (h *helper) getCpuUsageSummary() (interface{}, error) {
 	)
 }
 
-func (h *helper) getCpuHistory() (interface{}, error) {
+func (h *helper) getCpuHistory() (any, error) {
 	switch h.entityType {
 	case "host":
 		stmt := h.genHostCpuUsageHistoryStmt()
@@ -55,7 +55,7 @@ func (h *helper) getCpuHistory() (interface{}, error) {
 	)
 }
 
-func (h *helper) getCpuUsageRank() (interface{}, error) {
+func (h *helper) getCpuUsageRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		stmt := h.genHostCpuUsageRankStmt()

--- a/internal/api/v1/metrics/disk.go
+++ b/internal/api/v1/metrics/disk.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 )
 
-func (h *helper) getDiskBandwidthMetrics() (interface{}, error) {
+func (h *helper) getDiskBandwidthMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for disk bandwidth metrics")
@@ -22,7 +22,7 @@ func (h *helper) getDiskBandwidthMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskBandwidthHistory() (interface{}, error) {
+func (h *helper) getDiskBandwidthHistory() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GetDiskStorageBandwidthHistory(
@@ -39,7 +39,7 @@ func (h *helper) getDiskBandwidthHistory() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskUsageMetrics() (interface{}, error) {
+func (h *helper) getDiskUsageMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for disk usage metrics")
@@ -55,7 +55,7 @@ func (h *helper) getDiskUsageMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskUsageRank() (interface{}, error) {
+func (h *helper) getDiskUsageRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GetDiskUsageRankOfHosts(h.genHostStorageUsageRankStmt())
@@ -69,7 +69,7 @@ func (h *helper) getDiskUsageRank() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskIopsMetrics() (interface{}, error) {
+func (h *helper) getDiskIopsMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for disk iops metrics")
@@ -85,7 +85,7 @@ func (h *helper) getDiskIopsMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskIopsHistory() (interface{}, error) {
+func (h *helper) getDiskIopsHistory() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GetDiskIopsHistoryOfHosts(
@@ -102,7 +102,7 @@ func (h *helper) getDiskIopsHistory() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskReadIopsMetrics() (interface{}, error) {
+func (h *helper) getDiskReadIopsMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for disk read iops metrics")
@@ -118,7 +118,7 @@ func (h *helper) getDiskReadIopsMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskReadIopsRank() (interface{}, error) {
+func (h *helper) getDiskReadIopsRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return nil, fmt.Errorf("hosts is not supported yet for disk read iops rank")
@@ -132,7 +132,7 @@ func (h *helper) getDiskReadIopsRank() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskWriteIopsMetrics() (interface{}, error) {
+func (h *helper) getDiskWriteIopsMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for disk write iops metrics")
@@ -148,7 +148,7 @@ func (h *helper) getDiskWriteIopsMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskWriteIopsRank() (interface{}, error) {
+func (h *helper) getDiskWriteIopsRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return nil, fmt.Errorf("hosts is not supported yet for disk write iops rank")
@@ -162,7 +162,7 @@ func (h *helper) getDiskWriteIopsRank() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskLatencyMetrics() (interface{}, error) {
+func (h *helper) getDiskLatencyMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for disk latency metrics")
@@ -178,7 +178,7 @@ func (h *helper) getDiskLatencyMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getDiskLatencyHistory() (interface{}, error) {
+func (h *helper) getDiskLatencyHistory() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GeDiskLatencyHistoryOfHosts(

--- a/internal/api/v1/metrics/helper.go
+++ b/internal/api/v1/metrics/helper.go
@@ -40,11 +40,11 @@ func initHelper(c *gin.Context, handler string) (*helper, error) {
 	return h, h.parseParams()
 }
 
-func (h *helper) getDataCenterSummary() (interface{}, error) {
+func (h *helper) getDataCenterSummary() (any, error) {
 	return cubecos.GetDataCenterSummary()
 }
 
-func (h *helper) getMetrics() (interface{}, error) {
+func (h *helper) getMetrics() (any, error) {
 	switch h.metricType {
 	case "cpuUsage":
 		return h.getCpuUsageMetrics()

--- a/internal/api/v1/metrics/memory.go
+++ b/internal/api/v1/metrics/memory.go
@@ -6,12 +6,12 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 )
 
-func (h *helper) getMemoryUsageMetrics() (interface{}, error) {
+func (h *helper) getMemoryUsageMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return h.getMemoryUsageSummary()
 	case "history":
-		return nil, fmt.Errorf("history is not supported yet for cpu metrics")
+		return h.getMemoryHistory()
 	case "rank":
 		return h.getMemoryUsageRank()
 	}
@@ -22,7 +22,7 @@ func (h *helper) getMemoryUsageMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getMemoryUsageSummary() (interface{}, error) {
+func (h *helper) getMemoryUsageSummary() (any, error) {
 	switch h.entityType {
 	case "host":
 		return cubecos.GetMemoryUsageSummaryOfHost(h.entityId)
@@ -40,7 +40,22 @@ func (h *helper) getMemoryUsageSummary() (interface{}, error) {
 	)
 }
 
-func (h *helper) getMemoryUsageRank() (interface{}, error) {
+func (h *helper) getMemoryHistory() (any, error) {
+	switch h.entityType {
+	case "host":
+		stmt := h.genHostMemoryUsageHistoryStmt()
+		return cubecos.GetMemoryHistoryOfHost(stmt)
+	case "vm":
+		return nil, fmt.Errorf("vm is not supported yet for memory history")
+	}
+
+	return nil, fmt.Errorf(
+		"invalid entity type(%s) to get memory history",
+		h.entityType,
+	)
+}
+
+func (h *helper) getMemoryUsageRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GetMemoryUsageRankOfHosts(h.genHostMemoryUsageRankStmt())

--- a/internal/api/v1/metrics/network.go
+++ b/internal/api/v1/metrics/network.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 )
 
-func (h *helper) getNetworkTrafficInMetrics() (interface{}, error) {
+func (h *helper) getNetworkTrafficInMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for network traffic in metrics")
@@ -22,7 +22,7 @@ func (h *helper) getNetworkTrafficInMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getNetworkTrafficInRank() (interface{}, error) {
+func (h *helper) getNetworkTrafficInRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GetNetworkTrafficInRankOfHosts()
@@ -36,7 +36,7 @@ func (h *helper) getNetworkTrafficInRank() (interface{}, error) {
 	)
 }
 
-func (h *helper) getNetworkTrafficOutMetrics() (interface{}, error) {
+func (h *helper) getNetworkTrafficOutMetrics() (any, error) {
 	switch h.viewType {
 	case "summary":
 		return nil, fmt.Errorf("summary is not supported yet for network traffic out metrics")
@@ -52,7 +52,7 @@ func (h *helper) getNetworkTrafficOutMetrics() (interface{}, error) {
 	)
 }
 
-func (h *helper) getNetworkTrafficOutRank() (interface{}, error) {
+func (h *helper) getNetworkTrafficOutRank() (any, error) {
 	switch h.entityType {
 	case "hosts":
 		return cubecos.GetNetworkTrafficOutRankOfHosts()

--- a/internal/cubecos/event.go
+++ b/internal/cubecos/event.go
@@ -227,7 +227,7 @@ func setMetadataToEvent(event *definition.Event, record *query.FluxRecord) {
 		return
 	}
 
-	metaObj := map[string]interface{}{}
+	metaObj := map[string]any{}
 	err := json.Unmarshal([]byte(metadata), &metaObj)
 	if err != nil {
 		log.Debugf("failed to parse metadata from record: %v", record)
@@ -240,7 +240,7 @@ func setMetadataToEvent(event *definition.Event, record *query.FluxRecord) {
 	setHostnameToEvent(event, metaObj)
 }
 
-func setCategoryToEvent(event *definition.Event, metaObj map[string]interface{}) {
+func setCategoryToEvent(event *definition.Event, metaObj map[string]any) {
 	metaCategory, found := metaObj["category"]
 	if !found {
 		return
@@ -249,7 +249,7 @@ func setCategoryToEvent(event *definition.Event, metaObj map[string]interface{})
 	event.Category, _ = metaCategory.(string)
 }
 
-func setServiceToEvent(event *definition.Event, metaObj map[string]interface{}) {
+func setServiceToEvent(event *definition.Event, metaObj map[string]any) {
 	metaService, found := metaObj["service"]
 	if !found {
 		return
@@ -258,7 +258,7 @@ func setServiceToEvent(event *definition.Event, metaObj map[string]interface{}) 
 	event.Service, _ = metaService.(string)
 }
 
-func setHostnameToEvent(event *definition.Event, metaObj map[string]interface{}) {
+func setHostnameToEvent(event *definition.Event, metaObj map[string]any) {
 	metaHost, found := metaObj["host"]
 	if !found {
 		return

--- a/internal/cubecos/metrics.go
+++ b/internal/cubecos/metrics.go
@@ -560,7 +560,8 @@ func GetMemoryUsageRankOfHosts(stmt string) (*definition.MetricRank, error) {
 
 func appendHistoryToMemoryUsageRank(rank []definition.RankPoint) {
 	for i, host := range rank {
-		history, err := GetMemoryHistoryOfHost(host.Id, definition.Period{})
+		stmt := fmt.Sprintf(hostMemoryUsageHistoryStmt, host.Id)
+		history, err := GetMemoryHistoryOfHost(stmt)
 		if err != nil {
 			log.Errorf("failed to get memory history of host %s: %v", host.Id, err)
 			continue
@@ -570,8 +571,7 @@ func appendHistoryToMemoryUsageRank(rank []definition.RankPoint) {
 	}
 }
 
-func GetMemoryHistoryOfHost(entityId string, period definition.Period) ([]definition.TimeValue, error) {
-	stmt := fmt.Sprintf(hostMemoryUsageHistoryStmt, entityId)
+func GetMemoryHistoryOfHost(stmt string) ([]definition.TimeValue, error) {
 	c, cancel, err := influx.GetQueryCursor(stmt)
 	if err != nil {
 		return nil, err

--- a/internal/definition/v1/events.go
+++ b/internal/definition/v1/events.go
@@ -7,15 +7,15 @@ const (
 )
 
 type Event struct {
-	Type        string                 `json:"type"`
-	Severity    string                 `json:"severity"`
-	Id          string                 `json:"id"`
-	Description string                 `json:"description"`
-	Host        string                 `json:"host"`
-	Category    string                 `json:"category"`
-	Service     string                 `json:"service"`
-	Metadata    map[string]interface{} `json:"metadata"`
-	Time        string                 `json:"time"`
+	Type        string         `json:"type"`
+	Severity    string         `json:"severity"`
+	Id          string         `json:"id"`
+	Description string         `json:"description"`
+	Host        string         `json:"host"`
+	Category    string         `json:"category"`
+	Service     string         `json:"service"`
+	Metadata    map[string]any `json:"metadata"`
+	Time        string         `json:"time"`
 }
 
 type EventStat struct {


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

#45 #65 

<br/>

### What this PR does?

- add a GET API to fetch cpu/memory usage time series from a single host

- this API is not only for metric usage, but also will be leveraged in the node detailed page

- adjust the corresponding doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/38fdf58b-da29-4b4a-b3a0-6a6786c34ec6

<br/>

2). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/fb445f64-3e55-4d5d-b513-ec4618c26aa2




