### PR TITLE
Add 'pgs' in the block device list and parallelize the block device status fetching on the CubeCOS to decrease the req duration

### DIFF
--- a/internal/apis/v1/handlers/nodes/device.go
+++ b/internal/apis/v1/handlers/nodes/device.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"sync"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/blockdevice"
@@ -63,6 +64,7 @@ func (h *helper) syncCephOsds(blockDevs *[]nodes.BlockDevice) error {
 		if found {
 			(*blockDevs)[i].Class = cephDev.Class
 			(*blockDevs)[i].Osd = nodes.Osd{
+				Pgs:      h.getTotalPgs(cephDev.Osds),
 				Reweigth: cephDev.Reweight,
 				Daemons:  h.convertToOsds(cephDev.Osds),
 			}
@@ -70,6 +72,15 @@ func (h *helper) syncCephOsds(blockDevs *[]nodes.BlockDevice) error {
 	}
 
 	return nil
+}
+
+func (h *helper) getTotalPgs(osds []ceph.Osd) int {
+	total := 0
+	for _, osd := range osds {
+		total += osd.Pgs
+	}
+
+	return total
 }
 
 func (h *helper) convertToOsds(list []ceph.Osd) []nodes.Deamon {
@@ -104,9 +115,31 @@ func (h *helper) setBlockDeviceAvailability(blockDevs *[]nodes.BlockDevice, moun
 }
 
 func (h *helper) setBlockDeviceStatus(blockDevs *[]nodes.BlockDevice) {
+	statusMap := h.syncBlockDeviceStatus(blockDevs)
+
 	for i, blockDev := range *blockDevs {
-		(*blockDevs)[i].Status = h.getBlockDeviceStatus(blockDev)
+		s, found := statusMap.Load(blockDev.Name)
+		if found {
+			(*blockDevs)[i].Status = s.(status.BlockDevice)
+		}
 	}
+}
+
+func (h *helper) syncBlockDeviceStatus(blockDevs *[]nodes.BlockDevice) *sync.Map {
+	wg := sync.WaitGroup{}
+	statusMap := sync.Map{}
+
+	for _, blockDev := range *blockDevs {
+		wg.Add(1)
+		go func(blockDev nodes.BlockDevice) {
+			defer wg.Done()
+			status := h.getBlockDeviceStatus(blockDev)
+			statusMap.Store(blockDev.Name, status)
+		}(blockDev)
+	}
+
+	wg.Wait()
+	return &statusMap
 }
 
 func (h *helper) getBlockDeviceStatus(blockDev nodes.BlockDevice) status.BlockDevice {

--- a/internal/cubecos/storage.go
+++ b/internal/cubecos/storage.go
@@ -42,30 +42,30 @@ func GetCephUsage() metric.Space {
 }
 
 func GetRawBlockDevices() ([]nodes.RawBlockDevice, error) {
-	b, err := exec.Command("/bin/lsblk", "--sort", "name", "--json", "-o", "TYPE,NAME,ROTA,SERIAL,SIZE,MOUNTPOINTS", "-e", blockdevice.NetCode).Output()
+	out, err := exec.Command("/bin/lsblk", "--sort", "name", "--json", "-o", "TYPE,NAME,ROTA,SERIAL,SIZE,MOUNTPOINTS", "-e", blockdevice.NetCode).Output()
 	if err != nil {
 		log.Errorf("nodes: failed to get block device info(%v)", err)
 		return nil, err
 	}
 
-	blockDevMap := map[string][]nodes.RawBlockDevice{}
-	err = json.Unmarshal(b, &blockDevMap)
+	resp := map[string][]nodes.RawBlockDevice{}
+	err = json.Unmarshal(out, &resp)
 	if err != nil {
 		log.Errorf("nodes: failed to unmarshal block device info(%v)", err)
 		return nil, err
 	}
 
-	rawBlockDevs, found := blockDevMap["blockdevices"]
+	raws, found := resp["blockdevices"]
 	if !found {
 		log.Errorf("nodes: failed to find block devices in the output")
 		return nil, err
 	}
-	if len(rawBlockDevs) <= 0 {
+	if len(raws) <= 0 {
 		log.Errorf("nodes: no block device found")
 		return nil, errors.New("no block device found")
 	}
 
-	return getBlockOrPartitionOnly(rawBlockDevs), nil
+	return getBlockOrPartitionOnly(raws), nil
 }
 
 func ConvertToBlockDevice(rawBlockDev nodes.RawBlockDevice) nodes.BlockDevice {

--- a/internal/definition/v1/ceph/device.go
+++ b/internal/definition/v1/ceph/device.go
@@ -23,11 +23,21 @@ type Osd struct {
 	DeviceClass  string  `json:"device_class"`
 	Reweight     float64 `json:"reweight,omitzero"`
 	UsagePercent float64 `json:"usagePercent"`
+	Pgs          int     `json:"pgs"`
 	Status       string  `json:"status"`
 }
 
 type RawOsd struct {
 	Nodes []Node `json:"nodes"`
+}
+
+type PlacementGroup struct {
+	PgStats []PgStat `json:"pg_stats"`
+}
+
+type PgStat struct {
+	Id    string `json:"pgid"`
+	State string `json:"state"`
 }
 
 type Node struct {
@@ -37,6 +47,7 @@ type Node struct {
 	Type        string  `json:"type"`
 	Reweight    float64 `json:"reweight"`
 	Utilization float64 `json:"utilization"`
+	Pgs         int     `json:"pgs"`
 	Status      string  `json:"status"`
 }
 
@@ -191,6 +202,7 @@ func convertToOsd(raw Node) Osd {
 		DeviceClass:  raw.DeviceClass,
 		Reweight:     raw.Reweight,
 		UsagePercent: math.RoundDown(raw.Utilization, 4),
+		Pgs:          raw.Pgs,
 		Status:       raw.Status,
 	}
 }

--- a/internal/definition/v1/nodes/infra.go
+++ b/internal/definition/v1/nodes/infra.go
@@ -31,6 +31,7 @@ type BlockDevice struct {
 }
 
 type Osd struct {
+	Pgs      int      `json:"pgs" yaml:"pgs" bson:"pgs"`
 	Reweigth float64  `json:"reweight" yaml:"reweight" bson:"reweight"`
 	Daemons  []Deamon `json:"daemons" yaml:"daemons" bson:"daemons"`
 }
@@ -39,6 +40,7 @@ type Deamon struct {
 	Id           string     `json:"id" yaml:"id" bson:"id"`
 	UsagePercent float64    `json:"usagePercent" yaml:"usagePercent" bson:"usagePercent"`
 	Status       status.Osd `json:"status" yaml:"status" bson:"status"`
+	Pgs          int        `json:"-" yaml:"pgs" bson:"pgs"`
 }
 
 // note:


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

- Add 'pgs' in the block device list

- Parallelize the block device status fetching on the CubeCOS to speed up the req duration(ceph   and smartctl are taking quite long to get the status data)

<br/>

### What this PR does?

https://github.com/bigstack-oss/cubecos/issues/158

<br/>

### Test results (optional)

although, the perf is being improved 44%, but from the API perspective, 2x seconds is still quite long, but it's the current limit from fundamental service

<br/>

1). before: around 58s ~ 1m

```bash
2025-07-15T04:21:12.420+0800  INFO  req(7374355a): GET /api/v1/datacenters/control/nodes/cube451/devices (1m0.68045042s)
```

<br/>

2). after: 23s ~ 26s

```bash
2025-07-16T02:35:59.346+0800  INFO  req(95bb563d): GET /api/v1/datacenters/control/nodes/cube451/devices (26.897838367s)
```

