### PR TITLE
Adjust the license desc and add a new GET api for opensearch link

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2583,6 +2583,7 @@ const docTemplate = `{
                                             "data": {
                                                 "licenses": [
                                                     {
+                                                        "name": "example-license",
                                                         "type": "trial",
                                                         "hosts": [
                                                             "example-node-0"
@@ -10223,6 +10224,97 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/opensearch/instances/{instanceId}": {
+            "get": {
+                "operationId": "getOpenSearchInstances",
+                "tags": [
+                    "OpenSearch"
+                ],
+                "summary": "Get OpenSearch instances dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/instanceId"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Get OpenSearch instances dashboard",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetOpenSearchDashboardLinkResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Grafana instances dashboard link",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "link": "http://example-data-center/opensearch/waitingForCosToProvideTheActualPath/instance?var-TID=example-instance-id",
+                                                "enabled": true
+                                            },
+                                            "msg": "fetch top instance link successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to get OpenSearch instances dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -10236,6 +10328,16 @@ const docTemplate = `{
                 },
                 "description": "The name of the data center to operate",
                 "example": "example-data-center"
+            },
+            "instanceId": {
+                "in": "path",
+                "name": "instanceId",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The instance ID of the instance to operate",
+                "example": "example-instance-id"
             },
             "hostname": {
                 "in": "path",
@@ -10362,13 +10464,13 @@ const docTemplate = `{
                     "items": {
                         "type": "string",
                         "enum": [
-                            "cubeCOS",
-                            "cubeCMP"
+                            "CubeCOS",
+                            "CubeCMP"
                         ]
                     }
                 },
                 "description": "The product of the host",
-                "example": "cubeCOS"
+                "example": "CubeCOS"
             },
             "metricType": {
                 "in": "path",
@@ -10492,7 +10594,9 @@ const docTemplate = `{
                         "items": {
                             "type": "object",
                             "required": [
+                                "type",
                                 "name",
+                                "roles",
                                 "version",
                                 "virtualIp",
                                 "isHaEnabled",
@@ -10502,7 +10606,11 @@ const docTemplate = `{
                             ],
                             "properties": {
                                 "type": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "cloud",
+                                        "edge"
+                                    ]
                                 },
                                 "name": {
                                     "type": "string"
@@ -10611,7 +10719,11 @@ const docTemplate = `{
                         ],
                         "properties": {
                             "type": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "cloud",
+                                    "edge"
+                                ]
                             },
                             "name": {
                                 "type": "string"
@@ -11566,6 +11678,7 @@ const docTemplate = `{
                                 "items": {
                                     "type": "object",
                                     "required": [
+                                        "name",
                                         "type",
                                         "hosts",
                                         "serial",
@@ -11577,6 +11690,9 @@ const docTemplate = `{
                                         "status"
                                     ],
                                     "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
                                         "type": {
                                             "type": "string"
                                         },
@@ -11605,27 +11721,7 @@ const docTemplate = `{
                                             }
                                         },
                                         "issue": {
-                                            "type": "object",
-                                            "required": [
-                                                "by",
-                                                "to",
-                                                "hardware",
-                                                "date"
-                                            ],
-                                            "properties": {
-                                                "by": {
-                                                    "type": "string"
-                                                },
-                                                "to": {
-                                                    "type": "string"
-                                                },
-                                                "hardware": {
-                                                    "type": "string"
-                                                },
-                                                "date": {
-                                                    "type": "string"
-                                                }
-                                            }
+                                            "$ref": "#/components/schemas/LicenseIssue"
                                         },
                                         "quantity": {
                                             "type": "string"
@@ -11734,27 +11830,7 @@ const docTemplate = `{
                                         }
                                     },
                                     "issue": {
-                                        "type": "object",
-                                        "required": [
-                                            "by",
-                                            "to",
-                                            "hardware",
-                                            "date"
-                                        ],
-                                        "properties": {
-                                            "by": {
-                                                "type": "string"
-                                            },
-                                            "to": {
-                                                "type": "string"
-                                            },
-                                            "hardware": {
-                                                "type": "string"
-                                            },
-                                            "date": {
-                                                "type": "string"
-                                            }
-                                        }
+                                        "$ref": "#/components/schemas/LicenseIssue"
                                     },
                                     "quantity": {
                                         "type": "string"
@@ -14539,6 +14615,41 @@ const docTemplate = `{
                     }
                 }
             },
+            "GetOpenSearchDashboardLinkResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "link",
+                            "enabled"
+                        ],
+                        "properties": {
+                            "link": {
+                                "type": "string"
+                            },
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
             "MetricRank": {
                 "type": "object",
                 "required": [
@@ -14835,28 +14946,7 @@ const docTemplate = `{
                                 }
                             },
                             "issue": {
-                                "type": "object",
-                                "required": [
-                                    "by",
-                                    "to",
-                                    "hardware",
-                                    "date"
-                                ],
-                                "properties": {
-                                    "by": {
-                                        "type": "string"
-                                    },
-                                    "to": {
-                                        "type": "string"
-                                    },
-                                    "hardware": {
-                                        "type": "string"
-                                    },
-                                    "date": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    }
-                                }
+                                "$ref": "#/components/schemas/LicenseIssue"
                             },
                             "quantity": {
                                 "type": "string"
@@ -15195,6 +15285,35 @@ const docTemplate = `{
                     "uint",
                     "bool"
                 ]
+            },
+            "LicenseIssue": {
+                "type": "object",
+                "required": [
+                    "by",
+                    "to",
+                    "hardware",
+                    "date"
+                ],
+                "properties": {
+                    "by": {
+                        "type": "string"
+                    },
+                    "to": {
+                        "type": "string"
+                    },
+                    "hardware": {
+                        "type": "string",
+                        "description": "this field will be the serial number(s) of the host(s) that the license is issued to. '*' means all hosts, genearlly, it's for trial license only. for the paid license, it will be the comma separated serial numbers of the hosts.",
+                        "enum": [
+                            "*",
+                            "example-serial-number-1,example-serial-number-2,example-serial-number-3 ..."
+                        ]
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
             },
             "ListLicenseCurrentStatus": {
                 "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -2579,6 +2579,7 @@
                                             "data": {
                                                 "licenses": [
                                                     {
+                                                        "name": "example-license",
                                                         "type": "trial",
                                                         "hosts": [
                                                             "example-node-0"
@@ -10219,6 +10220,97 @@
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/opensearch/instances/{instanceId}": {
+            "get": {
+                "operationId": "getOpenSearchInstances",
+                "tags": [
+                    "OpenSearch"
+                ],
+                "summary": "Get OpenSearch instances dashboard",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/instanceId"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Get OpenSearch instances dashboard",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetOpenSearchDashboardLinkResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Grafana instances dashboard link",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "link": "http://example-data-center/opensearch/waitingForCosToProvideTheActualPath/instance?var-TID=example-instance-id",
+                                                "enabled": true
+                                            },
+                                            "msg": "fetch top instance link successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to get OpenSearch instances dashboard: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -10232,6 +10324,16 @@
                 },
                 "description": "The name of the data center to operate",
                 "example": "example-data-center"
+            },
+            "instanceId": {
+                "in": "path",
+                "name": "instanceId",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The instance ID of the instance to operate",
+                "example": "example-instance-id"
             },
             "hostname": {
                 "in": "path",
@@ -10358,13 +10460,13 @@
                     "items": {
                         "type": "string",
                         "enum": [
-                            "cubeCOS",
-                            "cubeCMP"
+                            "CubeCOS",
+                            "CubeCMP"
                         ]
                     }
                 },
                 "description": "The product of the host",
-                "example": "cubeCOS"
+                "example": "CubeCOS"
             },
             "metricType": {
                 "in": "path",
@@ -10488,7 +10590,9 @@
                         "items": {
                             "type": "object",
                             "required": [
+                                "type",
                                 "name",
+                                "roles",
                                 "version",
                                 "virtualIp",
                                 "isHaEnabled",
@@ -10498,7 +10602,11 @@
                             ],
                             "properties": {
                                 "type": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "cloud",
+                                        "edge"
+                                    ]
                                 },
                                 "name": {
                                     "type": "string"
@@ -10607,7 +10715,11 @@
                         ],
                         "properties": {
                             "type": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "cloud",
+                                    "edge"
+                                ]
                             },
                             "name": {
                                 "type": "string"
@@ -11562,6 +11674,7 @@
                                 "items": {
                                     "type": "object",
                                     "required": [
+                                        "name",
                                         "type",
                                         "hosts",
                                         "serial",
@@ -11573,6 +11686,9 @@
                                         "status"
                                     ],
                                     "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
                                         "type": {
                                             "type": "string"
                                         },
@@ -11601,27 +11717,7 @@
                                             }
                                         },
                                         "issue": {
-                                            "type": "object",
-                                            "required": [
-                                                "by",
-                                                "to",
-                                                "hardware",
-                                                "date"
-                                            ],
-                                            "properties": {
-                                                "by": {
-                                                    "type": "string"
-                                                },
-                                                "to": {
-                                                    "type": "string"
-                                                },
-                                                "hardware": {
-                                                    "type": "string"
-                                                },
-                                                "date": {
-                                                    "type": "string"
-                                                }
-                                            }
+                                            "$ref": "#/components/schemas/LicenseIssue"
                                         },
                                         "quantity": {
                                             "type": "string"
@@ -11730,27 +11826,7 @@
                                         }
                                     },
                                     "issue": {
-                                        "type": "object",
-                                        "required": [
-                                            "by",
-                                            "to",
-                                            "hardware",
-                                            "date"
-                                        ],
-                                        "properties": {
-                                            "by": {
-                                                "type": "string"
-                                            },
-                                            "to": {
-                                                "type": "string"
-                                            },
-                                            "hardware": {
-                                                "type": "string"
-                                            },
-                                            "date": {
-                                                "type": "string"
-                                            }
-                                        }
+                                        "$ref": "#/components/schemas/LicenseIssue"
                                     },
                                     "quantity": {
                                         "type": "string"
@@ -14535,6 +14611,41 @@
                     }
                 }
             },
+            "GetOpenSearchDashboardLinkResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "link",
+                            "enabled"
+                        ],
+                        "properties": {
+                            "link": {
+                                "type": "string"
+                            },
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
             "MetricRank": {
                 "type": "object",
                 "required": [
@@ -14831,28 +14942,7 @@
                                 }
                             },
                             "issue": {
-                                "type": "object",
-                                "required": [
-                                    "by",
-                                    "to",
-                                    "hardware",
-                                    "date"
-                                ],
-                                "properties": {
-                                    "by": {
-                                        "type": "string"
-                                    },
-                                    "to": {
-                                        "type": "string"
-                                    },
-                                    "hardware": {
-                                        "type": "string"
-                                    },
-                                    "date": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    }
-                                }
+                                "$ref": "#/components/schemas/LicenseIssue"
                             },
                             "quantity": {
                                 "type": "string"
@@ -15191,6 +15281,35 @@
                     "uint",
                     "bool"
                 ]
+            },
+            "LicenseIssue": {
+                "type": "object",
+                "required": [
+                    "by",
+                    "to",
+                    "hardware",
+                    "date"
+                ],
+                "properties": {
+                    "by": {
+                        "type": "string"
+                    },
+                    "to": {
+                        "type": "string"
+                    },
+                    "hardware": {
+                        "type": "string",
+                        "description": "this field will be the serial number(s) of the host(s) that the license is issued to. '*' means all hosts, genearlly, it's for trial license only. for the paid license, it will be the comma separated serial numbers of the hosts.",
+                        "enum": [
+                            "*",
+                            "example-serial-number-1, example-serial-number-2, ..."
+                        ]
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
             },
             "ListLicenseCurrentStatus": {
                 "type": "string",

--- a/internal/api/v1/datacenters/handlers.go
+++ b/internal/api/v1/datacenters/handlers.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-// TODO M2: the data center info will be persisted and retrieved from the database
+// M2 plan: the data center info will be persisted and retrieved from the database
 // M1 only has one data center, so just return the current one
 func listDataCenters(c *gin.Context) {
 	api.SetStatusOk(

--- a/internal/api/v1/licenses/filter.go
+++ b/internal/api/v1/licenses/filter.go
@@ -2,6 +2,7 @@ package licenses
 
 import (
 	"slices"
+	"strings"
 
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/blevesearch/bleve/v2"
@@ -75,9 +76,10 @@ func (h *helper) filteredByType(licenses []v1.License) []v1.License {
 }
 
 func (h *helper) filteredByProduct(licenses []v1.License) []v1.License {
+	v1.ToLowerInPlace(h.Products)
 	filtered := []v1.License{}
 	for _, license := range licenses {
-		if slices.Contains(h.Products, license.Product.Name) {
+		if slices.Contains(h.Products, strings.ToLower(license.Product.Name)) {
 			filtered = append(filtered, license)
 		}
 	}

--- a/internal/api/v1/nodes/filter.go
+++ b/internal/api/v1/nodes/filter.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"slices"
+	"strings"
 
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
 	"github.com/blevesearch/bleve/v2"
@@ -68,9 +69,10 @@ func (h *helper) filteredByLicenseStatus(nodes []v1.Node) []v1.Node {
 }
 
 func (h *helper) filteredByProduct(nodes []v1.Node) []v1.Node {
+	v1.ToLowerInPlace(h.products)
 	filtered := []v1.Node{}
 	for _, node := range nodes {
-		if slices.Contains(h.products, node.License.Product.Name) {
+		if slices.Contains(h.products, strings.ToLower(node.License.Product.Name)) {
 			filtered = append(filtered, node)
 		}
 	}

--- a/internal/api/v1/opensearch/handlers.go
+++ b/internal/api/v1/opensearch/handlers.go
@@ -1,0 +1,31 @@
+package opensearch
+
+import (
+	"net/http"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/api"
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	Handlers = []api.Handler{
+		{
+			Version: api.V1,
+			Method:  http.MethodGet,
+			Path:    "/opensearch/instances/:instanceId",
+			Func:    forwardInstanceLink,
+		},
+	}
+)
+
+func forwardInstanceLink(c *gin.Context) {
+	api.SetStatusOk(
+		c,
+		"fetch instance link successfully",
+		v1.Dashboard{
+			Link:    genInstanceLink(c),
+			Enabled: true,
+		},
+	)
+}

--- a/internal/api/v1/opensearch/links.go
+++ b/internal/api/v1/opensearch/links.go
@@ -1,0 +1,16 @@
+package opensearch
+
+import (
+	"fmt"
+
+	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
+	"github.com/gin-gonic/gin"
+)
+
+func genInstanceLink(c *gin.Context) string {
+	return fmt.Sprintf(
+		"https://%s/opensearch/fake/instance/url/%s",
+		v1.DataCenterVip,
+		c.Param("instanceId"),
+	)
+}

--- a/internal/definition/v1/datacenter.go
+++ b/internal/definition/v1/datacenter.go
@@ -4,6 +4,10 @@ const (
 	DataCenters = "datacenters"
 )
 
+var (
+	ServiceDiscoveryIdentity = ""
+)
+
 type DataCenter struct {
 	Type        string   `json:"type" bson:"type"`
 	Id          string   `json:"id,omitempty" bson:"id"`

--- a/internal/definition/v1/node.go
+++ b/internal/definition/v1/node.go
@@ -284,14 +284,14 @@ func GetRegisteredServices() ([]*registry.Service, error) {
 	getRegisteredServices.Lock()
 	defer getRegisteredServices.Unlock()
 
-	svcs, err := registry.GetService(DataCenterName)
+	svcs, err := registry.GetService(ServiceDiscoveryIdentity)
 	if err != nil {
-		log.Errorf("failed to get service from %s (%s)", DataCenterName, err.Error())
+		log.Errorf("failed to get service from %s (%s)", ServiceDiscoveryIdentity, err.Error())
 		return nil, err
 	}
 
 	if len(svcs) <= 0 {
-		err := fmt.Errorf("no any service find from %s", DataCenterName)
+		err := fmt.Errorf("no any service find from %s", ServiceDiscoveryIdentity)
 		log.Errorf(err.Error())
 		return nil, err
 	}

--- a/internal/definition/v1/opensearch.go
+++ b/internal/definition/v1/opensearch.go
@@ -1,0 +1,5 @@
+package v1
+
+const (
+	OpenSearch = "opensearch"
+)

--- a/internal/definition/v1/string.go
+++ b/internal/definition/v1/string.go
@@ -1,0 +1,9 @@
+package v1
+
+import "strings"
+
+func ToLowerInPlace(ss []string) {
+	for i, v := range ss {
+		ss[i] = strings.ToLower(v)
+	}
+}

--- a/internal/operators/v1/node/node.go
+++ b/internal/operators/v1/node/node.go
@@ -42,7 +42,7 @@ func (o *Operator) Init() error {
 
 func (o *Operator) Run() {
 	watcher, err := registry.Watch(
-		registry.WatchService(v1.DataCenterName),
+		registry.WatchService(v1.ServiceDiscoveryIdentity),
 	)
 	if err != nil {
 		log.Errorf("nodes: failed to create watcher (%s)", err.Error())

--- a/internal/runtime/dependency.go
+++ b/internal/runtime/dependency.go
@@ -120,6 +120,12 @@ func newAuthIdentities() error {
 		return err
 	}
 
+	v1.NodeMetadata, err = genNodeMetadata()
+	if err != nil {
+		log.Errorf("runtime: failed to generate node metadata: %s", err.Error())
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"fmt"
+
 	conf "github.com/bigstack-oss/cube-cos-api/internal/config"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
@@ -70,6 +72,12 @@ func initIdentities() error {
 		return err
 	}
 
+	v1.ServiceDiscoveryIdentity, err = parseServiceDiscoveryIdentity()
+	if err != nil {
+		log.Errorf("runtime: failed to parse service discovery identify: %s", err.Error())
+		return err
+	}
+
 	v1.DataCenterVersion, err = cubecos.GetDataCenterVersion()
 	if err != nil {
 		log.Errorf("runtime: failed to get data center version: %s", err.Error())
@@ -128,13 +136,23 @@ func initIdentities() error {
 		return err
 	}
 
-	v1.NodeMetadata, err = genNodeMetadata()
-	if err != nil {
-		log.Errorf("runtime: failed to generate node metadata: %s", err.Error())
-		return err
+	return nil
+}
+
+func parseServiceDiscoveryIdentity() (string, error) {
+	if v1.DataCenterName == "" {
+		return "", errors.InvalidDataCenterName
 	}
 
-	return nil
+	if v1.DataCenterVip == "" {
+		return "", errors.InvalidListenAddress
+	}
+
+	return fmt.Sprintf(
+		"%s-%s",
+		v1.DataCenterName,
+		v1.DataCenterVip,
+	), nil
 }
 
 func parseLocalListenAddr() (string, error) {

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/me"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/metrics"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/opensearch"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/services"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/settings"
 	"github.com/bigstack-oss/cube-cos-api/internal/api/v1/supportfiles"
@@ -218,6 +219,14 @@ func prepareApisHandlerByRole() {
 	api.RegisterHandlersToRoles(
 		v1.Grafana,
 		grafana.Handlers,
+		v1.RoleControl,
+		v1.RoleControlConverged,
+		v1.RoleModerator,
+	)
+
+	api.RegisterHandlersToRoles(
+		v1.OpenSearch,
+		opensearch.Handlers,
 		v1.RoleControl,
 		v1.RoleControlConverged,
 		v1.RoleModerator,

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -44,7 +44,7 @@ func newHttpServer() (*server.Server, error) {
 	}
 
 	srv := http.NewServer(
-		server.Name(v1.DataCenterName),
+		server.Name(v1.ServiceDiscoveryIdentity),
 		server.Metadata(v1.NodeMetadata),
 		server.WithLogger(log.DefaultLogger),
 		server.Address(v1.ListenAddr),


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

<br/>

### Which issue(s) this PR fixes?

#39 

<br/>

### What this PR does?

- License: change the enum product example to start with a capital

- License: add missed name field in the license related apis (api has returned the field, but missed doc)

- License: enrich the desc for license.hardware (to elaborate more for the hardware serial)

- OpenSearch: add a GET api to fetch the opensearch link for single instanceId

<br/>

### Test results (optional)

1). make sure the corresponding api doc has changed accordingly

- License: change the enum product example to start with a capital

![Screenshot 2025-04-25 at 4 29 17 PM](https://github.com/user-attachments/assets/8e66abc9-05d6-4c4f-8637-a15baa449310)

<br/>

- License: add missed name field in the license related apis (api has returned the field, but missed doc)

![Screenshot 2025-04-25 at 4 48 10 PM](https://github.com/user-attachments/assets/0fa17858-4cfb-4c23-af03-973e1c25f012)

<br/>

- License: enrich the desc for license.hardware (to elaborate more for the hardware serial)

![Screenshot 2025-04-25 at 4 28 55 PM](https://github.com/user-attachments/assets/a50a8aa7-6492-47c3-a8df-b919c5e86542)

<br/>

- OpenSearch: add a GET api to fetch the opensearch link for single instanceId

![Screenshot 2025-04-25 at 4 29 59 PM](https://github.com/user-attachments/assets/12e46522-b88f-4b82-adf0-bd34e130ee8f)

<br/>
<br/>



