### PR TITLE
Adjust the response schema for metrics usage history api

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4278,64 +4278,63 @@ const docTemplate = `{
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/components/schemas/GetCpuUsageHistoryOfHostResponse"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/GetMemoryUsageHistoryOfHostResponse"
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/HostMetricHistoryResponse"
                                 },
                                 "examples": {
                                     "example1": {
                                         "summary": "Cpu usage history of host",
                                         "value": {
                                             "code": 200,
-                                            "data": [
-                                                {
-                                                    "time": "2025-03-24T09:39:00+08:00",
-                                                    "value": 10.9059
-                                                },
-                                                {
-                                                    "time": "2025-03-24T09:40:00+08:00",
-                                                    "value": 10.5089
-                                                },
-                                                {
-                                                    "time": "2025-03-24T09:41:00+08:00",
-                                                    "value": 15.3512
-                                                },
-                                                {
-                                                    "time": "2025-03-24T09:42:00+08:00",
-                                                    "value": 12.3685
-                                                }
-                                            ],
+                                            "data": {
+                                                "unit": "percentage",
+                                                "history": [
+                                                    {
+                                                        "time": "2025-03-24T09:39:00+08:00",
+                                                        "value": 10.9059
+                                                    },
+                                                    {
+                                                        "time": "2025-03-24T09:40:00+08:00",
+                                                        "value": 10.5089
+                                                    },
+                                                    {
+                                                        "time": "2025-03-24T09:41:00+08:00",
+                                                        "value": 15.3512
+                                                    },
+                                                    {
+                                                        "time": "2025-03-24T09:42:00+08:00",
+                                                        "value": 12.3685
+                                                    }
+                                                ]
+                                            },
                                             "msg": "fetch metrics successfully",
                                             "status": "ok"
                                         }
                                     },
                                     "example2": {
-                                        "summary": "Memory usage history of host",
+                                        "summary": "Memory size history of host",
                                         "value": {
                                             "code": 200,
-                                            "data": [
-                                                {
-                                                    "time": "2025-03-24T07:06:00+08:00",
-                                                    "value": 55.9796
-                                                },
-                                                {
-                                                    "time": "2025-03-24T07:07:00+08:00",
-                                                    "value": 55.9997
-                                                },
-                                                {
-                                                    "time": "2025-03-24T07:08:00+08:00",
-                                                    "value": 55.9884
-                                                },
-                                                {
-                                                    "time": "2025-03-24T07:09:00+08:00",
-                                                    "value": 55.9449
-                                                }
-                                            ],
+                                            "data": {
+                                                "unit": "sizeMiB",
+                                                "history": [
+                                                    {
+                                                        "time": "2025-04-15T05:42:00+08:00",
+                                                        "value": 25918.1601
+                                                    },
+                                                    {
+                                                        "time": "2025-04-15T05:43:00+08:00",
+                                                        "value": 26017.2656
+                                                    },
+                                                    {
+                                                        "time": "2025-04-15T05:44:00+08:00",
+                                                        "value": 25927.0429
+                                                    },
+                                                    {
+                                                        "time": "2025-04-15T05:45:00+08:00",
+                                                        "value": 25998.707
+                                                    }
+                                                ]
+                                            },
                                             "msg": "fetch metrics successfully",
                                             "status": "ok"
                                         }
@@ -13669,7 +13668,7 @@ const docTemplate = `{
                     }
                 }
             },
