### PR TITLE
Add a missed 'unlicense' status in the query enum from the PR#224

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3021,7 +3021,7 @@ const docTemplate = `{
                         "$ref": "#/components/parameters/roles"
                     },
                     {
-                        "$ref": "#/components/parameters/listLicenseStatuses"
+                        "$ref": "#/components/parameters/listLicenseAttachmentStatuses"
                     }
                 ],
                 "responses": {
@@ -10542,6 +10542,19 @@ const docTemplate = `{
                 "description": "The status of the host",
                 "example": "valid"
             },
+            "listLicenseAttachmentStatuses": {
+                "in": "query",
+                "name": "statuses",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
+                    }
+                },
+                "description": "The status of the host",
+                "example": "valid"
+            },
             "types": {
                 "in": "query",
                 "name": "types",
@@ -12116,7 +12129,7 @@ const docTemplate = `{
                                     "type": "string"
                                 },
                                 "status": {
-                                    "type": "string"
+                                    "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
                                 }
                             }
                         }

--- a/api/docs.json
+++ b/api/docs.json
@@ -3017,7 +3017,7 @@
                         "$ref": "#/components/parameters/roles"
                     },
                     {
-                        "$ref": "#/components/parameters/listLicenseStatuses"
+                        "$ref": "#/components/parameters/listLicenseAttachmentStatuses"
                     }
                 ],
                 "responses": {
@@ -10538,6 +10538,19 @@
                 "description": "The status of the host",
                 "example": "valid"
             },
+            "listLicenseAttachmentStatuses": {
+                "in": "query",
+                "name": "statuses",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
+                    }
+                },
+                "description": "The status of the host",
+                "example": "valid"
+            },
             "types": {
                 "in": "query",
                 "name": "types",
@@ -12112,7 +12125,7 @@
                                     "type": "string"
                                 },
                                 "status": {
-                                    "type": "string"
+                                    "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
                                 }
                             }
                         }


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-api/issues/224

<br/>

### What this PR does?

as titled

quick api doc fix for the missed part from https://github.com/bigstack-oss/cube-cos-api/pull/224

