### PR TITLE
Auto aggregate the metrics if the query duration is too large

### DIFF
--- a/internal/api/v1/metrics/handlers.go
+++ b/internal/api/v1/metrics/handlers.go
@@ -39,7 +39,7 @@ func init() {
 func getDataCenterSummary(c *gin.Context) {
 	h, err := initHelper(c, "getDataCenterSummary")
 	if err != nil {
-		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		log.Errorf("metrics(%s): %v", api.GetReqId(c), err)
 		api.SetBadRequest(c, err)
 		return
 	}
@@ -56,14 +56,14 @@ func getDataCenterSummary(c *gin.Context) {
 func getMetrics(c *gin.Context) {
 	h, err := initHelper(c, "getMetrics")
 	if err != nil {
-		log.Errorf("request(%s): %v", api.GetReqId(c), err)
+		log.Errorf("metrics(%s): %v", api.GetReqId(c), err)
 		api.SetBadRequest(c, err)
 		return
 	}
 
 	metrics, err := h.getMetrics()
 	if err != nil {
-		log.Errorf("request(%s): failed to fetch metrics: %v", api.GetReqId(c), err)
+		log.Errorf("metrics(%s): failed to fetch %s: %v", api.GetReqId(c), h.metricType, err)
 		api.SetBadRequest(c, err)
 		return
 	}

--- a/internal/api/v1/metrics/helper.go
+++ b/internal/api/v1/metrics/helper.go
@@ -18,7 +18,8 @@ type helper struct {
 	entityId   string
 
 	v1.Period
-	past string
+	past            string
+	aggregateWindow string
 
 	limit int
 	rank

--- a/internal/api/v1/metrics/parameter.go
+++ b/internal/api/v1/metrics/parameter.go
@@ -15,7 +15,8 @@ import (
 func (h *helper) parseParams() error {
 	parsers := []func() error{
 		h.parseView, h.parseMetric, h.parseEntity, h.parseEntityId,
-		h.parsePast, h.parsePeriod, h.parseRank, h.parseLimit, h.parseWatch,
+		h.parsePast, h.parseAggregateWindow, h.parsePeriod,
+		h.parseRank, h.parseLimit, h.parseWatch,
 	}
 
 	for _, parse := range parsers {
@@ -96,6 +97,33 @@ func (h *helper) parsePast() error {
 	_, err := duration.Str2Duration(h.past)
 	if err != nil {
 		return fmt.Errorf("invalid 'past' duration: %s", h.past)
+	}
+
+	return nil
+}
+
+func (h *helper) parseAggregateWindow() error {
+	h.aggregateWindow = h.c.DefaultQuery("aggregateWindow", "")
+	if h.aggregateWindow == "" {
+		h.aggregateWindow = "1m"
+	}
+
+	_, err := duration.Str2Duration(h.aggregateWindow)
+	if err != nil {
+		return fmt.Errorf("invalid 'aggregateWindow' duration: %s", h.aggregateWindow)
+	}
+
+	past, err := duration.Str2Duration(h.past)
+	if err != nil {
+		return fmt.Errorf("invalid 'past' duration: %s", h.past)
+	}
+
+	if past > 12*time.Hour {
+		h.aggregateWindow = "30m"
+	}
+
+	if past > 24*time.Hour {
+		h.aggregateWindow = "1h"
 	}
 
 	return nil

--- a/internal/api/v1/metrics/stmt.go
+++ b/internal/api/v1/metrics/stmt.go
@@ -179,6 +179,7 @@ func (h *helper) genHostCpuUsageHistoryStmt() string {
 	return query.Bucket("telegraf").
 		Range(fmt.Sprintf("start: -%s", h.past)).
 		Filter(fmt.Sprintf(`fn: (r) => r._measurement == "cpu" and r.host == "%s" and r._field == "usage_idle"`, h.entityId)).
+		AggregateWindow(fmt.Sprintf(`every: %s, fn: mean, createEmpty: false`, h.aggregateWindow)).
 		Map(`fn: (r) => ({ r with _value: 100.0 - r._value })`).
 		Rename(`columns: {_value: "used"}`).
 		String()
@@ -189,6 +190,7 @@ func (h *helper) genHostMemorySizeHistoryStmt() string {
 	return query.Bucket("telegraf").
 		Range(fmt.Sprintf("start: -%s", h.past)).
 		Filter(fmt.Sprintf(`fn: (r) => r._measurement == "mem" and r.host == "%s" and r._field == "used"`, h.entityId)).
+		AggregateWindow(fmt.Sprintf(`every: %s, fn: mean, createEmpty: false`, h.aggregateWindow)).
 		Rename(`columns: {_value: "used"}`).
 		Keep(`columns: ["_time", "used", "host"]`).
 		String()

--- a/internal/cubecos/metrics.go
+++ b/internal/cubecos/metrics.go
@@ -1552,13 +1552,13 @@ func parseUsedOfHost(record *query.FluxRecord) float64 {
 	return math.RoundDown(used, 4)
 }
 
-func parseSizeOfHost(record *query.FluxRecord) int64 {
-	used, ok := record.ValueByKey("used").(int64)
+func parseSizeOfHost(record *query.FluxRecord) float64 {
+	used, ok := record.ValueByKey("used").(float64)
 	if !ok {
 		return 0
 	}
 
-	return used
+	return math.RoundDown(used, 4)
 }
 
 func parseCpuUsedOfVm(record *query.FluxRecord) float64 {

--- a/internal/operators/v1/node/node.go
+++ b/internal/operators/v1/node/node.go
@@ -54,7 +54,7 @@ func (o *Operator) Run() {
 	case <-o.ctx.Done():
 		return
 	default:
-		o.watchAndSyncNodeRoles(&watcher)
+		o.watchAndSyncNodes(&watcher)
 	}
 }
 
@@ -62,7 +62,7 @@ func (o *Operator) Stop() {
 	o.cancel()
 }
 
-func (o *Operator) watchAndSyncNodeRoles(watcher *registry.Watcher) {
+func (o *Operator) watchAndSyncNodes(watcher *registry.Watcher) {
 	event, err := (*watcher).Next()
 	if err != nil {
 		log.Errorf("nodes: failed to get service discovery event", err.Error())

--- a/internal/runtime/identity.go
+++ b/internal/runtime/identity.go
@@ -1,12 +1,9 @@
 package runtime
 
 import (
-	"fmt"
-
 	conf "github.com/bigstack-oss/cube-cos-api/internal/config"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	v1 "github.com/bigstack-oss/cube-cos-api/internal/definition/v1"
-	"github.com/bigstack-oss/cube-cos-api/internal/errors"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -137,44 +134,4 @@ func initIdentities() error {
 	}
 
 	return nil
-}
-
-func parseServiceDiscoveryIdentity() (string, error) {
-	if v1.DataCenterName == "" {
-		return "", errors.InvalidDataCenterName
-	}
-
-	if v1.DataCenterVip == "" {
-		return "", errors.InvalidListenAddress
-	}
-
-	return fmt.Sprintf(
-		"%s-%s",
-		v1.DataCenterName,
-		v1.DataCenterVip,
-	), nil
-}
-
-func parseLocalListenAddr() (string, error) {
-	if conf.Opts.Spec.Listen.Local == "" {
-		return "", errors.InvalidListenAddress
-	}
-
-	return conf.Opts.Spec.Listen.Local, nil
-}
-
-func parseLocalListenPort() (int, error) {
-	if conf.Opts.Spec.Listen.Port == 0 {
-		return 0, errors.InvalidListenPort
-	}
-
-	return conf.Opts.Spec.Listen.Port, nil
-}
-
-func parseAdvertisePort() (int, error) {
-	if conf.Opts.Spec.Listen.Port == 0 {
-		return 0, errors.InvalidListenPort
-	}
-
-	return conf.Opts.Spec.Listen.Port, nil
 }

--- a/internal/runtime/parser.go
+++ b/internal/runtime/parser.go
@@ -11,6 +11,46 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func parseServiceDiscoveryIdentity() (string, error) {
+	if v1.DataCenterName == "" {
+		return "", errors.InvalidDataCenterName
+	}
+
+	if v1.DataCenterVip == "" {
+		return "", errors.InvalidListenAddress
+	}
+
+	return fmt.Sprintf(
+		"%s-%s",
+		v1.DataCenterName,
+		v1.DataCenterVip,
+	), nil
+}
+
+func parseLocalListenAddr() (string, error) {
+	if conf.Opts.Spec.Listen.Local == "" {
+		return "", errors.InvalidListenAddress
+	}
+
+	return conf.Opts.Spec.Listen.Local, nil
+}
+
+func parseLocalListenPort() (int, error) {
+	if conf.Opts.Spec.Listen.Port == 0 {
+		return 0, errors.InvalidListenPort
+	}
+
+	return conf.Opts.Spec.Listen.Port, nil
+}
+
+func parseAdvertisePort() (int, error) {
+	if conf.Opts.Spec.Listen.Port == 0 {
+		return 0, errors.InvalidListenPort
+	}
+
+	return conf.Opts.Spec.Listen.Port, nil
+}
+
 func parseParams(c *gin.Context) string {
 	if c.Request.URL.RawQuery == "" {
 		return ""


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

#65 #46 

<br/>

### What this PR does?

In order to avoid the time series point to be too dense, we do the auto aggregation for time series data like cpu, memory, and so on if the query duration is too large

The behavior for making the decision on the aggregation window is

  -  if query duration <= 12 hrs: 1 min

  -  if query duration > 12 hrs: 30 min

  -  if query duration > 24 hrs: 1 hr


<br/>

### Test results (optional)

1). make sure the corresponding apis work well

https://github.com/user-attachments/assets/82f64d38-cc80-4db6-85d2-a3a3eeea81ff






