### PR TITLE
Align the disk r/w iops between chart and grafana

### DIFF
--- a/internal/apis/v1/handlers/metrics/stmt.go
+++ b/internal/apis/v1/handlers/metrics/stmt.go
@@ -90,8 +90,7 @@ func (h *helper) genHostsStorageReadIopsStmt() string {
 		AggregateWindow(`every: 60s, fn: sum, createEmpty: false`).
 		Derivative(`unit: 1s, nonNegative: true`).
 		Group(`columns: ["_time"]`).
-		Max(`column: "_value"`).
-		Group("").
+		Sum(`column: "_value"`).
 		String()
 }
 
@@ -103,8 +102,7 @@ func (h *helper) genHostsStorageWriteIopsStmt() string {
 		AggregateWindow(`every: 60s, fn: sum, createEmpty: false`).
 		Derivative(`unit: 1s, nonNegative: true`).
 		Group(`columns: ["_time"]`).
-		Max(`column: "_value"`).
-		Group("").
+		Sum(`column: "_value"`).
 		String()
 }
 


### PR DESCRIPTION
### What type of PR is this?

Fix and refactor

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/96

<br/>

### What this PR does?

- Align the disk r/w iops between chart and Grafana

<br/>

### Test results (optional)

1). make sure Chart's disk latency pattern align with Grafana

![Screenshot 2025-05-20 at 3 35 49 AM](https://github.com/user-attachments/assets/a82e419b-ddc6-46b3-b01d-825bdb8d4bad)

<img width="1721" alt="Screenshot 2025-05-20 at 3 35 56 AM" src="https://github.com/user-attachments/assets/4df894d0-36ca-4f10-bddb-8a92055ca4c6" />

<img width="1716" alt="Screenshot 2025-05-20 at 3 36 13 AM" src="https://github.com/user-attachments/assets/9e788e7f-4e92-4d61-a152-4a007634bd28" />

