### PR TITLE
Add support file deletion api

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -9743,6 +9743,251 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/supportFiles/{supportFileSet}": {
+            "delete": {
+                "operationId": "DeleteSupportFiles",
+                "tags": [
+                    "Support Files"
+                ],
+                "summary": "Delete support file set",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "supportFileSet",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the support file set to delete. (have to be done the http encode)",
+                        "example": "Cube Appliance 3.0.0 Support File Set 2025-06-18T15:54:48+00:00"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Delete support files successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeleteSupportFileSetResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Delete support file set",
+                                        "value": {
+                                            "code": 200,
+                                            "msg": "support file set deleted successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "support file set not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete support files: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "createSupportFiles",
+                "tags": [
+                    "Support Files"
+                ],
+                "summary": "Create one or more support files",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateSupportFilesRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Support file creation request",
+                                    "value": {
+                                        "description": "example-description",
+                                        "hosts": [
+                                            "example-node-0"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Support file creation request received",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreateSupportFilesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Support file creation response",
+                                        "value": {
+                                            "code": 202,
+                                            "msg": "support file creation request received",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid host found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to request support file creation: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/supportFiles/hosts/{hostname}": {
             "get": {
                 "operationId": "getHostSupportFile",
@@ -13403,6 +13648,25 @@ const docTemplate = `{
                                 "$ref": "#/components/schemas/Page"
                             }
                         }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "DeleteSupportFileSetResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
                     },
                     "msg": {
                         "type": "string"

--- a/api/docs.json
+++ b/api/docs.json
@@ -9739,6 +9739,251 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/supportFiles/{supportFileSet}": {
+            "delete": {
+                "operationId": "DeleteSupportFiles",
+                "tags": [
+                    "Support Files"
+                ],
+                "summary": "Delete support file set",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "supportFileSet",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The name of the support file set to delete. (have to be done the http encode)",
+                        "example": "Cube Appliance 3.0.0 Support File Set 2025-06-18T15:54:48+00:00"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Delete support files successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeleteSupportFileSetResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Delete support file set",
+                                        "value": {
+                                            "code": 200,
+                                            "msg": "support file set deleted successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "support file set not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete support files: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "createSupportFiles",
+                "tags": [
+                    "Support Files"
+                ],
+                "summary": "Create one or more support files",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateSupportFilesRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Support file creation request",
+                                    "value": {
+                                        "description": "example-description",
+                                        "hosts": [
+                                            "example-node-0"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Support file creation request received",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreateSupportFilesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Support file creation response",
+                                        "value": {
+                                            "code": 202,
+                                            "msg": "support file creation request received",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid host found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 401
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid_grant: Invalid user credentials"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "unauthorized"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to request support file creation: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/supportFiles/hosts/{hostname}": {
             "get": {
                 "operationId": "getHostSupportFile",
@@ -13399,6 +13644,25 @@
                                 "$ref": "#/components/schemas/Page"
                             }
                         }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "DeleteSupportFileSetResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
                     },
                     "msg": {
                         "type": "string"

--- a/internal/apis/v1/handlers/supportfiles/delegation.go
+++ b/internal/apis/v1/handlers/supportfiles/delegation.go
@@ -180,10 +180,14 @@ func (h *helper) deleteSupportFileGroup() error {
 		return err
 	}
 
+	return h.deleteSupportFiles(hosts)
+}
+
+func (h *helper) deleteSupportFiles(hosts []string) error {
 	for _, host := range hosts {
-		file, err := h.GetSupportFileByGroup(h.group.Name)
+		file, err := h.GetHostSupportFile(h.group.Name, host)
 		if err != nil {
-			log.Errorf("supportFiles(%s): failed to get support file by group %s: %v", h.reqId, h.group.Name, err)
+			log.Warnf("supportFiles(%s): failed to get support file by group %s(%v)", h.reqId, h.group.Name, err)
 			continue
 		}
 
@@ -194,7 +198,7 @@ func (h *helper) deleteSupportFileGroup() error {
 
 		node, err := nodes.Get(host)
 		if err != nil {
-			log.Errorf("supportFiles(%s): failed to get node by hostname %s: %v", h.reqId, host, err)
+			log.Errorf("supportFiles(%s): failed to get node by hostname %s(%v)", h.reqId, host, err)
 			continue
 		}
 
@@ -208,22 +212,23 @@ func (h *helper) deleteSupportFileGroup() error {
 			continue
 		}
 
-		h.deletePeerNodeSupportFiles(node)
+		h.deletePeerFile(node, file.Name)
 	}
 
 	return nil
 }
 
-func (h *helper) deletePeerNodeSupportFiles(node *nodes.Node) {
-	url := node.DeleteSupportFileUrl(h.group.Name)
+func (h *helper) deletePeerFile(node *nodes.Node, filename string) {
+	url := node.DeleteSupportFileUrl(h.group.Name, filename)
 	http := http.GetGlobalHelper()
 	resp, err := http.R().SetHeaders(nodes.GetSecretHeaders()).Delete(url)
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to delete support file group %s from %s: %v", h.reqId, h.group.Name, node.Hostname, err)
+		log.Errorf("supportFiles(%s): failed to delete support file group %s from %s(%v)", h.reqId, h.group.Name, node.Hostname, err)
 		return
 	}
+
 	if resp.IsError() {
-		log.Errorf("supportFiles(%s): %s resp error from %s: %s", h.reqId, h.group.Name, node.Hostname, string(resp.Body()))
+		log.Errorf("supportFiles(%s): %s resp error from %s(%s)", h.reqId, h.group.Name, node.Hostname, string(resp.Body()))
 		return
 	}
 
@@ -235,7 +240,7 @@ func (h *helper) deletePeerNodeSupportFiles(node *nodes.Node) {
 	)
 }
 
-func (h *helper) GetSupportFileByGroup(group string) (*support.File, error) {
+func (h *helper) GetHostSupportFile(group, host string) (*support.File, error) {
 	sets, err := h.listSupportFileSets()
 	if err != nil {
 		return nil, err
@@ -246,16 +251,28 @@ func (h *helper) GetSupportFileByGroup(group string) (*support.File, error) {
 			continue
 		}
 
-		for _, file := range set.Files {
-			if file.Source.Host != base.Hostname {
-				continue
-			}
-
-			return &file, nil
+		file, found := h.findFile(set, host)
+		if found {
+			return file, nil
 		}
 	}
 
-	return nil, fmt.Errorf("support file group(%s) not found", group)
+	return nil, fmt.Errorf(
+		"support file group(%s) not found",
+		group,
+	)
+}
+
+func (h *helper) findFile(set support.FileSet, host string) (*support.File, bool) {
+	for _, file := range set.Files {
+		if file.Source.Host != host {
+			continue
+		}
+
+		return &file, true
+	}
+
+	return nil, false
 }
 
 func (h *helper) streamDownloadByPeerNode(set support.FileSet, file support.File) {

--- a/internal/apis/v1/handlers/supportfiles/delegation.go
+++ b/internal/apis/v1/handlers/supportfiles/delegation.go
@@ -8,6 +8,7 @@ import (
 	ostime "time"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
@@ -170,6 +171,91 @@ func (h *helper) streamFileDownload(filename string) {
 		file,
 		nil,
 	)
+}
+
+func (h *helper) deleteSupportFileGroup() error {
+	hosts, err := h.getHostsByGroup(h.group.Name)
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to get hosts by group %s: %v", h.reqId, h.group.Name, err)
+		return err
+	}
+
+	for _, host := range hosts {
+		file, err := h.GetSupportFileByGroup(h.group.Name)
+		if err != nil {
+			log.Errorf("supportFiles(%s): failed to get support file by group %s: %v", h.reqId, h.group.Name, err)
+			continue
+		}
+
+		if file.IsCreating() {
+			log.Warnf("supportFiles(%s): group %s has creating file, skip to delete", h.reqId, h.group.Name)
+			return errors.New("has creating file, skip to delete")
+		}
+
+		node, err := nodes.Get(host)
+		if err != nil {
+			log.Errorf("supportFiles(%s): failed to get node by hostname %s: %v", h.reqId, host, err)
+			continue
+		}
+
+		if node.IsLocal() {
+			cubecos.DeleteSupportFile(*file)
+			continue
+		}
+
+		if node.IsDown() {
+			log.Warnf("supportFiles(%s): node %s is down, cannot delete group %s", h.reqId, node.Hostname, h.group.Name)
+			continue
+		}
+
+		h.deletePeerNodeSupportFiles(node)
+	}
+
+	return nil
+}
+
+func (h *helper) deletePeerNodeSupportFiles(node *nodes.Node) {
+	url := node.DeleteSupportFileUrl(h.group.Name)
+	http := http.GetGlobalHelper()
+	resp, err := http.R().SetHeaders(nodes.GetSecretHeaders()).Delete(url)
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to delete support file group %s from %s: %v", h.reqId, h.group.Name, node.Hostname, err)
+		return
+	}
+	if resp.IsError() {
+		log.Errorf("supportFiles(%s): %s resp error from %s: %s", h.reqId, h.group.Name, node.Hostname, string(resp.Body()))
+		return
+	}
+
+	log.Infof(
+		"supportFiles(%s): support file group(%s) deleted successfully from %s",
+		h.reqId,
+		h.group.Name,
+		node.Hostname,
+	)
+}
+
+func (h *helper) GetSupportFileByGroup(group string) (*support.File, error) {
+	sets, err := h.listSupportFileSets()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, set := range sets {
+		if set.Name != group {
+			continue
+		}
+
+		for _, file := range set.Files {
+			if file.Source.Host != base.Hostname {
+				continue
+			}
+
+			return &file, nil
+		}
+	}
+
+	return nil, fmt.Errorf("support file group(%s) not found", group)
 }
 
 func (h *helper) streamDownloadByPeerNode(set support.FileSet, file support.File) {

--- a/internal/apis/v1/handlers/supportfiles/handlers.go
+++ b/internal/apis/v1/handlers/supportfiles/handlers.go
@@ -21,6 +21,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  "GET",
+			Path:    "/supportFiles/hosts/:hostname",
+			Func:    listHostSupportFiles,
+		},
+		{
+			Version: apis.V1,
 			Method:  "POST",
 			Path:    "/supportFiles",
 			Func:    createSupportFile,
@@ -33,15 +39,15 @@ var (
 		},
 		{
 			Version: apis.V1,
-			Method:  "PATCH",
+			Method:  "DELETE",
 			Path:    "/supportFiles/:supportFileGroup",
-			Func:    updateSupportFileTask,
+			Func:    deleteSupportFileGroup,
 		},
 		{
 			Version: apis.V1,
-			Method:  "GET",
-			Path:    "/supportFiles/hosts/:hostname",
-			Func:    listHostSupportFiles,
+			Method:  "PATCH",
+			Path:    "/supportFiles/:supportFileGroup",
+			Func:    updateSupportFileTask,
 		},
 	}
 )
@@ -92,6 +98,26 @@ func downloadSupportFile(c *gin.Context) {
 		log.Errorf("supportFiles(%s): failed to download support file: %v", h.reqId, err)
 		return
 	}
+}
+
+func deleteSupportFileGroup(c *gin.Context) {
+	h, err := initHepler(c, "deleteSupportFileGroup")
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to init req helper: %v", h.reqId, err)
+		return
+	}
+
+	err = h.deleteSupportFileGroup()
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to delete support file group: %v", h.reqId, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"support file group deleted successfully",
+		nil,
+	)
 }
 
 func updateSupportFileTask(c *gin.Context) {

--- a/internal/apis/v1/handlers/supportfiles/handlers.go
+++ b/internal/apis/v1/handlers/supportfiles/handlers.go
@@ -45,6 +45,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  "DELETE",
+			Path:    "/supportFiles/:supportFileGroup/:supportFileName",
+			Func:    deleteSupportFile,
+		},
+		{
+			Version: apis.V1,
 			Method:  "PATCH",
 			Path:    "/supportFiles/:supportFileGroup",
 			Func:    updateSupportFileTask,
@@ -55,7 +61,7 @@ var (
 func listSupportFiles(c *gin.Context) {
 	h, err := initHepler(c, "listSupportFiles")
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to init list helper: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to init list helper(%v)", h.reqId, err)
 		return
 	}
 
@@ -74,7 +80,7 @@ func listSupportFiles(c *gin.Context) {
 func createSupportFile(c *gin.Context) {
 	h, err := initHepler(c, "createSupportFile")
 	if err != nil {
-		log.Infof("supportFiles(%s): failed to init req helper: %v", h.reqId, err)
+		log.Infof("supportFiles(%s): failed to init req helper(%v)", h.reqId, err)
 		return
 	}
 
@@ -89,13 +95,13 @@ func createSupportFile(c *gin.Context) {
 func downloadSupportFile(c *gin.Context) {
 	h, err := initHepler(c, "downloadSupportFile")
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to init req helper: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to init req helper(%v)", h.reqId, err)
 		return
 	}
 
 	err = h.downloadSupportFile()
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to download support file: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to download support file(%v)", h.reqId, err)
 		return
 	}
 }
@@ -103,13 +109,12 @@ func downloadSupportFile(c *gin.Context) {
 func deleteSupportFileGroup(c *gin.Context) {
 	h, err := initHepler(c, "deleteSupportFileGroup")
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to init req helper: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to init req helper(%v)", h.reqId, err)
 		return
 	}
 
 	err = h.deleteSupportFileGroup()
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to delete support file group: %v", h.reqId, err)
 		return
 	}
 
@@ -120,10 +125,30 @@ func deleteSupportFileGroup(c *gin.Context) {
 	)
 }
 
+func deleteSupportFile(c *gin.Context) {
+	h, err := initHepler(c, "deleteSupportFile")
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to init req helper(%v)", h.reqId, err)
+		return
+	}
+
+	err = cubecos.DeleteSupportFile(h.file)
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to delete support file(%v)", h.reqId, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"support file deleted successfully",
+		nil,
+	)
+}
+
 func updateSupportFileTask(c *gin.Context) {
 	h, err := initHepler(c, "updateSupportFileTask")
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to init req helper: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to init req helper(%v)", h.reqId, err)
 		return
 	}
 
@@ -137,13 +162,13 @@ func updateSupportFileTask(c *gin.Context) {
 func listHostSupportFiles(c *gin.Context) {
 	h, err := initHepler(c, "listHostSupportFiles")
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to init req helper: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to init req helper(%v)", h.reqId, err)
 		return
 	}
 
 	files, err := cubecos.ListHostSupportFiles(support.ListFileOptions{Host: h.host})
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to list host support file: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to list host support file(%v)", h.reqId, err)
 		return
 	}
 

--- a/internal/apis/v1/handlers/supportfiles/helper.go
+++ b/internal/apis/v1/handlers/supportfiles/helper.go
@@ -15,12 +15,14 @@ type helper struct {
 	reqId   string
 	handler string
 
-	keyword string
-	host    string
-	group   support.FileSet
-	file    support.File
-	fileReq support.FileRequest
-	roles   []string
+	keyword  string
+	host     string
+	hosts    []string
+	allHosts bool
+	group    support.FileSet
+	file     support.File
+	fileReq  support.FileRequest
+	roles    []string
 
 	*pages.Page
 	past string
@@ -29,8 +31,6 @@ type helper struct {
 	watch bool
 }
 
-// note:
-// deletion will be supported in the M2 release
 func initHepler(c *gin.Context, handler string) (*helper, error) {
 	h := helper{
 		c:       c,
@@ -43,15 +43,12 @@ func initHepler(c *gin.Context, handler string) (*helper, error) {
 }
 
 func (h *helper) listSupportFiles() (*filePage, error) {
-	files, err := cubecos.ListSupportFiles(support.ListFileOptions{AllNodes: true})
+	sets, err := h.listSupportFileSets()
 	if err != nil {
-		log.Errorf("supportFiles(%s): failed to list files: %v", h.reqId, err)
+		log.Errorf("supportFiles(%s): failed to list file sets: %v", h.reqId, err)
 		return nil, err
 	}
 
-	h.syncCreatingFiles(&files)
-	h.syncHostPortInUrl(&files)
-	sets := h.genFileSets(files)
 	pagedSets, err := h.paginateFileSets(sets)
 	if err != nil {
 		log.Errorf("supportFiles(%s): failed to paginate files: %v", h.reqId, err)
@@ -68,4 +65,16 @@ func (h *helper) listSupportFiles() (*filePage, error) {
 		SupportFileSet: pagedSets,
 		Page:           page,
 	}, nil
+}
+
+func (h *helper) listSupportFileSets() ([]support.FileSet, error) {
+	files, err := cubecos.ListSupportFiles(support.ListFileOptions{AllNodes: true})
+	if err != nil {
+		log.Errorf("supportFiles(%s): failed to list files: %v", h.reqId, err)
+		return nil, err
+	}
+
+	h.syncCreatingFiles(&files)
+	h.syncHostPortInUrl(&files)
+	return h.genFileSets(files), nil
 }

--- a/internal/apis/v1/handlers/supportfiles/helper.go
+++ b/internal/apis/v1/handlers/supportfiles/helper.go
@@ -15,14 +15,12 @@ type helper struct {
 	reqId   string
 	handler string
 
-	keyword  string
-	host     string
-	hosts    []string
-	allHosts bool
-	group    support.FileSet
-	file     support.File
-	fileReq  support.FileRequest
-	roles    []string
+	keyword string
+	host    string
+	group   support.FileSet
+	file    support.File
+	fileReq support.FileRequest
+	roles   []string
 
 	*pages.Page
 	past string

--- a/internal/apis/v1/handlers/supportfiles/parse.go
+++ b/internal/apis/v1/handlers/supportfiles/parse.go
@@ -21,7 +21,9 @@ func (h *helper) parseParamsByHandler() error {
 	case "createSupportFile":
 		return h.parseCreateParams()
 	case "deleteSupportFileGroup":
-		return h.parseDeleteParams()
+		return h.parseDeleteGroupParams()
+	case "deleteSupportFile":
+		return h.parseDeleteFileParams()
 	case "downloadSupportFile":
 		return h.parseDownloadParams()
 	case "updateSupportFileTask":
@@ -76,13 +78,18 @@ func (h *helper) parseCreateParams() error {
 	return h.parseHosts()
 }
 
-func (h *helper) parseDeleteParams() error {
+func (h *helper) parseDeleteGroupParams() error {
 	group, err := url.PathUnescape(h.c.Param("supportFileGroup"))
 	if err != nil {
 		return err
 	}
 
 	h.group.Name = group
+	return nil
+}
+
+func (h *helper) parseDeleteFileParams() error {
+	h.file = support.File{Name: h.c.Param("supportFileName")}
 	return nil
 }
 

--- a/internal/apis/v1/handlers/supportfiles/parse.go
+++ b/internal/apis/v1/handlers/supportfiles/parse.go
@@ -2,11 +2,13 @@ package supportfiles
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 	ostime "time"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/support"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
 )
 
@@ -18,6 +20,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseHostListParams()
 	case "createSupportFile":
 		return h.parseCreateParams()
+	case "deleteSupportFileGroup":
+		return h.parseDeleteParams()
 	case "downloadSupportFile":
 		return h.parseDownloadParams()
 	case "updateSupportFileTask":
@@ -70,6 +74,16 @@ func (h *helper) parseHostListParams() error {
 
 func (h *helper) parseCreateParams() error {
 	return h.parseHosts()
+}
+
+func (h *helper) parseDeleteParams() error {
+	group, err := url.PathUnescape(h.c.Param("supportFileGroup"))
+	if err != nil {
+		return err
+	}
+
+	h.group.Name = group
+	return nil
 }
 
 func (h *helper) parseDownloadParams() error {
@@ -152,4 +166,42 @@ func (h *helper) isKeywordRequired() bool {
 
 func (h *helper) isRoleRequired() bool {
 	return len(h.roles) > 0
+}
+
+func (h *helper) getHostsByGroup(group string) ([]string, error) {
+	sets, err := h.listSupportFileSets()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, set := range sets {
+		if set.Name == group {
+			return h.parseHostsFromSet(set)
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"support file group(%s) not found",
+		group,
+	)
+}
+
+func (h *helper) parseHostsFromSet(set support.FileSet) ([]string, error) {
+	hosts := []string{}
+	for _, file := range set.Files {
+		if file.IsCreating() {
+			return nil, errors.New("has creating file, skip to delete")
+		}
+
+		if file.Source.Host == "" {
+			continue
+		}
+
+		hosts = append(
+			hosts,
+			file.Source.Host,
+		)
+	}
+
+	return hosts, nil
 }

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -294,7 +294,8 @@ func SyncSupportFiles() {
 	}
 
 	if len(files) == 0 {
-		log.Warnf("supportFile: no support file found")
+		log.Infof("supportFile: no support file found")
+		support.SetEmptyLocalList()
 		return
 	}
 
@@ -302,6 +303,8 @@ func SyncSupportFiles() {
 }
 
 func setSupportFiles(files []os.DirEntry) {
+	hasAtLeatOneUpdated := false
+
 	for _, file := range files {
 		supportFile, err := parseSupportFile(file)
 		if err != nil {
@@ -313,10 +316,15 @@ func setSupportFiles(files []os.DirEntry) {
 			continue
 		}
 
+		hasAtLeatOneUpdated = true
 		support.SetLocalFile(enrichSupportFile(
 			supportFile,
 			*info,
 		))
+	}
+
+	if !hasAtLeatOneUpdated {
+		support.SetEmptyLocalList()
 	}
 }
 

--- a/internal/cubecos/supportfile.go
+++ b/internal/cubecos/supportfile.go
@@ -153,6 +153,15 @@ func GetSupportFile(file support.File) (string, error) {
 	return info.Name(), nil
 }
 
+func DeleteSupportFile(file support.File) error {
+	return os.Remove(
+		filepath.Join(
+			support.DefaultFileDir,
+			file.Name,
+		),
+	)
+}
+
 func UploadSupportFileToObjectStore(supportFile support.File) error {
 	file, err := os.Open(supportFile.Name)
 	if err != nil {

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -125,11 +125,11 @@ func (n *Node) PatchSupportFileTaskUrl(file support.File) string {
 	return u.String()
 }
 
-func (n *Node) DeleteSupportFileUrl(group string) string {
+func (n *Node) DeleteSupportFileUrl(group, file string) string {
 	u := url.URL{}
 	u.Scheme = n.Protocol
 	u.Host = n.Address
-	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportFiles/%s", base.DataCenterName, group)
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportFiles/%s/%s", base.DataCenterName, group, file)
 	return u.String()
 }
 

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -125,6 +125,14 @@ func (n *Node) PatchSupportFileTaskUrl(file support.File) string {
 	return u.String()
 }
 
+func (n *Node) DeleteSupportFileUrl(group string) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/supportFiles/%s", base.DataCenterName, group)
+	return u.String()
+}
+
 func (n *Node) PatchSettingTaskUrl(setting settings.Setting) string {
 	u := url.URL{}
 	u.Scheme = n.Protocol

--- a/internal/definition/v1/support/support.go
+++ b/internal/definition/v1/support/support.go
@@ -157,6 +157,10 @@ func SetLocalFile(File File) {
 	localFiles.Store(File.Name, File)
 }
 
+func SetEmptyLocalList() {
+	localFiles = sync.Map{}
+}
+
 func ListLocalFiles() []File {
 	files := []File{}
 	localFiles.Range(func(key, value any) bool {

--- a/internal/operators/v1/supportfiles/watch.go
+++ b/internal/operators/v1/supportfiles/watch.go
@@ -53,7 +53,7 @@ func syncSourceSupportFiles(event fsnotify.Event) {
 	}
 
 	if shouldSync(event) {
-		bslog.Throttle("supportFiles", fmt.Sprintf("support file %s created", event.Name))
+		bslog.Throttle("supportFiles", fmt.Sprintf("support file %s get updated", event.Name))
 		cubecos.SyncSupportFiles()
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/167

<br/>

### What this PR does?

Add a new interface to delete the support file group (cross-node deletion)

<br/>

### Test results (optional)

1). Make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/92cfbeb9-a4d4-4411-8f5f-15712e05b07a

<br/>

2). Make sure the API works properly

https://github.com/user-attachments/assets/de2907d0-c641-4265-859d-5c8237d1c356