-            "GetCpuUsageHistoryOfHostResponse": {
+            "HostMetricHistoryResponse": {
                 "type": "object",
                 "required": [
                     "code",
@@ -13682,34 +13681,21 @@ const docTemplate = `{
                         "type": "integer"
                     },
                     "data": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/TimeValuePair"
-                        }                    },
-                    "msg": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    }
-                }
-            },
-            "GetMemoryUsageHistoryOfHostResponse": {
-                "type": "object",
-                "required": [
-                    "code",
-                    "data",
-                    "msg",
-                    "status"
-                ],
-                "properties": {
-                    "code": {
-                        "type": "integer"
-                    },
-                    "data": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/TimeValuePair"
+                        "type": "object",
+                        "required": [
+                            "unit",
+                            "history"
+                        ],
+                        "properties": {
+                            "unit": {
+                                "type": "string"
+                            },
+                            "history": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/TimeValuePair"
+                                }
+                            }
                         }
                     },
                     "msg": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -4274,64 +4274,63 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/components/schemas/GetCpuUsageHistoryOfHostResponse"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/GetMemoryUsageHistoryOfHostResponse"
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/HostMetricHistoryResponse"
                                 },
                                 "examples": {
                                     "example1": {
                                         "summary": "Cpu usage history of host",
                                         "value": {
                                             "code": 200,
-                                            "data": [
-                                                {
-                                                    "time": "2025-03-24T09:39:00+08:00",
-                                                    "value": 10.9059
-                                                },
-                                                {
-                                                    "time": "2025-03-24T09:40:00+08:00",
-                                                    "value": 10.5089
-                                                },
-                                                {
-                                                    "time": "2025-03-24T09:41:00+08:00",
-                                                    "value": 15.3512
-                                                },
-                                                {
-                                                    "time": "2025-03-24T09:42:00+08:00",
-                                                    "value": 12.3685
-                                                }
-                                            ],
+                                            "data": {
+                                                "unit": "percentage",
+                                                "history": [
+                                                    {
+                                                        "time": "2025-03-24T09:39:00+08:00",
+                                                        "value": 10.9059
+                                                    },
+                                                    {
+                                                        "time": "2025-03-24T09:40:00+08:00",
+                                                        "value": 10.5089
+                                                    },
+                                                    {
+                                                        "time": "2025-03-24T09:41:00+08:00",
+                                                        "value": 15.3512
+                                                    },
+                                                    {
+                                                        "time": "2025-03-24T09:42:00+08:00",
+                                                        "value": 12.3685
+                                                    }
+                                                ]
+                                            },
                                             "msg": "fetch metrics successfully",
                                             "status": "ok"
                                         }
                                     },
                                     "example2": {
-                                        "summary": "Memory usage history of host",
+                                        "summary": "Memory size history of host",
                                         "value": {
                                             "code": 200,
-                                            "data": [
-                                                {
-                                                    "time": "2025-03-24T07:06:00+08:00",
-                                                    "value": 55.9796
-                                                },
-                                                {
-                                                    "time": "2025-03-24T07:07:00+08:00",
-                                                    "value": 55.9997
-                                                },
-                                                {
-                                                    "time": "2025-03-24T07:08:00+08:00",
-                                                    "value": 55.9884
-                                                },
-                                                {
-                                                    "time": "2025-03-24T07:09:00+08:00",
-                                                    "value": 55.9449
-                                                }
-                                            ],
+                                            "data": {
+                                                "unit": "sizeMiB",
+                                                "history": [
+                                                    {
+                                                        "time": "2025-04-15T05:42:00+08:00",
+                                                        "value": 25918.1601
+                                                    },
+                                                    {
+                                                        "time": "2025-04-15T05:43:00+08:00",
+                                                        "value": 26017.2656
+                                                    },
+                                                    {
+                                                        "time": "2025-04-15T05:44:00+08:00",
+                                                        "value": 25927.0429
+                                                    },
+                                                    {
+                                                        "time": "2025-04-15T05:45:00+08:00",
+                                                        "value": 25998.707
+                                                    }
+                                                ]
+                                            },
                                             "msg": "fetch metrics successfully",
                                             "status": "ok"
                                         }
@@ -13665,7 +13664,7 @@
                     }
                 }
             },
-            "GetCpuUsageHistoryOfHostResponse": {
+            "HostMetricHistoryResponse": {
                 "type": "object",
                 "required": [
                     "code",
@@ -13678,34 +13677,21 @@
                         "type": "integer"
                     },
                     "data": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/TimeValuePair"
-                        }                    },
-                    "msg": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    }
-                }
-            },
-            "GetMemoryUsageHistoryOfHostResponse": {
-                "type": "object",
-                "required": [
-                    "code",
-                    "data",
-                    "msg",
-                    "status"
-                ],
-                "properties": {
-                    "code": {
-                        "type": "integer"
-                    },
-                    "data": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/TimeValuePair"
+                        "type": "object",
+                        "required": [
+                            "unit",
+                            "history"
+                        ],
+                        "properties": {
+                            "unit": {
+                                "type": "string"
+                            },
+                            "history": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/TimeValuePair"
+                                }
+                            }
                         }
                     },
                     "msg": {

--- a/internal/api/v1/metrics/memory.go
+++ b/internal/api/v1/metrics/memory.go
@@ -43,8 +43,8 @@ func (h *helper) getMemoryUsageSummary() (any, error) {
 func (h *helper) getMemoryHistory() (any, error) {
 	switch h.entityType {
 	case "host":
-		stmt := h.genHostMemoryUsageHistoryStmt()
-		return cubecos.GetMemoryHistoryOfHost(stmt)
+		stmt := h.genHostMemorySizeHistoryStmt()
+		return cubecos.GetMemorySizeHistoryOfHost(stmt)
 	case "vm":
 		return nil, fmt.Errorf("vm is not supported yet for memory history")
 	}

--- a/internal/api/v1/metrics/parameter.go
+++ b/internal/api/v1/metrics/parameter.go
@@ -90,7 +90,7 @@ func (h *helper) parseLimit() error {
 func (h *helper) parsePast() error {
 	h.past = h.c.DefaultQuery("past", "")
 	if h.past == "" {
-		return nil
+		h.past = "1h"
 	}
 
 	_, err := duration.Str2Duration(h.past)

--- a/internal/api/v1/metrics/stmt.go
+++ b/internal/api/v1/metrics/stmt.go
@@ -177,18 +177,18 @@ func (h *helper) genHostNetworkEgressRankStmt() string {
 func (h *helper) genHostCpuUsageHistoryStmt() string {
 	query := influx.Query{}
 	return query.Bucket("telegraf").
-		Range("start: -1h").
+		Range(fmt.Sprintf("start: -%s", h.past)).
 		Filter(fmt.Sprintf(`fn: (r) => r._measurement == "cpu" and r.host == "%s" and r._field == "usage_idle"`, h.entityId)).
 		Map(`fn: (r) => ({ r with _value: 100.0 - r._value })`).
 		Rename(`columns: {_value: "used"}`).
 		String()
 }
 
-func (h *helper) genHostMemoryUsageHistoryStmt() string {
+func (h *helper) genHostMemorySizeHistoryStmt() string {
 	query := influx.Query{}
 	return query.Bucket("telegraf").
-		Range("start: -1h").
-		Filter(fmt.Sprintf(`fn: (r) => r._measurement == "mem" and r.host == "%s" and r._field == "used_percent"`, h.entityId)).
+		Range(fmt.Sprintf("start: -%s", h.past)).
+		Filter(fmt.Sprintf(`fn: (r) => r._measurement == "mem" and r.host == "%s" and r._field == "used"`, h.entityId)).
 		Rename(`columns: {_value: "used"}`).
 		Keep(`columns: ["_time", "used", "host"]`).
 		String()

--- a/internal/cubecos/metrics.go
+++ b/internal/cubecos/metrics.go
@@ -398,7 +398,7 @@ func GetCpuSummaryOfHost(hostname string) (*definition.ComputeStatistic, error) 
 	}, nil
 }
 
-func GetCpuHistoryOfHost(stmt string) ([]definition.TimeValue, error) {
+func GetCpuHistoryOfHost(stmt string) (*definition.MetricHistory, error) {
 	c, cancel, err := influx.GetQueryCursor(stmt)
 	if err != nil {
 		return nil, err
@@ -406,7 +406,16 @@ func GetCpuHistoryOfHost(stmt string) ([]definition.TimeValue, error) {
 
 	defer cancel()
 	defer c.Close()
-	return parseCpuUsageHistory(c)
+	history, err := parseCpuUsageHistory(c)
+	if err != nil {
+		log.Errorf("metrics: failed to parse cpu usage history: %v", err)
+		return nil, err
+	}
+
+	return &definition.MetricHistory{
+		Unit:    "percentage",
+		History: history,
+	}, nil
 }
 
 func parseCpuUsageHistory(c *api.QueryTableResult) ([]definition.TimeValue, error) {
@@ -478,13 +487,13 @@ func GetCpuUsageRankOfHosts(stmt string) (*definition.MetricRank, error) {
 
 func appendHistoryToCpuUsageRank(rank []definition.RankPoint) {
 	for i, host := range rank {
-		history, err := GetCpuHistoryOfHost(genHostCpuUsageHistoryStmt(host.Id))
+		data, err := GetCpuHistoryOfHost(genHostCpuUsageHistoryStmt(host.Id))
 		if err != nil {
 			log.Errorf("failed to get cpu history of host %s: %v", host.Id, err)
 			continue
 		}
 
-		rank[i].History = history
+		rank[i].History = data.History
 	}
 }
 
@@ -595,6 +604,26 @@ func GetMemoryHistoryOfHost(stmt string) ([]definition.TimeValue, error) {
 	return parseMemoryUsageHistory(c)
 }
 
+func GetMemorySizeHistoryOfHost(stmt string) (*definition.MetricHistory, error) {
+	c, cancel, err := influx.GetQueryCursor(stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	defer cancel()
+	defer c.Close()
+	history, err := parseMemorySizeHistory(c)
+	if err != nil {
+		log.Errorf("metrics: failed to parse memory usage history: %v", err)
+		return nil, err
+	}
+
+	return &definition.MetricHistory{
+		Unit:    "sizeMiB",
+		History: history,
+	}, nil
+}
+
 func parseMemoryUsageHistory(c *api.QueryTableResult) ([]definition.TimeValue, error) {
 	points := []definition.TimeValue{}
 	for c.Next() {
@@ -608,6 +637,27 @@ func parseMemoryUsageHistory(c *api.QueryTableResult) ([]definition.TimeValue, e
 			definition.TimeValue{
 				Time:  definition.TimeLocalRFC3339(date),
 				Value: parseUsedOfHost(c.Record()),
+			},
+		)
+	}
+
+	return points, nil
+}
+
+func parseMemorySizeHistory(c *api.QueryTableResult) ([]definition.TimeValue, error) {
+	points := []definition.TimeValue{}
+	for c.Next() {
+		date, err := time.Parse(eventTimeLayout, c.Record().Time().String())
+		if err != nil {
+			continue
+		}
+
+		value := float64(parseSizeOfHost(c.Record())) / 1024.0 / 1024.0
+		points = append(
+			points,
+			definition.TimeValue{
+				Time:  definition.TimeLocalRFC3339(date),
+				Value: math.RoundDown(value, 4),
 			},
 		)
 	}
@@ -1500,6 +1550,15 @@ func parseUsedOfHost(record *query.FluxRecord) float64 {
 	}
 
 	return math.RoundDown(used, 4)
+}
+
+func parseSizeOfHost(record *query.FluxRecord) int64 {
+	used, ok := record.ValueByKey("used").(int64)
+	if !ok {
+		return 0
+	}
+
+	return used
 }
 
 func parseCpuUsedOfVm(record *query.FluxRecord) float64 {

--- a/internal/definition/v1/metrics.go
+++ b/internal/definition/v1/metrics.go
@@ -47,6 +47,11 @@ type MetricRank struct {
 	Rank []RankPoint `json:"rank"`
 }
 
+type MetricHistory struct {
+	Unit    string      `json:"unit"`
+	History []TimeValue `json:"history"`
+}
+
 type RankPoint struct {
 	Id      string      `json:"id"`
 	Name    string      `json:"name"`


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

<br/>

### Which issue(s) this PR fixes?

#46 #65 

<br/>

### What this PR does?

- Adjust the original history data to be wrapped by `data.unit` and `data.history[]`

- Changes are applied for fetching cpu usage history and memory size history for single host

- Adjust the corresponding api docs

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/62e65a80-ad5a-44fb-917d-62c214544f9e

<br/>
<br/>
<br/>

2). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/0438123f-d2dd-438b-8d22-2f25afd22a9a


