### PR TITLE
Unify and simplify the source of truth for global node list

### DIFF
--- a/internal/api/v1/nodes/details.go
+++ b/internal/api/v1/nodes/details.go
@@ -160,7 +160,7 @@ func isSkippableLine(line string) bool {
 	return line == "" || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "Label")
 }
 
-func (h *helper) addDetailsToNodes(nodes *[]*definition.Node) {
+func (h *helper) addDetailsToNodes(nodes *[]definition.Node) {
 	openstack := openstack.GetGlobalHelper()
 	for _, node := range *nodes {
 		hypervisor, err := openstack.GetHypervisorByHostname(node.Hostname)
@@ -171,9 +171,9 @@ func (h *helper) addDetailsToNodes(nodes *[]*definition.Node) {
 
 		node.ManagementIP = hypervisor.HostIP
 		node.Status = hypervisor.State
-		h.addHardwareInfoToNode(node)
-		h.addMetricToNode(node, hypervisor)
-		h.addUptimeToNode(node)
+		h.addHardwareInfoToNode(&node)
+		h.addMetricToNode(&node, hypervisor)
+		h.addUptimeToNode(&node)
 	}
 }
 

--- a/internal/api/v1/nodes/details.go
+++ b/internal/api/v1/nodes/details.go
@@ -162,18 +162,18 @@ func isSkippableLine(line string) bool {
 
 func (h *helper) addDetailsToNodes(nodes *[]definition.Node) {
 	openstack := openstack.GetGlobalHelper()
-	for _, node := range *nodes {
+	for i, node := range *nodes {
 		hypervisor, err := openstack.GetHypervisorByHostname(node.Hostname)
 		if err != nil {
 			log.Debugf("request(%s): failed to add hypervisor info to the node: %s", api.GetReqId(h.c), err.Error())
 			continue
 		}
 
-		node.ManagementIP = hypervisor.HostIP
-		node.Status = hypervisor.State
-		h.addHardwareInfoToNode(&node)
-		h.addMetricToNode(&node, hypervisor)
-		h.addUptimeToNode(&node)
+		(*nodes)[i].ManagementIP = hypervisor.HostIP
+		(*nodes)[i].Status = hypervisor.State
+		h.addHardwareInfoToNode((&(*nodes)[i]))
+		h.addMetricToNode((&(*nodes)[i]), hypervisor)
+		h.addUptimeToNode((&(*nodes)[i]))
 	}
 }
 

--- a/internal/api/v1/nodes/filter.go
+++ b/internal/api/v1/nodes/filter.go
@@ -12,7 +12,7 @@ const (
 	maxSearchResults = 10000
 )
 
-func (h *helper) filterNodes(nodes []*definition.Node) []*definition.Node {
+func (h *helper) filterNodes(nodes []definition.Node) []definition.Node {
 	if !h.isFilterRequired() {
 		return nodes
 	}
@@ -49,8 +49,8 @@ func (h *helper) isLicenseStatusRequired() bool {
 	return required
 }
 
-func (h *helper) filteredByLicenseStatus(nodes []*definition.Node) []*definition.Node {
-	filtered := []*definition.Node{}
+func (h *helper) filteredByLicenseStatus(nodes []definition.Node) []definition.Node {
+	filtered := []definition.Node{}
 	for _, node := range nodes {
 		if node.License.Status.Current == h.licenseStatus {
 			filtered = append(filtered, node)
@@ -60,7 +60,7 @@ func (h *helper) filteredByLicenseStatus(nodes []*definition.Node) []*definition
 	return filtered
 }
 
-func (h *helper) filteredByKeyword(nodes []*definition.Node) []*definition.Node {
+func (h *helper) filteredByKeyword(nodes []definition.Node) []definition.Node {
 	result, err := h.searchNodes(nodes)
 	if err != nil {
 		log.Errorf("failed to search nodes: %s", err.Error())
@@ -68,7 +68,7 @@ func (h *helper) filteredByKeyword(nodes []*definition.Node) []*definition.Node 
 	}
 
 	nodeMap := genNodeMap(nodes)
-	filtered := []*definition.Node{}
+	filtered := []definition.Node{}
 	for _, hit := range result.Hits {
 		filtered = append(filtered, nodeMap[hit.ID])
 	}
@@ -76,7 +76,7 @@ func (h *helper) filteredByKeyword(nodes []*definition.Node) []*definition.Node 
 	return filtered
 }
 
-func (h *helper) searchNodes(nodes []*definition.Node) (*bleve.SearchResult, error) {
+func (h *helper) searchNodes(nodes []definition.Node) (*bleve.SearchResult, error) {
 	searcher := definition.GetNodeSearcher()
 	for _, node := range nodes {
 		err := searcher.Index(node.Name, node)
@@ -99,8 +99,8 @@ func (h *helper) wrapWilcardKeyword() string {
 	return "*" + h.keyword + "*"
 }
 
-func genNodeMap(nodes []*definition.Node) map[string]*definition.Node {
-	nodeMap := map[string]*definition.Node{}
+func genNodeMap(nodes []definition.Node) map[string]definition.Node {
+	nodeMap := map[string]definition.Node{}
 	for _, node := range nodes {
 		nodeMap[node.Name] = node
 	}
@@ -108,8 +108,8 @@ func genNodeMap(nodes []*definition.Node) map[string]*definition.Node {
 	return nodeMap
 }
 
-func (h *helper) filteredByRoles(nodes []*definition.Node) []*definition.Node {
-	filtered := []*definition.Node{}
+func (h *helper) filteredByRoles(nodes []definition.Node) []definition.Node {
+	filtered := []definition.Node{}
 	for _, node := range nodes {
 		if h.containsRoles(node) {
 			filtered = append(filtered, node)
@@ -119,6 +119,6 @@ func (h *helper) filteredByRoles(nodes []*definition.Node) []*definition.Node {
 	return filtered
 }
 
-func (h *helper) containsRoles(node *definition.Node) bool {
+func (h *helper) containsRoles(node definition.Node) bool {
 	return slices.Contains(h.roles, node.Role)
 }

--- a/internal/api/v1/nodes/helper.go
+++ b/internal/api/v1/nodes/helper.go
@@ -59,12 +59,7 @@ func (h *helper) parseGetOptions() error {
 }
 
 func (h *helper) listNodes() (*data, error) {
-	nodes, err := definition.ListNodes()
-	if err != nil {
-		log.Errorf("request(%s): failed to get nodes: %s", api.GetReqId(h.c), err.Error())
-		return nil, err
-	}
-
+	nodes := definition.ListNodes()
 	h.addLicenseInfoToNodes(&nodes)
 	h.addDetailsToNodes(&nodes)
 	nodes = h.filterNodes(nodes)

--- a/internal/api/v1/nodes/license.go
+++ b/internal/api/v1/nodes/license.go
@@ -22,7 +22,7 @@ func (h *helper) addLicenseToNode(node *definition.Node) {
 	)
 }
 
-func (h *helper) addLicenseInfoToNodes(nodes *[]*definition.Node) {
+func (h *helper) addLicenseInfoToNodes(nodes *[]definition.Node) {
 	licenses, err := cubecos.ListLicenses()
 	if err != nil {
 		log.Warnf("request(%s): failed to add license info to the nodes: %s", api.GetReqId(h.c), err.Error())

--- a/internal/api/v1/nodes/pagination.go
+++ b/internal/api/v1/nodes/pagination.go
@@ -6,7 +6,7 @@ import (
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 )
 
-func paginateNodes(nodes []*definition.Node, page definition.Page) ([]*definition.Node, error) {
+func paginateNodes(nodes []definition.Node, page definition.Page) ([]definition.Node, error) {
 	if !page.IsRequired() {
 		return nodes, nil
 	}
@@ -16,7 +16,7 @@ func paginateNodes(nodes []*definition.Node, page definition.Page) ([]*definitio
 	return nodes[left:right], nil
 }
 
-func genPageInfo(nodes []*definition.Node, page definition.Page) (definition.Page, error) {
+func genPageInfo(nodes []definition.Node, page definition.Page) (definition.Page, error) {
 	if !page.IsRequired() {
 		return definition.Page{
 			Total:          1,

--- a/internal/api/v1/nodes/resp.go
+++ b/internal/api/v1/nodes/resp.go
@@ -3,6 +3,6 @@ package nodes
 import definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 
 type data struct {
-	Nodes           []*definition.Node `json:"nodes"`
+	Nodes           []definition.Node `json:"nodes"`
 	definition.Page `json:"page"`
 }

--- a/internal/api/v1/tunings/filter.go
+++ b/internal/api/v1/tunings/filter.go
@@ -27,12 +27,12 @@ func selectRolesUsingActivityAndLabels(tuningSpec *definition.TuningSpec) []*def
 	return roles
 }
 
-func getNodesBySelector(nodes []*definition.Node, selector definition.Selector) []*definition.Node {
+func getNodesBySelector(nodes []definition.Node, selector definition.Selector) []definition.Node {
 	if !selector.Enabled {
 		return nodes
 	}
 
-	filtered := []*definition.Node{}
+	filtered := []definition.Node{}
 	for _, node := range nodes {
 		for key, value := range selector.Labels {
 			if node.Labels[key] == value {

--- a/internal/cubecos/metrics.go
+++ b/internal/cubecos/metrics.go
@@ -290,13 +290,8 @@ func GetMemoryAverageOfHosts(spaceStats []definition.SpaceStatistic) definition.
 }
 
 func GetHostSummary() (*HostSummary, error) {
-	nodes, err := definition.ListNodes()
-	if err != nil {
-		log.Errorf("failed to list nodes: %v", err)
-		return nil, err
-	}
-
 	s := &HostSummary{}
+	nodes := definition.ListNodes()
 	s.SetHostUsageByNodes(nodes)
 	s.SetRoleUsageByHosts()
 	return s, nil
@@ -471,14 +466,8 @@ func appendHistoryToCpuUsageRank(rank []definition.RankPoint) {
 }
 
 func GetMemoryUsageSummaryOfHosts() (*definition.SpaceStatistic, error) {
-	nodes, err := definition.ListNodes()
-	if err != nil {
-		log.Errorf("failed to list nodes: %v", err)
-		return nil, err
-	}
-
 	usages := []definition.SpaceStatistic{}
-	for _, node := range nodes {
+	for _, node := range definition.ListNodes() {
 		usage, err := GetMemoryUsageSummaryOfHost(node.Hostname)
 		if err != nil {
 			continue

--- a/internal/cubecos/metrics.go
+++ b/internal/cubecos/metrics.go
@@ -297,7 +297,7 @@ func GetHostSummary() (*HostSummary, error) {
 	return s, nil
 }
 
-func GetHostUsage(node *definition.Node) (*definition.HostUsage, error) {
+func GetHostUsage(node definition.Node) (*definition.HostUsage, error) {
 	cpuStat, err := GetCpuSummaryOfHost(node.Hostname)
 	if err != nil {
 		log.Errorf("failed to get cpu summary of host %s: %v", node.Hostname, err)

--- a/internal/cubecos/node.go
+++ b/internal/cubecos/node.go
@@ -7,8 +7,8 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
-func ListNodes() ([]*definition.Node, error) {
-	nodes := []*definition.Node{}
+func ListNodes() ([]definition.Node, error) {
+	nodes := []definition.Node{}
 	for _, role := range definition.Roles {
 		roleNodes, err := definition.GetNodesByRole(role)
 		if err != nil {

--- a/internal/cubecos/statistic.go
+++ b/internal/cubecos/statistic.go
@@ -42,7 +42,7 @@ func (h *HostSummary) ListMemoryUsages() []definition.SpaceStatistic {
 
 func (h *HostSummary) SetHostUsageByNodes(nodes []definition.Node) {
 	for _, node := range nodes {
-		usage, err := GetHostUsage(&node)
+		usage, err := GetHostUsage(node)
 		if err != nil {
 			continue
 		}

--- a/internal/cubecos/statistic.go
+++ b/internal/cubecos/statistic.go
@@ -40,9 +40,9 @@ func (h *HostSummary) ListMemoryUsages() []definition.SpaceStatistic {
 	return list
 }
 
-func (h *HostSummary) SetHostUsageByNodes(nodes []*definition.Node) {
+func (h *HostSummary) SetHostUsageByNodes(nodes []definition.Node) {
 	for _, node := range nodes {
-		usage, err := GetHostUsage(node)
+		usage, err := GetHostUsage(&node)
 		if err != nil {
 			continue
 		}

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/openstack/v2"
 	"github.com/bigstack-oss/cube-cos-api/internal/api"
 	"github.com/bigstack-oss/cube-cos-api/internal/config"
+	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/support"
 	log "go-micro.dev/v5/logger"
@@ -58,19 +59,13 @@ func ListHostSupportFiles(opts support.ListFileOptions) ([]support.File, error) 
 }
 
 func ListSupportFilesFromOtherNodes() ([]support.File, error) {
-	nodes, err := v1.ListNodes()
-	if err != nil {
-		log.Errorf("failed to list nodes for supportFiles: %s", err.Error())
-		return nil, err
-	}
-
 	files := []support.File{}
-	for _, node := range nodes {
+	for _, node := range definition.ListNodes() {
 		if node.IsLocal() {
 			continue
 		}
 
-		file, err := getNodeSupportFiles(*node)
+		file, err := getNodeSupportFiles(node)
 		if err != nil {
 			log.Errorf("failed to get supportFiles from node %s: %s", node.Name, err.Error())
 			continue

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -1107,19 +1107,13 @@ func ListTunings(opts definition.ListTuningOptions) ([]definition.Tuning, error)
 }
 
 func ListTuningsFromOtherNodes() (map[string][]definition.Tuning, error) {
-	nodes, err := definition.ListNodes()
-	if err != nil {
-		log.Errorf("failed to list nodes for tunings: %s", err.Error())
-		return nil, err
-	}
-
 	nodeTunings := map[string][]definition.Tuning{}
-	for _, node := range nodes {
+	for _, node := range definition.ListNodes() {
 		if node.IsLocal() {
 			continue
 		}
 
-		tunings, err := getNodeTunings(*node)
+		tunings, err := getNodeTunings(node)
 		if err != nil {
 			log.Errorf("failed to get tunings from node %s: %s", node.Name, err.Error())
 			continue

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"sync"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/support"
@@ -37,6 +38,8 @@ var (
 	IsHaEnabled              bool
 	IsGpuEnabled             bool
 
+	updateNodes  = sync.Mutex{}
+	nodes        = []Node{}
 	nodeSearcher bleve.Index
 )
 
@@ -205,7 +208,7 @@ func GenerateNodeHashByMacAddr() (string, error) {
 	return hex.EncodeToString(hash[:])[:8], nil
 }
 
-func GetNodesByRole(roleName string) ([]*Node, error) {
+func GetNodesByRole(roleName string) ([]Node, error) {
 	svcs, err := registry.GetService(DataCenterName)
 	if err != nil {
 		log.Errorf("failed to get %s role from service %s (%s)", roleName, DataCenterName, err.Error())
@@ -215,7 +218,7 @@ func GetNodesByRole(roleName string) ([]*Node, error) {
 		return nil, nil
 	}
 
-	nodes := []*Node{}
+	nodes := []Node{}
 	for _, svc := range svcs {
 		roleNodes := parseNodesByRole(svc, roleName)
 		if len(roleNodes) == 0 {
@@ -223,20 +226,6 @@ func GetNodesByRole(roleName string) ([]*Node, error) {
 		}
 
 		nodes = append(nodes, roleNodes...)
-	}
-
-	return nodes, nil
-}
-
-func ListNodes() ([]*Node, error) {
-	svcs, err := GetRegisteredServices()
-	if err != nil {
-		return nil, err
-	}
-
-	nodes := []*Node{}
-	for _, svc := range svcs {
-		nodes = append(nodes, parseNodes(svc)...)
 	}
 
 	return nodes, nil
@@ -290,14 +279,14 @@ func HostnameNodeMap() (map[string]Node, error) {
 	for _, svc := range svcs {
 		nodes := parseNodes(svc)
 		for _, node := range nodes {
-			nodeMap[node.Hostname] = *node
+			nodeMap[node.Hostname] = node
 		}
 	}
 
 	return nodeMap, nil
 }
 
-func GetControllerNodes() ([]*Node, error) {
+func GetControllerNodes() ([]Node, error) {
 	nodes, err := GetNodesByRole("control")
 	if err == nil && len(nodes) > 0 {
 		return nodes, nil
@@ -320,18 +309,13 @@ func GetOneOfControllerNode() (*Node, error) {
 		return nil, err
 	}
 
-	return nodes[0], nil
+	return &nodes[0], nil
 }
 
 func GetNodeByHostname(hostname string) (*Node, error) {
-	nodes, err := ListNodes()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, node := range nodes {
+	for _, node := range ListNodes() {
 		if node.Hostname == hostname {
-			return node, nil
+			return &node, nil
 		}
 	}
 
@@ -339,6 +323,30 @@ func GetNodeByHostname(hostname string) (*Node, error) {
 		"failed to get node by hostname %s",
 		hostname,
 	)
+}
+
+func SyncNodes() {
+	updateNodes.Lock()
+	defer updateNodes.Unlock()
+
+	syncNodes := []Node{}
+	for _, role := range Roles {
+		role := getRole(role)
+		if role == nil {
+			continue
+		}
+
+		syncNodes = append(
+			syncNodes,
+			role.Nodes...,
+		)
+	}
+
+	nodes = syncNodes
+}
+
+func ListNodes() []Node {
+	return nodes
 }
 
 func InitNodeSearchIndex() error {

--- a/internal/definition/v1/roles.go
+++ b/internal/definition/v1/roles.go
@@ -16,9 +16,9 @@ const (
 )
 
 var (
-	CurrentRole string
-	Roles       = []string{RoleControl, RoleCompute, RoleStorage, RoleControlConverged, RoleModerator, RoleEdgeCore}
-	update      = sync.Mutex{}
+	CurrentRole     string
+	Roles           = []string{RoleControl, RoleCompute, RoleStorage, RoleControlConverged, RoleModerator, RoleEdgeCore}
+	updateRoleNodes = sync.Mutex{}
 
 	ControlRole          = newControlRole()
 	ComputeRole          = newComputeRole()
@@ -56,9 +56,9 @@ var (
 )
 
 type Role struct {
-	Name  string  `json:"name" bson:"name"`
-	Hosts []Host  `json:"hosts" bson:"hosts"`
-	Nodes []*Node `json:"-"`
+	Name  string `json:"name" bson:"name"`
+	Hosts []Host `json:"hosts" bson:"hosts"`
+	Nodes []Node `json:"-"`
 }
 
 type Host struct {
@@ -129,8 +129,8 @@ func GetEdgeCoreRole() *Role {
 }
 
 func SyncRoleNodes() {
-	update.Lock()
-	defer update.Unlock()
+	updateRoleNodes.Lock()
+	defer updateRoleNodes.Unlock()
 
 	for _, role := range Roles {
 		nodes, err := GetNodesByRole(role)
@@ -146,7 +146,7 @@ func SyncRoleNodes() {
 	}
 }
 
-func convertNodesToHosts(nodes []*Node) []Host {
+func convertNodesToHosts(nodes []Node) []Host {
 	hosts := []Host{}
 	for _, node := range nodes {
 		hosts = append(hosts, Host{
@@ -158,8 +158,8 @@ func convertNodesToHosts(nodes []*Node) []Host {
 	return hosts
 }
 
-func parseNodes(svc *registry.Service) []*Node {
-	nodes := []*Node{}
+func parseNodes(svc *registry.Service) []Node {
+	nodes := []Node{}
 	for _, node := range svc.Nodes {
 		nodes = append(nodes, newNode(node))
 	}
@@ -167,8 +167,8 @@ func parseNodes(svc *registry.Service) []*Node {
 	return nodes
 }
 
-func parseNodesByRole(svc *registry.Service, roleName string) []*Node {
-	nodes := []*Node{}
+func parseNodesByRole(svc *registry.Service, roleName string) []Node {
+	nodes := []Node{}
 	for _, node := range svc.Nodes {
 		if node.Metadata["role"] != roleName {
 			continue
@@ -180,8 +180,8 @@ func parseNodesByRole(svc *registry.Service, roleName string) []*Node {
 	return nodes
 }
 
-func newNode(node *registry.Node) *Node {
-	return &Node{
+func newNode(node *registry.Node) Node {
+	return Node{
 		Role:         node.Metadata["role"],
 		Id:           node.Metadata["nodeID"],
 		SerialNumber: node.Metadata["serialNumber"],

--- a/internal/definition/v1/service.go
+++ b/internal/definition/v1/service.go
@@ -6,6 +6,10 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/status"
 )
 
+const (
+	Services = "services"
+)
+
 type Service struct {
 	Name               string          `json:"name" bson:"name"`
 	Category           string          `json:"category" bson:"category"`

--- a/internal/definition/v1/services.go
+++ b/internal/definition/v1/services.go
@@ -1,5 +1,0 @@
-package v1
-
-const (
-	Services = "services"
-)

--- a/internal/operators/v1/node/node.go
+++ b/internal/operators/v1/node/node.go
@@ -60,6 +60,7 @@ func (o *Operator) watchAndSyncNodeRoles(watcher *registry.Watcher) {
 	event, err := (*watcher).Next()
 	if err == nil {
 		definition.SyncRoleNodes()
+		definition.SyncNodes()
 		logThrottling(event)
 		return
 	}


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

#25

(also related to the stories which used ListNodes() to fetch the node list for further process)

<br/>

### What this PR does?

- Unify and simplify the source of truth for global node list

(also to prevent some of unexpected empty svc list from go-mirco's registry.GetService())


<br/>

### Test results (optional)

1). make sure the mentioned/related apis can work properly

https://github.com/user-attachments/assets/d17fc53f-b34b-48f3-bc71-722d4c40157f


