### PR TITLE
Remove the unnecessary fields from health schema and fix the inappropriate health status identification

### DIFF
--- a/internal/api/v1/healths/helper.go
+++ b/internal/api/v1/healths/helper.go
@@ -155,7 +155,6 @@ func (h *helper) parsePast() error {
 	h.past = h.c.DefaultQuery("past", "")
 	if h.past == "" {
 		h.past = defaultPastOneHour
-		return nil
 	}
 
 	_, err := duration.Str2Duration(h.past)

--- a/internal/api/v1/healths/parameter.go
+++ b/internal/api/v1/healths/parameter.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultPastOneHour = "1h"
+	defaultPastOneHour = "24h"
 )
 
 func parseModule(c *gin.Context) (*definition.Module, error) {

--- a/internal/cubecos/health.go
+++ b/internal/cubecos/health.go
@@ -279,7 +279,7 @@ func genHealthCheckByRecord(record *query.FluxRecord) v1.HealthCheck {
 }
 
 func syncStatusDetails(record *query.FluxRecord, check *v1.HealthCheck) {
-	desc := parseDescription(record)
+	desc := parseHealthResult(record)
 	if desc == status.Ok {
 		check.Status = status.Ok
 		return
@@ -294,6 +294,20 @@ func syncStatusDetails(record *query.FluxRecord, check *v1.HealthCheck) {
 		Nodes:       parseNodes(record),
 		Log:         parseLog(record),
 	}
+}
+
+func parseHealthResult(record *query.FluxRecord) string {
+	result := record.ValueByKey("code")
+	val, ok := result.(string)
+	if !ok {
+		return "ng"
+	}
+
+	if val != "0" {
+		return status.Ng
+	}
+
+	return status.Ok
 }
 
 func GetServicesToCheckHealth() []v1.Service {

--- a/internal/cubecos/health.go
+++ b/internal/cubecos/health.go
@@ -304,7 +304,7 @@ func GetServicesToCheckHealth() []v1.Service {
 			continue
 		}
 
-		services[i].Status = status.NewOk()
+		services[i].Status = status.NewHealthOk()
 	}
 
 	return services

--- a/internal/definition/v1/service.go
+++ b/internal/definition/v1/service.go
@@ -11,18 +11,18 @@ const (
 )
 
 type Service struct {
-	Name               string          `json:"name" bson:"name"`
-	Category           string          `json:"category" bson:"category"`
-	Status             *status.Details `json:"status,omitempty" bson:"status,omitempty"`
-	Modules            []Module        `json:"modules" bson:"modules"`
-	IsInternalViewOnly bool            `json:"-" bson:"isInternalViewOnly"`
+	Name               string         `json:"name" bson:"name"`
+	Category           string         `json:"category" bson:"category"`
+	Status             *status.Health `json:"status,omitempty" bson:"status,omitempty"`
+	Modules            []Module       `json:"modules" bson:"modules"`
+	IsInternalViewOnly bool           `json:"-" bson:"isInternalViewOnly"`
 }
 
 type Module struct {
-	Name         string          `json:"name" bson:"name"`
-	Status       *status.Details `json:"status,omitempty" bson:"status,omitempty"`
-	IsRepairable bool            `json:"-" bson:"isRepairable"`
-	Description  string          `json:"description,omitzero" bson:"description"`
+	Name         string         `json:"name" bson:"name"`
+	Status       *status.Health `json:"status,omitempty" bson:"status,omitempty"`
+	IsRepairable bool           `json:"-" bson:"isRepairable"`
+	Description  string         `json:"description,omitempty" bson:"description"`
 }
 
 type ReairingInfo struct {
@@ -38,7 +38,7 @@ func (s *Service) IsStatusOk() bool {
 }
 
 func (s *Service) SetRepairingStatus(repairingInfo ReairingInfo) {
-	s.Status = &status.Details{
+	s.Status = &status.Health{
 		Current:  status.Repairing,
 		IsFixing: true,
 		Description: fmt.Sprintf(
@@ -58,7 +58,7 @@ func (s *Service) CopyModuleEmptyStruct() Service {
 
 func (s *Service) ConvergeUnhealthyStatus(moduleName string) {
 	if s.Status == nil {
-		s.Status = &status.Details{}
+		s.Status = &status.Health{}
 	}
 
 	s.Status.Current = status.Ng
@@ -70,18 +70,18 @@ func (s *Service) ConvergeUnhealthyStatus(moduleName string) {
 }
 
 func (m *Module) InitOkStatus() {
-	m.Status = status.NewOk()
+	m.Status = status.NewHealthOk()
 }
 
 func (m *Module) SetUnhealthyStatus() {
-	m.Status = &status.Details{
+	m.Status = &status.Health{
 		Current:     status.Ng,
 		Description: fmt.Sprintf(`has failure from %s`, m.Name),
 	}
 }
 
 func (m *Module) SetRepairingStatus() {
-	m.Status = &status.Details{
+	m.Status = &status.Health{
 		Current:  status.Repairing,
 		IsFixing: true,
 	}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -23,10 +23,6 @@ const (
 	Error     = "error"
 )
 
-func NewOk() *Details {
-	return &Details{Current: Ok}
-}
-
 type Details struct {
 	Current string `json:"current,omitempty" bson:"current"`
 	Desired string `json:"desired,omitempty" bson:"desired"`
@@ -35,18 +31,18 @@ type Details struct {
 	UpdatedAt time.Time `json:"updatedAt,omitzero" bson:"updatedAt"`
 	IsFixing  bool      `json:"isFixing" bson:"isFixing"`
 
-	Description string `json:"description,omitzero" bson:"description"`
+	Description string `json:"description,omitempty" bson:"description"`
 }
 
 type Health struct {
 	Current string `json:"current,omitempty" bson:"current"`
 	Desired string `json:"desired,omitempty" bson:"desired"`
 
-	CreatedAt time.Time `json:"createdAt,omitzero" bson:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt,omitzero" bson:"updatedAt"`
-	IsFixing  bool      `json:"isFixing" bson:"isFixing"`
+	CreatedAt *time.Time `json:"createdAt,omitzero" bson:"createdAt"`
+	UpdatedAt *time.Time `json:"updatedAt,omitzero" bson:"updatedAt"`
+	IsFixing  bool       `json:"isFixing" bson:"isFixing"`
 
-	Description string `json:"description,omitzero" bson:"description"`
+	Description string `json:"description,omitempty" bson:"description"`
 }
 
 type Tuning struct {
@@ -81,6 +77,10 @@ type SupportFile struct {
 type License struct {
 	Current    string `json:"current,omitempty" bson:"current"`
 	IsExpiring bool   `json:"isExpiring" bson:"isExpiring"`
+}
+
+func NewHealthOk() *Health {
+	return &Health{Current: Ok}
 }
 
 func (d *Details) ClearDesired() {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -38,8 +38,8 @@ type Health struct {
 	Current string `json:"current,omitempty" bson:"current"`
 	Desired string `json:"desired,omitempty" bson:"desired"`
 
-	CreatedAt *time.Time `json:"createdAt,omitzero" bson:"createdAt"`
-	UpdatedAt *time.Time `json:"updatedAt,omitzero" bson:"updatedAt"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" bson:"createdAt"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty" bson:"updatedAt"`
 	IsFixing  bool       `json:"isFixing" bson:"isFixing"`
 
 	Description string `json:"description,omitempty" bson:"description"`


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

<br/>

### Which issue(s) this PR fixes?

#23 

<br/>

### What this PR does?

- Remove the unnecessary fields from health schema

- Fix the inappropriate health status identification

(⚠️ I was using `description` to identify and translate the status to ok or ng, but I realized it's inappropriate for such purpose because the some of module's ok status won't be shown as `ok`. for example: 99% of modules will show ok in desc when they're ok, `ceph_osd`'s ok will be `disable` which is not consistent with others o_q...)


<br/>

### Test results (optional)

1). make sure the mentioned/related apis can work properly

make suer won't get the incorrect ng status from ceph_osd

<img width="1728" alt="Screenshot 2025-04-07 at 1 37 36 AM" src="https://github.com/user-attachments/assets/65c18a15-418f-4f41-b043-9acfeb837b0a" />

<br/>
<br/>
<br/>

make suer the status.createdAt and status.updatedAt won't be appeared when the value is empty

<img width="1417" alt="Screenshot 2025-04-07 at 1 44 36 AM" src="https://github.com/user-attachments/assets/a1abe523-efd6-4086-9d2a-1f897e269296" />


