### PR TITLE
Enhance the experience of node transition during powering on/off/cycle

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -9,7 +9,7 @@ vars:
   dbReplicaSet: "cube-cos-rs"
   devCosUser: "root"
   devCosIp: "<REPLACE_WITH_YOUR_DEV_COS_IP>"
-  devE2EIp: "10.32.200.12"
+  devE2EIp: "<REPLACE_WITH_YOUR_E2E_COS_IP>"
   devE2EContainer: "3c_3p_5s"
   devE2ENode: "10.1.0.1"
   mongoVersion: "6.0.19"
@@ -118,7 +118,7 @@ tasks:
   activateSystemdService:
     cmds:
       - ssh {{.devCosUser}}@{{.devCosIp}} "systemctl daemon-reload"
-      - ssh {{.devCosUser}}@{{.devCosIp}} "systemctl enable cube-cos-api.service"
+      - ssh {{.devCosUser}}@{{.devCosIp}} "systemctl disable cube-cos-api.service"
       - ssh {{.devCosUser}}@{{.devCosIp}} "systemctl restart cube-cos-api.service"
   restartRemoteE2ESystemdService:
     cmds:

--- a/internal/apis/v1/handlers/nodes/record.go
+++ b/internal/apis/v1/handlers/nodes/record.go
@@ -41,7 +41,7 @@ func setTrackerCallback(p *ping.Pinger, hostname, operation string) {
 	if operation == "poweron" {
 		p.OnRecv = func(pkt *ping.Packet) {
 			log.Infof("nodes: node %s is starting", hostname)
-			updateFinalStatus(hostname, operation)
+			updatePendingStatus(hostname, operation)
 			p.Stop()
 		}
 	}
@@ -60,7 +60,7 @@ func updatePendingStatus(hostname, operation string) error {
 	m := mongo.GetGlobalHelper()
 	return m.UpdateOne(
 		nodes.Db,
-		nodes.RequestsCollection,
+		nodes.ReqCollection,
 		bson.M{"hostname": hostname},
 		bson.M{"$set": bson.M{"hostname": hostname, "status": status}},
 		options.Update().SetUpsert(true),
@@ -72,7 +72,7 @@ func updateFinalStatus(hostname, operation string) {
 	m := mongo.GetGlobalHelper()
 	err := m.UpdateOne(
 		nodes.Db,
-		nodes.RequestsCollection,
+		nodes.ReqCollection,
 		bson.M{"hostname": hostname},
 		bson.M{"$set": bson.M{"hostname": hostname, "status": status}},
 		options.Update().SetUpsert(true),
@@ -98,11 +98,11 @@ func getPendingStatus(operation string) string {
 func getFinalStatus(operation string) string {
 	switch operation {
 	case "poweron":
-		return "up"
+		return status.Up
 	case "poweroff":
-		return "down"
+		return status.Down
 	default:
-		return "unknown final status"
+		return status.Syncing
 	}
 }
 

--- a/internal/cubecos/nodes.go
+++ b/internal/cubecos/nodes.go
@@ -175,7 +175,7 @@ func syncVirutalIpOwner(list *[]nodes.Node) {
 
 func syncPowerStatus(list *[]nodes.Node) {
 	for i, node := range *list {
-		if !hasPowerRequest(node.Hostname) {
+		if !IsNodeHasPowerRequest(node.Hostname) {
 			continue
 		}
 
@@ -196,11 +196,11 @@ func syncIpmiAccess(list *[]nodes.Node) {
 	}
 }
 
-func hasPowerRequest(hostname string) bool {
+func IsNodeHasPowerRequest(hostname string) bool {
 	mongo := mongo.GetGlobalHelper()
 	count, err := mongo.GetCount(
 		nodes.Db,
-		nodes.RequestsCollection,
+		nodes.ReqCollection,
 		bson.M{"hostname": hostname},
 	)
 	if err != nil {
@@ -245,7 +245,7 @@ func getPendingPowerStatus(hostname string) (string, error) {
 	mongo := mongo.GetGlobalHelper()
 	doc, err := mongo.Get(
 		nodes.Db,
-		nodes.RequestsCollection,
+		nodes.ReqCollection,
 		bson.M{"hostname": hostname},
 	)
 	if err != nil {

--- a/internal/definition/v1/nodes/node.go
+++ b/internal/definition/v1/nodes/node.go
@@ -18,7 +18,7 @@ import (
 const (
 	Module                         = "nodes"
 	Db                             = "nodes"
-	RequestsCollection             = "requests"
+	ReqCollection                  = "requests"
 	CollectionTemporaryNodeDetails = "temporaryNodeDetails"
 	CollectionIpmiAccess           = "ipmiAccess"
 	CollectionIpmiSupport          = "ipmiSupport"

--- a/internal/operators/v1/nodes/nodes.go
+++ b/internal/operators/v1/nodes/nodes.go
@@ -31,7 +31,7 @@ func (o *Operator) Init() error {
 	o.ctx, o.cancel = context.WithCancel(context.Background())
 	go o.syncOrderSensitiveServices()
 	go o.periodicSyncNodes()
-	o.removeHostPendingReq()
+	go o.removeHostPendingReq()
 	return nil
 }
 

--- a/internal/operators/v1/nodes/record.go
+++ b/internal/operators/v1/nodes/record.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	log "go-micro.dev/v5/logger"
@@ -10,10 +11,11 @@ import (
 )
 
 func (o *Operator) removeHostPendingReq() {
+	wait.Seconds(90)
 	h := mongo.GetGlobalHelper()
 	err := h.DeleteAll(
 		nodes.Db,
-		nodes.RequestsCollection,
+		nodes.ReqCollection,
 		bson.M{"hostname": base.Hostname},
 	)
 	if err != nil {

--- a/internal/operators/v1/nodes/sync.go
+++ b/internal/operators/v1/nodes/sync.go
@@ -121,19 +121,24 @@ func (o *Operator) syncNodesUpAndDown() ([]nodes.Node, error) {
 			continue
 		}
 
-		o.setNodeDown(&node)
+		o.setNodeDownOrSyncing(&node)
 		nodes = append(nodes, node)
 	}
 
 	return nodes, nil
 }
 
-func (o *Operator) setNodeDown(node *nodes.Node) {
+func (o *Operator) setNodeDownOrSyncing(node *nodes.Node) {
 	node.DataCenter = base.DataCenterName
 	node.BlockDevices = []nodes.BlockDevice{}
 	node.NetworkInterfaces = []nodes.NetworkInterface{}
 	node.License = o.getPreviousLicense(node.Hostname)
-	node.Status = status.Down
+
+	if cubecos.IsNodeHasPowerRequest(node.Hostname) {
+		node.Status = status.Syncing
+	} else {
+		node.Status = status.Down
+	}
 }
 
 func (o *Operator) getPreviousLicense(hostname string) licenses.License {


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

Enhance the experience of node transition during powering on/off/cycle by

- Set systemctl to be disable for dev env cause production env won't do this.

- Delay the deletion of powering request 

- Replace the `up` with `powering up` after target host is pingable

<br/>

### What this PR does?

https://github.com/bigstack-oss/cubecos/issues/159