### PR TITLE
refactor(ci): use topdir macro

### DIFF
--- a/init/cube-cos-api.spec
+++ b/init/cube-cos-api.spec
@@ -14,7 +14,7 @@ The API service for CubeCOS.
 
 %prep
 rm -rf ./*
-cp ../SOURCES/"cube-cos-api-%{version}.tar.gz" .
+cp %{_topdir}/SOURCES/"cube-cos-api-%{version}.tar.gz" .
 tar -xzf "cube-cos-api-%{version}.tar.gz"
 rm "cube-cos-api-%{version}.tar.gz"
 mv ./source/* .


### PR DESCRIPTION
### What type of PR is this?

- refactor

### Which issue(s) this PR fixes?

### What this PR does?

- Use `_topdir` macro to allow using a local rpm build directory in CubeCOS build process

### Test results (optional)
