### PR TITLE
Add 7 APIs for block device and OSD operations

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5782,6 +5782,30 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "404": {
+                        "description": "Node not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "content": {
@@ -5833,7 +5857,7 @@ const docTemplate = `{
                                 "example": {
                                     "summary": "Add Node Device",
                                     "value": {
-                                        "device": "sdd"
+                                        "device": "sdb"
                                     }
                                 }
                             }
@@ -5841,8 +5865,8 @@ const docTemplate = `{
                     }
                 },
                 "responses": {
-                    "201": {
-                        "description": "Device added to the node successfully",
+                    "202": {
+                        "description": "the request to add node device is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5902,7 +5926,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{device}": {
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{deviceName}": {
             "delete": {
                 "operationId": "removeNodeDevice",
                 "tags": [
@@ -5922,7 +5946,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "202": {
-                        "description": "the device removal request is received and is being processed",
+                        "description": "the request to remove node device is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6006,7 +6030,7 @@ const docTemplate = `{
                                 "example1": {
                                     "summary": "Promote a device to SSD class",
                                     "value": {
-                                        "class": "sdd"
+                                        "class": "ssd"
                                     }
                                 },
                                 "example2": {
@@ -6021,7 +6045,7 @@ const docTemplate = `{
                 },
                 "responses": {
                     "202": {
-                        "description": "the device update request is received and is being processed",
+                        "description": "the request to update node device is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6119,7 +6143,7 @@ const docTemplate = `{
                 },
                 "responses": {
                     "202": {
-                        "description": "the OSD update request is received and is being processed",
+                        "description": "the request to update node OSD is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6197,7 +6221,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "202": {
-                        "description": "the OSD deletion request is received and is being processed",
+                        "description": "the request to delete node OSD is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6277,7 +6301,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "202": {
-                        "description": "the OSD restart request is received and is being processed",
+                        "description": "the request to restart node OSD is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -15474,7 +15498,7 @@ const docTemplate = `{
                 "properties": {
                     "code": {
                         "type": "integer",
-                        "example": 201
+                        "example": 202
                     },
                     "msg": {
                         "type": "string",

--- a/api/docs.go
+++ b/api/docs.go
@@ -931,7 +931,7 @@ const docTemplate = `{
                             }
                         },
                         "description": "The ids of the event to query.",
-                        "example": "Info"
+                        "example": "CPU00004I"
                     }
                 ],
                 "responses": {
@@ -4975,29 +4975,6 @@ const docTemplate = `{
                                                                 "speed": "NA/1000F"
                                                             }
                                                         ],
-                                                        "blockDevices": [
-                                                            {
-                                                                "serial": "200264800526",
-                                                                "device": "nvme0n1",
-                                                                "type": "SSD",
-                                                                "sizeMiB": 222110.7482,
-                                                                "availability": "system",
-                                                                "status": {
-                                                                    "current": "ok"
-                                                                }
-                                                            },
-                                                            {
-                                                                "serial": "200598804038",
-                                                                "device": "nvme1n1",
-                                                                "type": "SSD",
-                                                                "sizeMiB": 222110.7482,
-                                                                "availability": "in-use",
-                                                                "status": {
-                                                                    "current": "warning",
-                                                                    "description": "status fetch timeout"
-                                                                }
-                                                            }
-                                                        ],
                                                         "ipmi": {
                                                             "isSupported": true,
                                                             "isConnected": false,
@@ -5181,29 +5158,6 @@ const docTemplate = `{
                                                         "driver": "tg3",
                                                         "state": "DOWN",
                                                         "speed": "NA/1000F"
-                                                    }
-                                                ],
-                                                "blockDevices": [
-                                                    {
-                                                        "serial": "200264800526",
-                                                        "device": "nvme0n1",
-                                                        "type": "SSD",
-                                                        "sizeMiB": 222110.7482,
-                                                        "availability": "system",
-                                                        "status": {
-                                                            "current": "ok"
-                                                        }
-                                                    },
-                                                    {
-                                                        "serial": "200598804038",
-                                                        "device": "nvme1n1",
-                                                        "type": "SSD",
-                                                        "sizeMiB": 222110.7482,
-                                                        "availability": "in-use",
-                                                        "status": {
-                                                            "current": "warning",
-                                                            "description": "status fetch timeout"
-                                                        }
                                                     }
                                                 ],
                                                 "ipmi": {
@@ -5696,6 +5650,693 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices": {
+            "get": {
+                "operationId": "listNodeDevices",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Retrieve the node devices",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/watch"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the node devices successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListNodeDevicesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Node Devices",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "serial": "57T0A05UF5YE",
+                                                    "device": "sda",
+                                                    "type": "HDD",
+                                                    "class": "hdd",
+                                                    "osd": {
+                                                        "pgs": 646,
+                                                        "reweight": 1,
+                                                        "daemons": [
+                                                            {
+                                                                "id": "osd.0",
+                                                                "usagePercent": 21.9012,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "osd.1",
+                                                                "usagePercent": 17.4514,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "sizeMiB": 533008.5754,
+                                                    "availability": "in-use",
+                                                    "status": {
+                                                        "current": "ok",
+                                                        "isPromotable": true,
+                                                        "isDemotable": false,
+                                                        "isProcessing": false
+                                                    }
+                                                },
+                                                {
+                                                    "serial": "183222E1E59B",
+                                                    "device": "sdb",
+                                                    "type": "SSD",
+                                                    "class": "",
+                                                    "osd": {
+                                                        "pgs": 0,
+                                                        "reweight": 0,
+                                                        "daemons": []
+                                                    },
+                                                    "sizeMiB": 426387.7868,
+                                                    "availability": "system",
+                                                    "status": {
+                                                        "current": "ok",
+                                                        "isPromotable": true,
+                                                        "isDemotable": false,
+                                                        "isProcessing": false
+                                                    }
+                                                },
+                                                {
+                                                    "serial": "57P0A0EWF5YE",
+                                                    "device": "sdc",
+                                                    "type": "HDD",
+                                                    "class": "hdd",
+                                                    "osd": {
+                                                        "pgs": 634,
+                                                        "reweight": 1,
+                                                        "daemons": [
+                                                            {
+                                                                "id": "osd.2",
+                                                                "usagePercent": 15.748,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "osd.3",
+                                                                "usagePercent": 21.4815,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "sizeMiB": 533008.5754,
+                                                    "availability": "in-use",
+                                                    "status": {
+                                                        "current": "ok",
+                                                        "isPromotable": true,
+                                                        "isDemotable": false,
+                                                        "isProcessing": false
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "fetch node devices successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch setting: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "addNodeDevice",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Add a device to the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddNodeDeviceRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Add Node Device",
+                                    "value": {
+                                        "device": "sdd"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Device added to the node successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AddNodeDeviceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to add device: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{device}": {
+            "delete": {
+                "operationId": "removeNodeDevice",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Remove a device from the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/device"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the device removal request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoveNodeDeviceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or device not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or device not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to remove device: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "updateNodeDevice",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Update a device on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateNodeDeviceRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Promote a device to SSD class",
+                                    "value": {
+                                        "class": "sdd"
+                                    }
+                                },
+                                "example2": {
+                                    "summary": "Demote a device to HDD class",
+                                    "value": {
+                                        "class": "hdd"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "the device update request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UpdateNodeDeviceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or device not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or device not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update device: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}": {
+            "patch": {
+                "operationId": "updateNodeOsd",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Update an OSD on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/osdId"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateNodeOsdRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Reweight an OSD",
+                                    "value": {
+                                        "reweight": 0.5
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "the OSD update request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UpdateNodeOsdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or OSD not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or osd not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update osd: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteNodeOsd",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Delete an OSD on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/osdId"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the OSD deletion request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeleteNodeOsdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or OSD not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or osd not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete osd: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}/restart": {
+            "post": {
+                "operationId": "restartNodeOsd",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Restart an OSD on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/osdId"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the OSD restart request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RestartNodeOsdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or OSD not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or osd not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to restart osd: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/settings": {
             "get": {
                 "operationId": "getSettings",
@@ -5766,7 +6407,7 @@ const docTemplate = `{
                                                     "channels": [
                                                         {
                                                             "name": "#example-alert-channel-1",
-                                                            "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                                            "url": "https://hooks.slack.com/services/example-token",
                                                             "description": "example alert channel 1",
                                                             "status": {
                                                                 "current": "ok",
@@ -5775,7 +6416,7 @@ const docTemplate = `{
                                                         },
                                                         {
                                                             "name": "#example-alert-channel-2",
-                                                            "url": "https://hooks.slack.com/services/T9LMCCCCC/C08GQACCCCC/CCCCCCCSevAyxkM2dPYCCCCC",
+                                                            "url": "https://hooks.slack.com/services/example-token",
                                                             "description": "example alert channel 2",
                                                             "status": {
                                                                 "current": "ok",
@@ -5921,8 +6562,8 @@ const docTemplate = `{
                                     "value": {
                                         "host": "email-smtp.example.mailserver.com",
                                         "port": 587,
-                                        "username": "ABBBBBBMJM56DCCCCJR",
-                                        "password": "VBHWEEGEEEEEX0f5NLHDXLESxdZR",
+                                        "username": "example-user",
+                                        "password": "example-password",
                                         "from": "noreply@example.com"
                                     }
                                 }
@@ -6640,7 +7281,7 @@ const docTemplate = `{
                                     "summary": "Slack Channel",
                                     "value": {
                                         "name": "#example-alert-channel-1",
-                                        "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                        "url": "https://hooks.slack.com/services/example-token",
                                         "description": "example alert channel 1"
                                     }
                                 }
@@ -6713,7 +7354,7 @@ const docTemplate = `{
                                                 "slackChannels": [
                                                     {
                                                         "name": "#example-alert-channel-1",
-                                                        "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                                        "url": "https://hooks.slack.com/services/example-token",
                                                         "description": "example alert channel 1",
                                                         "status": {
                                                             "current": "ok",
@@ -6722,7 +7363,7 @@ const docTemplate = `{
                                                     },
                                                     {
                                                         "name": "#example-alert-channel-2",
-                                                        "url": "https://hooks.slack.com/services/T9LMCCCCC/C08GQACCCCC/CCCCCCCSevAyxkM2dPYCCCCC",
+                                                        "url": "https://hooks.slack.com/services/example-token",
                                                         "description": "example alert channel 2",
                                                         "status": {
                                                             "current": "ok",
@@ -6856,7 +7497,7 @@ const docTemplate = `{
                                     "summary": "Slack channel",
                                     "value": {
                                         "name": "#example-alert-channel-1",
-                                        "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                        "url": "https://hooks.slack.com/services/example-token",
                                         "description": "example alert channel 1"
                                     }
                                 }
@@ -6996,8 +7637,8 @@ const docTemplate = `{
                                         "value": {
                                             "code": 201,
                                             "data": {
-                                                "token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwdDdGdWlJZC1lbnhVUWRZWGVZalZ6Q0pQZFRWMmxaU0NZanRkQW01S3djIn0.eyJleHAiOjE3Mzg5NjA2NzYsImlhdCI6MTczODk1MzQ3NiwianRpIjoiZjZjZTJlMjMtYzgwNC00N2YxLWE0OWEtZjdlNWZlYTgyYThjIiwiaXNzIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjpbIm1hc3Rlci1yZWFsbSIsImFjY291bnQiXSwic3ViIjoiMDY1OTVlMDAtZWIzOS00YWUxLTkzYjctZDMyNzg1MDdiZTUzIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidG9rZW4tY29ubmVjdCIsInNlc3Npb25fc3RhdGUiOiJlOTE0MWVhZC01MTQ1LTRjZmQtODhiZC00ZjYxYzI0MzA0NzAiLCJhY3IiOiIxIiwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImNyZWF0ZS1yZWFsbSIsImRlZmF1bHQtcm9sZXMtbWFzdGVyIiwib2ZmbGluZV9hY2Nlc3MiLCJhZG1pbiIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsibWFzdGVyLXJlYWxtIjp7InJvbGVzIjpbInZpZXctaWRlbnRpdHktcHJvdmlkZXJzIiwidmlldy1yZWFsbSIsIm1hbmFnZS1pZGVudGl0eS1wcm92aWRlcnMiLCJpbXBlcnNvbmF0aW9uIiwiY3JlYXRlLWNsaWVudCIsIm1hbmFnZS11c2VycyIsInF1ZXJ5LXJlYWxtcyIsInZpZXctYXV0aG9yaXphdGlvbiIsInF1ZXJ5LWNsaWVudHMiLCJxdWVyeS11c2VycyIsIm1hbmFnZS1ldmVudHMiLCJtYW5hZ2UtcmVhbG0iLCJ2aWV3LWV2ZW50cyIsInZpZXctdXNlcnMiLCJ2aWV3LWNsaWVudHMiLCJtYW5hZ2UtYXV0aG9yaXphdGlvbiIsIm1hbmFnZS1jbGllbnRzIiwicXVlcnktZ3JvdXBzIl19LCJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwic2lkIjoiZTkxNDFlYWQtNTE0NS00Y2ZkLTg4YmQtNGY2MWMyNDMwNDcwIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiJ9.LkywGnG2BhQ90n-f3vJvX-frq1wRS6DAop5MUcCFb5FSuGvv3oP_byeiuHvh9rh06QWcwhpiTU_L_hOaUzMXF9spJjos8s2iOwK-4o46Ka_4Q2gnlitjd8ZG5wGfuqKRp0vb25RsBpNr6rxGFzOxxmULkjEXOGXbcrqQJBWIaWdRldYunLFRVErIpmH23w4KHKWSB5XkwqpkD9HnLH_PqbaunGpp2acgZ826JpevC8vhEhIg6fxXcDnCKhkw7nNvfs3rCC08Qci32WtzujeKH6js1ASRkKWOUxVkfIkzZ5Yg4Tfdb79_Tgy2iXLT3teeNTepmLsaftn2JzLn_6vHwg",
-                                                "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1OGRkY2JhNC1hM2ZkLTQ2MTYtODgyYi1lMGY1ZjRlNzAyMTIifQ.eyJleHAiOjE3Mzg5NTUyNzYsImlhdCI6MTczODk1MzQ3NiwianRpIjoiNjkyZDkxMTAtMjExMy00NTU1LTgxMTctNWYxZTA2NzlmYmUxIiwiaXNzIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDY1OTVlMDAtZWIzOS00YWUxLTkzYjctZDMyNzg1MDdiZTUzIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRva2VuLWNvbm5lY3QiLCJzZXNzaW9uX3N0YXRlIjoiZTkxNDFlYWQtNTE0NS00Y2ZkLTg4YmQtNGY2MWMyNDMwNDcwIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsInNpZCI6ImU5MTQxZWFkLTUxNDUtNGNmZC04OGJkLTRmNjFjMjQzMDQ3MCJ9._B9rU8TG_YSvwsri48bfne3RxFhc4Yq83bzR43nL4-c",
+                                                "token": "example-token",
+                                                "refresh": "example-refresh-token",
                                                 "expires": {
                                                     "access": 7200,
                                                     "refresh": 1800
@@ -11658,6 +12299,26 @@ const docTemplate = `{
                 },
                 "example": "example-node-0"
             },
+            "device": {
+                "in": "path",
+                "name": "device",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The device to remove from the node",
+                "example": "sdb"
+            },
+            "osdId": {
+                "in": "path",
+                "name": "osdId",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The OSD ID to operate",
+                "example": "osd.0"
+            },
             "instanceId": {
                 "in": "path",
                 "name": "instanceId",
@@ -14596,6 +15257,18 @@ const docTemplate = `{
                     }
                 }
             },
+            "AddNodeDeviceRequest": {
+                "type": "object",
+                "required": [
+                    "device"
+                ],
+                "properties": {
+                    "device": {
+                        "type": "string",
+                        "description": "The device path, e.g., sdc"
+                    }
+                }
+            },
             "SetNodeIpmiSettingResponse": {
                 "type": "object",
                 "required": [
@@ -14637,6 +15310,316 @@ const docTemplate = `{
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "ListNodeDevicesResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "serial",
+                                "device",
+                                "type",
+                                "class",
+                                "sizeMiB",
+                                "availability",
+                                "osd",
+                                "status"
+                            ],
+                            "properties": {
+                                "serial": {
+                                    "type": "string"
+                                },
+                                "device": {
+                                    "type": "string"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "enum": [
+                                        "ssd",
+                                        "hdd"
+                                    ]
+                                },
+                                "type": {
+                                    "type": "string"
+                                },
+                                "sizeMiB": {
+                                    "type": "number"
+                                },
+                                "availability": {
+                                    "type": "string"
+                                },
+                                "osd": {
+                                    "type": "object",
+                                    "required": [
+                                        "pgs",
+                                        "reweight",
+                                        "daemons"
+                                    ],
+                                    "properties": {
+                                        "pgs": {
+                                            "type": "integer"
+                                        },
+                                        "reweight": {
+                                            "type": "number"
+                                        },
+                                        "daemons": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "usagePercent",
+                                                    "status"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "usagePercent": {
+                                                        "type": "number"
+                                                    },
+                                                    "status": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "current",
+                                                            "isProcessing"
+                                                        ],
+                                                        "properties": {
+                                                            "current": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "up",
+                                                                    "down",
+                                                                    "warning",
+                                                                    "error"
+                                                                ]
+                                                            },
+                                                            "isProcessing": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "required": [
+                                        "current",
+                                        "description",
+                                        "isPromotable",
+                                        "isDemotable",
+                                        "isProcessing"
+                                    ],
+                                    "properties": {
+                                        "current": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ok",
+                                                "warning",
+                                                "fail"
+                                            ]
+                                        },
+                                        "isPromotable": {
+                                            "type": "boolean"
+                                        },
+                                        "isDemotable": {
+                                            "type": "boolean"
+                                        },
+                                        "isProcessing": {
+                                            "type": "boolean"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "list node devices successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "AddNodeDeviceResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 201
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to add node device is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "UpdateNodeDeviceResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to update node device is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "RemoveNodeDeviceResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to remove node device is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "UpdateNodeOsdResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to update node OSD is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "RestartNodeOsdResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to restart node OSD is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "DeleteNodeOsdResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to delete node OSD is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "UpdateNodeDeviceRequest": {
+                "type": "object",
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "type": "string",
+                        "enum": [
+                            "ssd",
+                            "hdd"
+                        ]
+                    }
+                }
+            },
+            "UpdateNodeOsdRequest": {
+                "type": "object",
+                "required": [
+                    "reweight"
+                ],
+                "properties": {
+                    "reweight": {
+                        "type": "number",
+                        "description": "The reweight value for the OSD, e.g., 0.5"
                     }
                 }
             },
@@ -17014,7 +17997,6 @@ const docTemplate = `{
                     "status",
                     "cpuSpec",
                     "networkInterfaces",
-                    "blockDevices",
                     "ipmi",
                     "vcpu",
                     "memory",
@@ -17170,57 +18152,6 @@ const docTemplate = `{
                                 },
                                 "speed": {
                                     "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "blockDevices": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "serial",
-                                "device",
-                                "type",
-                                "sizeMiB",
-                                "availability",
-                                "status"
-                            ],
-                            "properties": {
-                                "serial": {
-                                    "type": "string"
-                                },
-                                "device": {
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "type": "string"
-                                },
-                                "sizeMiB": {
-                                    "type": "number"
-                                },
-                                "availability": {
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "type": "object",
-                                    "required": [
-                                        "current",
-                                        "description"
-                                    ],
-                                    "properties": {
-                                        "current": {
-                                            "type": "string",
-                                            "enum": [
-                                                "ok",
-                                                "warning",
-                                                "fail"
-                                            ]
-                                        },
-                                        "description": {
-                                            "type": "string"
-                                        }
-                                    }
                                 }
                             }
                         }

--- a/api/docs.json
+++ b/api/docs.json
@@ -5778,6 +5778,30 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "Node not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "content": {
@@ -5829,7 +5853,7 @@
                                 "example": {
                                     "summary": "Add Node Device",
                                     "value": {
-                                        "device": "sdd"
+                                        "device": "sdb"
                                     }
                                 }
                             }
@@ -5837,8 +5861,8 @@
                     }
                 },
                 "responses": {
-                    "201": {
-                        "description": "Device added to the node successfully",
+                    "202": {
+                        "description": "the request to add node device is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5898,7 +5922,7 @@
                 }
             }
         },
-        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{device}": {
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{deviceName}": {
             "delete": {
                 "operationId": "removeNodeDevice",
                 "tags": [
@@ -5918,7 +5942,7 @@
                 ],
                 "responses": {
                     "202": {
-                        "description": "the device removal request is received and is being processed",
+                        "description": "the request to remove node device is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6002,7 +6026,7 @@
                                 "example1": {
                                     "summary": "Promote a device to SSD class",
                                     "value": {
-                                        "class": "sdd"
+                                        "class": "ssd"
                                     }
                                 },
                                 "example2": {
@@ -6017,7 +6041,7 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "the device update request is received and is being processed",
+                        "description": "the request to update node device is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6115,7 +6139,7 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "the OSD update request is received and is being processed",
+                        "description": "the request to update node OSD is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6193,7 +6217,7 @@
                 ],
                 "responses": {
                     "202": {
-                        "description": "the OSD deletion request is received and is being processed",
+                        "description": "the request to delete node OSD is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6273,7 +6297,7 @@
                 ],
                 "responses": {
                     "202": {
-                        "description": "the OSD restart request is received and is being processed",
+                        "description": "the request to restart node OSD is accepted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -15470,7 +15494,7 @@
                 "properties": {
                     "code": {
                         "type": "integer",
-                        "example": 201
+                        "example": 202
                     },
                     "msg": {
                         "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -927,7 +927,7 @@
                             }
                         },
                         "description": "The ids of the event to query.",
-                        "example": "Info"
+                        "example": "CPU00004I"
                     }
                 ],
                 "responses": {
@@ -4971,29 +4971,6 @@
                                                                 "speed": "NA/1000F"
                                                             }
                                                         ],
-                                                        "blockDevices": [
-                                                            {
-                                                                "serial": "200264800526",
-                                                                "device": "nvme0n1",
-                                                                "type": "SSD",
-                                                                "sizeMiB": 222110.7482,
-                                                                "availability": "system",
-                                                                "status": {
-                                                                    "current": "ok"
-                                                                }
-                                                            },
-                                                            {
-                                                                "serial": "200598804038",
-                                                                "device": "nvme1n1",
-                                                                "type": "SSD",
-                                                                "sizeMiB": 222110.7482,
-                                                                "availability": "in-use",
-                                                                "status": {
-                                                                    "current": "warning",
-                                                                    "description": "status fetch timeout"
-                                                                }
-                                                            }
-                                                        ],
                                                         "ipmi": {
                                                             "isSupported": true,
                                                             "isConnected": false,
@@ -5177,29 +5154,6 @@
                                                         "driver": "tg3",
                                                         "state": "DOWN",
                                                         "speed": "NA/1000F"
-                                                    }
-                                                ],
-                                                "blockDevices": [
-                                                    {
-                                                        "serial": "200264800526",
-                                                        "device": "nvme0n1",
-                                                        "type": "SSD",
-                                                        "sizeMiB": 222110.7482,
-                                                        "availability": "system",
-                                                        "status": {
-                                                            "current": "ok"
-                                                        }
-                                                    },
-                                                    {
-                                                        "serial": "200598804038",
-                                                        "device": "nvme1n1",
-                                                        "type": "SSD",
-                                                        "sizeMiB": 222110.7482,
-                                                        "availability": "in-use",
-                                                        "status": {
-                                                            "current": "warning",
-                                                            "description": "status fetch timeout"
-                                                        }
                                                     }
                                                 ],
                                                 "ipmi": {
@@ -5692,6 +5646,693 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices": {
+            "get": {
+                "operationId": "listNodeDevices",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Retrieve the node devices",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/watch"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the node devices successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListNodeDevicesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Node Devices",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "serial": "57T0A05UF5YE",
+                                                    "device": "sda",
+                                                    "type": "HDD",
+                                                    "class": "hdd",
+                                                    "osd": {
+                                                        "pgs": 646,
+                                                        "reweight": 1,
+                                                        "daemons": [
+                                                            {
+                                                                "id": "osd.0",
+                                                                "usagePercent": 21.9012,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "osd.1",
+                                                                "usagePercent": 17.4514,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "sizeMiB": 533008.5754,
+                                                    "availability": "in-use",
+                                                    "status": {
+                                                        "current": "ok",
+                                                        "isPromotable": true,
+                                                        "isDemotable": false,
+                                                        "isProcessing": false
+                                                    }
+                                                },
+                                                {
+                                                    "serial": "183222E1E59B",
+                                                    "device": "sdb",
+                                                    "type": "SSD",
+                                                    "class": "",
+                                                    "osd": {
+                                                        "pgs": 0,
+                                                        "reweight": 0,
+                                                        "daemons": []
+                                                    },
+                                                    "sizeMiB": 426387.7868,
+                                                    "availability": "system",
+                                                    "status": {
+                                                        "current": "ok",
+                                                        "isPromotable": true,
+                                                        "isDemotable": false,
+                                                        "isProcessing": false
+                                                    }
+                                                },
+                                                {
+                                                    "serial": "57P0A0EWF5YE",
+                                                    "device": "sdc",
+                                                    "type": "HDD",
+                                                    "class": "hdd",
+                                                    "osd": {
+                                                        "pgs": 634,
+                                                        "reweight": 1,
+                                                        "daemons": [
+                                                            {
+                                                                "id": "osd.2",
+                                                                "usagePercent": 15.748,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "id": "osd.3",
+                                                                "usagePercent": 21.4815,
+                                                                "status": {
+                                                                    "current": "up",
+                                                                    "isProcessing": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "sizeMiB": 533008.5754,
+                                                    "availability": "in-use",
+                                                    "status": {
+                                                        "current": "ok",
+                                                        "isPromotable": true,
+                                                        "isDemotable": false,
+                                                        "isProcessing": false
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "fetch node devices successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch setting: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "addNodeDevice",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Add a device to the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddNodeDeviceRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Add Node Device",
+                                    "value": {
+                                        "device": "sdd"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Device added to the node successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AddNodeDeviceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to add device: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{device}": {
+            "delete": {
+                "operationId": "removeNodeDevice",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Remove a device from the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/device"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the device removal request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoveNodeDeviceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or device not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or device not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to remove device: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "updateNodeDevice",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Update a device on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateNodeDeviceRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Promote a device to SSD class",
+                                    "value": {
+                                        "class": "sdd"
+                                    }
+                                },
+                                "example2": {
+                                    "summary": "Demote a device to HDD class",
+                                    "value": {
+                                        "class": "hdd"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "the device update request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UpdateNodeDeviceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or device not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or device not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update device: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}": {
+            "patch": {
+                "operationId": "updateNodeOsd",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Update an OSD on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/osdId"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateNodeOsdRequest"
+                            },
+                            "examples": {
+                                "example": {
+                                    "summary": "Reweight an OSD",
+                                    "value": {
+                                        "reweight": 0.5
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "the OSD update request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UpdateNodeOsdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or OSD not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or osd not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update osd: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteNodeOsd",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Delete an OSD on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/osdId"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the OSD deletion request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeleteNodeOsdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or OSD not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or osd not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete osd: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}/restart": {
+            "post": {
+                "operationId": "restartNodeOsd",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Restart an OSD on the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/osdId"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the OSD restart request is received and is being processed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RestartNodeOsdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node or OSD not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node or osd not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to restart osd: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/settings": {
             "get": {
                 "operationId": "getSettings",
@@ -5762,7 +6403,7 @@
                                                     "channels": [
                                                         {
                                                             "name": "#example-alert-channel-1",
-                                                            "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                                            "url": "https://hooks.slack.com/services/example-token",
                                                             "description": "example alert channel 1",
                                                             "status": {
                                                                 "current": "ok",
@@ -5771,7 +6412,7 @@
                                                         },
                                                         {
                                                             "name": "#example-alert-channel-2",
-                                                            "url": "https://hooks.slack.com/services/T9LMCCCCC/C08GQACCCCC/CCCCCCCSevAyxkM2dPYCCCCC",
+                                                            "url": "https://hooks.slack.com/services/example-token",
                                                             "description": "example alert channel 2",
                                                             "status": {
                                                                 "current": "ok",
@@ -5917,8 +6558,8 @@
                                     "value": {
                                         "host": "email-smtp.example.mailserver.com",
                                         "port": 587,
-                                        "username": "ABBBBBBMJM56DCCCCJR",
-                                        "password": "VBHWEEGEEEEEX0f5NLHDXLESxdZR",
+                                        "username": "example-user",
+                                        "password": "example-password",
                                         "from": "noreply@example.com"
                                     }
                                 }
@@ -6636,7 +7277,7 @@
                                     "summary": "Slack Channel",
                                     "value": {
                                         "name": "#example-alert-channel-1",
-                                        "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                        "url": "https://hooks.slack.com/services/example-token",
                                         "description": "example alert channel 1"
                                     }
                                 }
@@ -6709,7 +7350,7 @@
                                                 "slackChannels": [
                                                     {
                                                         "name": "#example-alert-channel-1",
-                                                        "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                                        "url": "https://hooks.slack.com/services/example-token",
                                                         "description": "example alert channel 1",
                                                         "status": {
                                                             "current": "ok",
@@ -6718,7 +7359,7 @@
                                                     },
                                                     {
                                                         "name": "#example-alert-channel-2",
-                                                        "url": "https://hooks.slack.com/services/T9LMCCCCC/C08GQACCCCC/CCCCCCCSevAyxkM2dPYCCCCC",
+                                                        "url": "https://hooks.slack.com/services/example-token",
                                                         "description": "example alert channel 2",
                                                         "status": {
                                                             "current": "ok",
@@ -6852,7 +7493,7 @@
                                     "summary": "Slack channel",
                                     "value": {
                                         "name": "#example-alert-channel-1",
-                                        "url": "https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB",
+                                        "url": "https://hooks.slack.com/services/example-token",
                                         "description": "example alert channel 1"
                                     }
                                 }
@@ -6992,8 +7633,8 @@
                                         "value": {
                                             "code": 201,
                                             "data": {
-                                                "token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwdDdGdWlJZC1lbnhVUWRZWGVZalZ6Q0pQZFRWMmxaU0NZanRkQW01S3djIn0.eyJleHAiOjE3Mzg5NjA2NzYsImlhdCI6MTczODk1MzQ3NiwianRpIjoiZjZjZTJlMjMtYzgwNC00N2YxLWE0OWEtZjdlNWZlYTgyYThjIiwiaXNzIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjpbIm1hc3Rlci1yZWFsbSIsImFjY291bnQiXSwic3ViIjoiMDY1OTVlMDAtZWIzOS00YWUxLTkzYjctZDMyNzg1MDdiZTUzIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidG9rZW4tY29ubmVjdCIsInNlc3Npb25fc3RhdGUiOiJlOTE0MWVhZC01MTQ1LTRjZmQtODhiZC00ZjYxYzI0MzA0NzAiLCJhY3IiOiIxIiwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImNyZWF0ZS1yZWFsbSIsImRlZmF1bHQtcm9sZXMtbWFzdGVyIiwib2ZmbGluZV9hY2Nlc3MiLCJhZG1pbiIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsibWFzdGVyLXJlYWxtIjp7InJvbGVzIjpbInZpZXctaWRlbnRpdHktcHJvdmlkZXJzIiwidmlldy1yZWFsbSIsIm1hbmFnZS1pZGVudGl0eS1wcm92aWRlcnMiLCJpbXBlcnNvbmF0aW9uIiwiY3JlYXRlLWNsaWVudCIsIm1hbmFnZS11c2VycyIsInF1ZXJ5LXJlYWxtcyIsInZpZXctYXV0aG9yaXphdGlvbiIsInF1ZXJ5LWNsaWVudHMiLCJxdWVyeS11c2VycyIsIm1hbmFnZS1ldmVudHMiLCJtYW5hZ2UtcmVhbG0iLCJ2aWV3LWV2ZW50cyIsInZpZXctdXNlcnMiLCJ2aWV3LWNsaWVudHMiLCJtYW5hZ2UtYXV0aG9yaXphdGlvbiIsIm1hbmFnZS1jbGllbnRzIiwicXVlcnktZ3JvdXBzIl19LCJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwic2lkIjoiZTkxNDFlYWQtNTE0NS00Y2ZkLTg4YmQtNGY2MWMyNDMwNDcwIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiJ9.LkywGnG2BhQ90n-f3vJvX-frq1wRS6DAop5MUcCFb5FSuGvv3oP_byeiuHvh9rh06QWcwhpiTU_L_hOaUzMXF9spJjos8s2iOwK-4o46Ka_4Q2gnlitjd8ZG5wGfuqKRp0vb25RsBpNr6rxGFzOxxmULkjEXOGXbcrqQJBWIaWdRldYunLFRVErIpmH23w4KHKWSB5XkwqpkD9HnLH_PqbaunGpp2acgZ826JpevC8vhEhIg6fxXcDnCKhkw7nNvfs3rCC08Qci32WtzujeKH6js1ASRkKWOUxVkfIkzZ5Yg4Tfdb79_Tgy2iXLT3teeNTepmLsaftn2JzLn_6vHwg",
-                                                "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1OGRkY2JhNC1hM2ZkLTQ2MTYtODgyYi1lMGY1ZjRlNzAyMTIifQ.eyJleHAiOjE3Mzg5NTUyNzYsImlhdCI6MTczODk1MzQ3NiwianRpIjoiNjkyZDkxMTAtMjExMy00NTU1LTgxMTctNWYxZTA2NzlmYmUxIiwiaXNzIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDY1OTVlMDAtZWIzOS00YWUxLTkzYjctZDMyNzg1MDdiZTUzIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRva2VuLWNvbm5lY3QiLCJzZXNzaW9uX3N0YXRlIjoiZTkxNDFlYWQtNTE0NS00Y2ZkLTg4YmQtNGY2MWMyNDMwNDcwIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsInNpZCI6ImU5MTQxZWFkLTUxNDUtNGNmZC04OGJkLTRmNjFjMjQzMDQ3MCJ9._B9rU8TG_YSvwsri48bfne3RxFhc4Yq83bzR43nL4-c",
+                                                "token": "example-token",
+                                                "refresh": "example-refresh-token",
                                                 "expires": {
                                                     "access": 7200,
                                                     "refresh": 1800
@@ -11654,6 +12295,26 @@
                 },
                 "example": "example-node-0"
             },
+            "device": {
+                "in": "path",
+                "name": "device",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The device to remove from the node",
+                "example": "sdb"
+            },
+            "osdId": {
+                "in": "path",
+                "name": "osdId",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The OSD ID to operate",
+                "example": "osd.0"
+            },
             "instanceId": {
                 "in": "path",
                 "name": "instanceId",
@@ -14592,6 +15253,18 @@
                     }
                 }
             },
+            "AddNodeDeviceRequest": {
+                "type": "object",
+                "required": [
+                    "device"
+                ],
+                "properties": {
+                    "device": {
+                        "type": "string",
+                        "description": "The device path, e.g., sdc"
+                    }
+                }
+            },
             "SetNodeIpmiSettingResponse": {
                 "type": "object",
                 "required": [
@@ -14633,6 +15306,316 @@
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "ListNodeDevicesResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "serial",
+                                "device",
+                                "type",
+                                "class",
+                                "sizeMiB",
+                                "availability",
+                                "osd",
+                                "status"
+                            ],
+                            "properties": {
+                                "serial": {
+                                    "type": "string"
+                                },
+                                "device": {
+                                    "type": "string"
+                                },
+                                "class": {
+                                    "type": "string",
+                                    "enum": [
+                                        "ssd",
+                                        "hdd"
+                                    ]
+                                },
+                                "type": {
+                                    "type": "string"
+                                },
+                                "sizeMiB": {
+                                    "type": "number"
+                                },
+                                "availability": {
+                                    "type": "string"
+                                },
+                                "osd": {
+                                    "type": "object",
+                                    "required": [
+                                        "pgs",
+                                        "reweight",
+                                        "daemons"
+                                    ],
+                                    "properties": {
+                                        "pgs": {
+                                            "type": "integer"
+                                        },
+                                        "reweight": {
+                                            "type": "number"
+                                        },
+                                        "daemons": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "usagePercent",
+                                                    "status"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "usagePercent": {
+                                                        "type": "number"
+                                                    },
+                                                    "status": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "current",
+                                                            "isProcessing"
+                                                        ],
+                                                        "properties": {
+                                                            "current": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "up",
+                                                                    "down",
+                                                                    "warning",
+                                                                    "error"
+                                                                ]
+                                                            },
+                                                            "isProcessing": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "required": [
+                                        "current",
+                                        "description",
+                                        "isPromotable",
+                                        "isDemotable",
+                                        "isProcessing"
+                                    ],
+                                    "properties": {
+                                        "current": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ok",
+                                                "warning",
+                                                "fail"
+                                            ]
+                                        },
+                                        "isPromotable": {
+                                            "type": "boolean"
+                                        },
+                                        "isDemotable": {
+                                            "type": "boolean"
+                                        },
+                                        "isProcessing": {
+                                            "type": "boolean"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "list node devices successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "AddNodeDeviceResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 201
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to add node device is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "UpdateNodeDeviceResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to update node device is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "RemoveNodeDeviceResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to remove node device is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "UpdateNodeOsdResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to update node OSD is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "RestartNodeOsdResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to restart node OSD is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "DeleteNodeOsdResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 202
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "the request to delete node OSD is accepted successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "UpdateNodeDeviceRequest": {
+                "type": "object",
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "type": "string",
+                        "enum": [
+                            "ssd",
+                            "hdd"
+                        ]
+                    }
+                }
+            },
+            "UpdateNodeOsdRequest": {
+                "type": "object",
+                "required": [
+                    "reweight"
+                ],
+                "properties": {
+                    "reweight": {
+                        "type": "number",
+                        "description": "The reweight value for the OSD, e.g., 0.5"
                     }
                 }
             },
@@ -17010,7 +17993,6 @@
                     "status",
                     "cpuSpec",
                     "networkInterfaces",
-                    "blockDevices",
                     "ipmi",
                     "vcpu",
                     "memory",
@@ -17166,57 +18148,6 @@
                                 },
                                 "speed": {
                                     "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "blockDevices": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "serial",
-                                "device",
-                                "type",
-                                "sizeMiB",
-                                "availability",
-                                "status"
-                            ],
-                            "properties": {
-                                "serial": {
-                                    "type": "string"
-                                },
-                                "device": {
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "type": "string"
-                                },
-                                "sizeMiB": {
-                                    "type": "number"
-                                },
-                                "availability": {
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "type": "object",
-                                    "required": [
-                                        "current",
-                                        "description"
-                                    ],
-                                    "properties": {
-                                        "current": {
-                                            "type": "string",
-                                            "enum": [
-                                                "ok",
-                                                "warning",
-                                                "fail"
-                                            ]
-                                        },
-                                        "description": {
-                                            "type": "string"
-                                        }
-                                    }
                                 }
                             }
                         }

--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -57,8 +57,8 @@ var (
 		{
 			Version: apis.V1,
 			Method:  http.MethodPost,
-			Path:    "/nodes/:nodeName/devices/:device",
-			Func:    createNodeDevice,
+			Path:    "/nodes/:nodeName/devices",
+			Func:    addNodeDevice,
 		},
 		{
 			Version: apis.V1,
@@ -290,8 +290,8 @@ func listNodeDevices(c *gin.Context) {
 	)
 }
 
-func createNodeDevice(c *gin.Context) {
-	h, err := initHelper(c, "createNodeDevice")
+func addNodeDevice(c *gin.Context) {
+	h, err := initHelper(c, "addNodeDevice")
 	if err != nil {
 		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err)

--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -60,6 +60,36 @@ var (
 			Path:    "/nodes/:nodeName/devices/:device",
 			Func:    createNodeDevice,
 		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodDelete,
+			Path:    "/nodes/:nodeName/devices/:device",
+			Func:    removeNodeDevice,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/nodes/:nodeName/devices/:device",
+			Func:    promoteOrDemoteNodeDevice,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPost,
+			Path:    "/nodes/:nodeName/osds/:id/restart",
+			Func:    restartNodeOsd,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodDelete,
+			Path:    "/nodes/:nodeName/osds/:id",
+			Func:    removeNodeOsd,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/nodes/:nodeName/osds/:id",
+			Func:    patchNodeOsd,
+		},
 	}
 )
 
@@ -282,5 +312,91 @@ func createNodeDevice(c *gin.Context) {
 	bodies.SetAccepted(
 		c,
 		"the request of creating node device is accepted and under processing",
+	)
+}
+
+func removeNodeDevice(c *gin.Context) {
+	h, err := initHelper(c, "removeNodeDevice")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.validateRemovalReq()
+	if err != nil {
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.delegateDeviceReq()
+	if err != nil {
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"the request of deleting node device is accepted and under processing",
+	)
+}
+
+func promoteOrDemoteNodeDevice(c *gin.Context) {
+	h, err := initHelper(c, "promoteOrDemoteNodeDevice")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.delegateDeviceReq()
+	if err != nil {
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"the request of promoting or demoting node device is accepted and under processing",
+	)
+}
+
+func restartNodeOsd(c *gin.Context) {
+	h, err := initHelper(c, "restartNodeOsd")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"the request of restarting node osd is accepted and under processing",
+	)
+}
+
+func removeNodeOsd(c *gin.Context) {
+	h, err := initHelper(c, "removeNodeOsd")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"the request of removing node osd is accepted and under processing",
+	)
+}
+
+func patchNodeOsd(c *gin.Context) {
+	h, err := initHelper(c, "patchNodeOsd")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"the request of patching node osd is accepted and under processing",
 	)
 }

--- a/internal/apis/v1/handlers/nodes/helper.go
+++ b/internal/apis/v1/handlers/nodes/helper.go
@@ -34,7 +34,9 @@ type helper struct {
 	ipmi            nodes.Ipmi
 	operation       string
 	device          string
+	osdId           string
 	deviceReqOpts   nodes.DeviceReqOpts
+	osdReqOpts      nodes.OsdReqOpts
 
 	page  *pages.Page
 	watch bool

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -20,7 +20,7 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseIpmiOperateOptions()
 	case "listNodeDevices":
 		return h.parseListDevicesOptions()
-	case "createNodeDevice":
+	case "addNodeDevice":
 		return h.parseCreateDeviceOptions()
 	case "promoteOrDemoteNodeDevice":
 		return h.parsePromoteOrDemoteOptions()

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -22,6 +22,16 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseListDevicesOptions()
 	case "createNodeDevice":
 		return h.parseCreateDeviceOptions()
+	case "promoteOrDemoteNodeDevice":
+		return h.parsePromoteOrDemoteOptions()
+	case "removeNodeDevice":
+		return h.parseRemoveDeviceOptions()
+	case "restartNodeOsd":
+		return h.parseRestartOsdOptions()
+	case "removeNodeOsd":
+		return h.parseRemoveOsdOptions()
+	case "patchNodeOsd":
+		return h.parsePatchOsdOptions()
 	default:
 		return fmt.Errorf(
 			"unknown node handler: %s",
@@ -125,6 +135,92 @@ func (h *helper) parseCreateDeviceOptions() error {
 	if err != nil {
 		return fmt.Errorf(
 			"failed to parse create device options(%v)",
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (h *helper) parsePromoteOrDemoteOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	h.device = h.c.Param("device")
+	if h.device == "" {
+		return fmt.Errorf("device name should be provided")
+	}
+
+	err := h.c.ShouldBindJSON(&h.deviceReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse promote or demote options(%v)",
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (h *helper) parseRemoveDeviceOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	h.device = h.c.Param("device")
+	if h.device == "" {
+		return fmt.Errorf("device name should be provided")
+	}
+
+	return nil
+}
+
+func (h *helper) parseRestartOsdOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	h.osdId = h.c.Param("id")
+	if h.osdId == "" {
+		return fmt.Errorf("osd id should be provided")
+	}
+
+	return nil
+}
+
+func (h *helper) parseRemoveOsdOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	h.osdId = h.c.Param("id")
+	if h.osdId == "" {
+		return fmt.Errorf("osd id should be provided")
+	}
+
+	return nil
+}
+
+func (h *helper) parsePatchOsdOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	h.osdId = h.c.Param("id")
+	if h.osdId == "" {
+		return fmt.Errorf("osd id should be provided")
+	}
+
+	err := h.c.ShouldBindJSON(&h.osdReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse patch osd options(%v)",
 			err,
 		)
 	}

--- a/internal/apis/v1/handlers/nodes/verify.go
+++ b/internal/apis/v1/handlers/nodes/verify.go
@@ -61,3 +61,19 @@ func (h *helper) validateCreationReq() error {
 
 	return nil
 }
+
+func (h *helper) validateRemovalReq() error {
+	// if !nodes.IsExist(node) {
+	// 	return fmt.Errorf("node(%s) does not exist", h.node)
+	// }
+
+	// if !cubecos.HasDevice(h.node, h.createOpts.Device) {
+	// 	return fmt.Errorf(
+	// 		"device(%s) does not exist on node(%s)",
+	// 		h.createOpts.Device,
+	// 		h.node,
+	// 	)
+	// }
+
+	return nil
+}

--- a/internal/cubecos/osd.go
+++ b/internal/cubecos/osd.go
@@ -47,3 +47,52 @@ func RemoveOsd(req nodes.OsdReqOpts) error {
 
 	return nil
 }
+
+func ReweightOsd(req nodes.OsdReqOpts) error {
+	id := fmt.Sprintf("osd.%s", req.Id)
+	reweight := fmt.Sprintf("%f", req.Reweight)
+	out, err := exec.Command("ceph", "osd", "crush", "reweight", id, reweight).CombinedOutput()
+	if err != nil {
+		log.Errorf(
+			"hexSdk: failed to execute osd reweight cmd %s(%v %s)",
+			req.Id, err, string(out),
+		)
+		return err
+	}
+
+	if !IsHexSdkSuccess(err) {
+		return fmt.Errorf(
+			"failed to reweight osd %s(%v %s)",
+			req.Id, err, string(out),
+		)
+	}
+
+	return nil
+}
+
+func GetDeviceByOsdId(osdId string) (*nodes.BlockDevice, error) {
+	out, err := exec.Command("hex_sdk", "ceph_osd_get_device", osdId).CombinedOutput()
+	if err != nil {
+		log.Errorf(
+			"hexSdk: failed to get device by osd id %s(%v %s)",
+			osdId, err, string(out),
+		)
+		return nil, err
+	}
+
+	if !IsHexSdkSuccess(err) {
+		return nil, fmt.Errorf(
+			"failed to get device by osd id %s(%v %s)",
+			osdId, err, string(out),
+		)
+	}
+
+	device := &nodes.Device{}
+	err = nodes.UnmarshalDevice(out, device)
+	if err != nil {
+		log.Errorf("hexSdk: failed to unmarshal device(%v)", err)
+		return nil, err
+	}
+
+	return device, nil
+}

--- a/internal/cubecos/osd.go
+++ b/internal/cubecos/osd.go
@@ -69,30 +69,3 @@ func ReweightOsd(req nodes.OsdReqOpts) error {
 
 	return nil
 }
-
-func GetDeviceByOsdId(osdId string) (*nodes.BlockDevice, error) {
-	out, err := exec.Command("hex_sdk", "ceph_osd_get_device", osdId).CombinedOutput()
-	if err != nil {
-		log.Errorf(
-			"hexSdk: failed to get device by osd id %s(%v %s)",
-			osdId, err, string(out),
-		)
-		return nil, err
-	}
-
-	if !IsHexSdkSuccess(err) {
-		return nil, fmt.Errorf(
-			"failed to get device by osd id %s(%v %s)",
-			osdId, err, string(out),
-		)
-	}
-
-	device := &nodes.Device{}
-	err = nodes.UnmarshalDevice(out, device)
-	if err != nil {
-		log.Errorf("hexSdk: failed to unmarshal device(%v)", err)
-		return nil, err
-	}
-
-	return device, nil
-}

--- a/internal/definition/v1/ceph/device.go
+++ b/internal/definition/v1/ceph/device.go
@@ -3,7 +3,9 @@ package ceph
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/math"
@@ -102,6 +104,35 @@ func ListRawDevicesByHost(host string) ([]RawDevice, error) {
 	}
 
 	return devices, nil
+}
+
+func GetDeviceByOsdId(host, id string) (*Device, error) {
+	devices, err := ListRawDevicesByHost(host)
+	if err != nil {
+		log.Errorf("ceph: failed to list devices by host %s(%v)", host, err)
+		return nil, err
+	}
+
+	for _, device := range devices {
+		if !slices.Contains(device.Daemons, id) {
+			continue
+		}
+
+		if len(device.Location) == 0 {
+			continue
+		}
+
+		return &Device{
+			Dev:  device.Location[0].Dev,
+			Osds: genOsdsByRaw(device.Daemons),
+		}, nil
+	}
+
+	log.Errorf("ceph: no device found for osd %s on host %s", id, host)
+	return nil, fmt.Errorf(
+		"no device found for osd %s on host %s",
+		id, host,
+	)
 }
 
 func convertToDevices(raws []RawDevice) ([]Device, error) {

--- a/internal/definition/v1/nodes/device.go
+++ b/internal/definition/v1/nodes/device.go
@@ -5,6 +5,7 @@ import "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 type DeviceReqOpts struct {
 	Hostname string             `json:"host"`
 	Device   string             `json:"device"`
+	Class    string             `json:"class"`
 	Status   status.BlockDevice `json:"status"`
 }
 


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/158

https://github.com/bigstack-oss/cubecos/issues/209

https://github.com/bigstack-oss/cubecos/issues/210

https://github.com/bigstack-oss/cubecos/issues/211

https://github.com/bigstack-oss/cubecos/issues/212

https://github.com/bigstack-oss/cubecos/issues/213

https://github.com/bigstack-oss/cubecos/issues/214

<br/>

### What this PR does?

- Add 7 APIs for block device and OSD operations (list, add, remove, restart, reweight, promote, demote, and so on ...)

- Add corresponding api docs for the APIs above

<br/>

### Test results (optional)

1). make sure the api docs have been updated accordingly

could check and direct interact with https://10.32.45.10/api/v1/datacenters/control/apidocs/index.html#