### PR TITLE
Unify the registered services/nodes fetching from go-micro's service discovery

### DIFF
--- a/internal/api/v1/licenses/delegation.go
+++ b/internal/api/v1/licenses/delegation.go
@@ -21,7 +21,6 @@ func genUrl(node definition.Node) string {
 }
 
 func sendLicenseToOtherNodes(nodeName string, licenseFile *multipart.FileHeader) error {
-	// M1 TODO: might be the incorrect usage
 	nodes, err := service.GetNodesByRole(nodeName)
 	if err != nil {
 		log.Errorf("failed to get nodes by role %s: %s", nodeName, err.Error())
@@ -34,12 +33,9 @@ func sendLicenseToOtherNodes(nodeName string, licenseFile *multipart.FileHeader)
 		return err
 	}
 
-	// M1 TODO: should protect against index out of range
-	// because nodes might be empty from GetNodesByRole
 	node := nodes[0]
-	h := cubeHttp.GetGlobalHelper()
-
-	resp, err := h.R().
+	http := cubeHttp.GetGlobalHelper()
+	resp, err := http.R().
 		SetFileReader("license", licenseFile.Filename, reader).
 		SetHeader(node.GenAuthHeader()).
 		Post(genUrl(node))

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/support"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/trigger"
 	"github.com/blevesearch/bleve/v2"
@@ -38,9 +37,10 @@ var (
 	IsHaEnabled              bool
 	IsGpuEnabled             bool
 
-	updateNodes  = sync.Mutex{}
-	nodes        = []Node{}
-	nodeSearcher bleve.Index
+	getRegisteredServices = sync.Mutex{}
+	updateNodes           = sync.Mutex{}
+	nodes                 = []Node{}
+	nodeSearcher          bleve.Index
 )
 
 type Node struct {
@@ -209,13 +209,9 @@ func GenerateNodeHashByMacAddr() (string, error) {
 }
 
 func GetNodesByRole(roleName string) ([]Node, error) {
-	svcs, err := registry.GetService(DataCenterName)
+	svcs, err := GetRegisteredServices()
 	if err != nil {
-		log.Errorf("failed to get %s role from service %s (%s)", roleName, DataCenterName, err.Error())
 		return nil, err
-	}
-	if len(svcs) == 0 {
-		return nil, nil
 	}
 
 	nodes := []Node{}
@@ -231,48 +227,29 @@ func GetNodesByRole(roleName string) ([]Node, error) {
 	return nodes, nil
 }
 
-// M1 TODO:
-// The issue(https://github.com/bigstack-oss/cube-cos-ui/issues/224) found out that not sure why
-// registry.GetService() might return empty list once it's being called multiple times
-//
-// currently, we temporarily set a retry mechanism to get the nodes
-// but, we've to check if it's go-mirco's bug,
-// or maybe we should make the node list to be a global read only var, and only can be writed/updated by node syncer
 func GetRegisteredServices() ([]*registry.Service, error) {
-	maxTries := 5
-	services := []*registry.Service{}
+	getRegisteredServices.Lock()
+	defer getRegisteredServices.Unlock()
 
-	for range maxTries {
-		svcs, err := registry.GetService(DataCenterName)
-		if err != nil {
-			log.Errorf("failed to get nodes from %s (%s)", DataCenterName, err.Error())
-			continue
-		}
-
-		if len(svcs) > 0 {
-			services = svcs
-			break
-		}
-
-		log.Warnf("no nodes found from %s network, trying sync again", DataCenterName)
-		wait.Seconds(1)
+	svcs, err := registry.GetService(DataCenterName)
+	if err != nil {
+		log.Errorf("failed to get service from %s (%s)", DataCenterName, err.Error())
+		return nil, err
 	}
 
-	if len(services) == 0 {
-		return nil, fmt.Errorf("no nodes found from %s network", DataCenterName)
+	if len(svcs) <= 0 {
+		err := fmt.Errorf("no any service find from %s", DataCenterName)
+		log.Errorf(err.Error())
+		return nil, err
 	}
 
-	return services, nil
+	return svcs, nil
 }
 
 func HostnameNodeMap() (map[string]Node, error) {
-	svcs, err := registry.GetService(DataCenterName)
+	svcs, err := GetRegisteredServices()
 	if err != nil {
-		log.Errorf("failed to get nodes from %s (%s)", DataCenterName, err.Error())
 		return nil, err
-	}
-	if len(svcs) == 0 {
-		return nil, nil
 	}
 
 	nodeMap := map[string]Node{}

--- a/internal/service/node.go
+++ b/internal/service/node.go
@@ -1,9 +1,9 @@
 package service
 
 import (
+	"fmt"
+
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
-	cuberr "github.com/bigstack-oss/cube-cos-api/internal/errors"
-	log "go-micro.dev/v5/logger"
 	"go-micro.dev/v5/registry"
 )
 
@@ -39,19 +39,19 @@ func isLocalNode(node *registry.Node) bool {
 }
 
 func GetNodesByRole(roleName string) ([]definition.Node, error) {
-	svcs, err := registry.GetService(definition.DataCenterName)
+	svcs, err := definition.GetRegisteredServices()
 	if err != nil {
-		log.Errorf("failed to get service %s (%s)", roleName, err.Error())
 		return nil, err
-	}
-	if len(svcs) == 0 {
-		return nil, cuberr.ServiceNotFound
 	}
 
 	nodes := []definition.Node{}
 	for _, svc := range svcs {
 		roleNodes := parseNodes(svc)
 		setNodesIfRoleMatched(&nodes, roleNodes, roleName)
+	}
+
+	if len(nodes) <= 0 {
+		return nil, fmt.Errorf("no nodes found for role %s", roleName)
 	}
 
 	return nodes, nil


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

#25

(also related to the stories which used ListNodes() to fetch the node list for further process)

<br/>

### What this PR does?

- Unify the registered services/nodes fetching from go-micro's service discovery

- Add more error identification and protection around the service fetching


<br/>

### Test results (optional)

1). make sure the mentioned/related apis can work properly

<img width="1724" alt="Screenshot 2025-04-06 at 10 30 28 PM" src="https://github.com/user-attachments/assets/c414a9ee-bbe9-4a38-b41b-7b849519def7" />

<img width="1724" alt="Screenshot 2025-04-06 at 10 30 54 PM" src="https://github.com/user-attachments/assets/1e3c93ff-126b-49ce-961f-26c33457861b" />

<img width="1724" alt="Screenshot 2025-04-06 at 10 30 47 PM" src="https://github.com/user-attachments/assets/d7a448cd-de7d-4f74-981c-d26203a2ed12" />

<img width="1725" alt="Screenshot 2025-04-06 at 10 30 41 PM" src="https://github.com/user-attachments/assets/0cb56d7e-b2e6-487a-ad64-4001132be497" />


