### PR TITLE
Use vm state to identify the actual status of vm rather power state

### DIFF
--- a/internal/cubecos/vm.go
+++ b/internal/cubecos/vm.go
@@ -1,6 +1,8 @@
 package cubecos
 
 import (
+	"strings"
+
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/math"
 	openstack "github.com/bigstack-oss/bigstack-dependency-go/pkg/openstack/v2"
 	definition "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
@@ -34,18 +36,16 @@ func genVmStatusOverview(servers []servers.Server) *VmStatus {
 	vm := &VmStatus{Total: len(servers)}
 
 	for _, server := range servers {
-		switch server.PowerState.String() {
-		case "RUNNING":
+		switch strings.ToLower(server.VmState) {
+		case "active":
 			vm.Running++
-		case "SHUTDOWN":
+		case "stopped":
 			vm.Stopped++
-		case "SUSPENDED":
+		case "suspended":
 			vm.Suspend++
-		case "PAUSED":
+		case "paused":
 			vm.Paused++
-		case "CRASHED":
-			vm.Error++
-		default:
+		case "error":
 			vm.Error++
 		}
 	}


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

<br/>

### Which issue(s) this PR fixes?

#22 

https://github.com/bigstack-oss/cube-cos-ui/issues/218

<br/>

### What this PR does?

- Use vm state to identify the actual status of vm rather power state

(⚠️ Although the official provided `power-state` has the 100 matched status for our needs, the actual behavior from openstack doesn't behave like what it planed. instead, we should use `vm-state` with a bit string conversion to fulfill the e2e case)


<br/>

### Test results (optional)

1). make sure the mentioned/related apis can work properly

<img width="1714" alt="Screenshot 2025-04-07 at 10 51 58 AM" src="https://github.com/user-attachments/assets/23771a92-ec80-499a-b831-934095af3e4a" />

<img width="1717" alt="Screenshot 2025-04-07 at 10 50 04 AM" src="https://github.com/user-attachments/assets/8cb266d9-df83-4d1a-96ac-92a8e17f531a" />



