### PR TITLE
Integrate the block device DELETE API with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5941,7 +5941,7 @@ const docTemplate = `{
                         "$ref": "#/components/parameters/nodeName"
                     },
                     {
-                        "$ref": "#/components/parameters/device"
+                        "$ref": "#/components/parameters/deviceName"
                     }
                 ],
                 "responses": {
@@ -12323,14 +12323,14 @@ const docTemplate = `{
                 },
                 "example": "example-node-0"
             },
-            "device": {
+            "deviceName": {
                 "in": "path",
-                "name": "device",
+                "name": "deviceName",
                 "required": true,
                 "schema": {
                     "type": "string"
                 },
-                "description": "The device to remove from the node",
+                "description": "The device name to remove from the node",
                 "example": "sdb"
             },
             "osdId": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -5937,7 +5937,7 @@
                         "$ref": "#/components/parameters/nodeName"
                     },
                     {
-                        "$ref": "#/components/parameters/device"
+                        "$ref": "#/components/parameters/deviceName"
                     }
                 ],
                 "responses": {
@@ -6013,6 +6013,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/nodeName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/deviceName"
                     }
                 ],
                 "requestBody": {
@@ -12319,14 +12322,14 @@
                 },
                 "example": "example-node-0"
             },
-            "device": {
+            "deviceName": {
                 "in": "path",
-                "name": "device",
+                "name": "deviceName",
                 "required": true,
                 "schema": {
                     "type": "string"
                 },
-                "description": "The device to remove from the node",
+                "description": "The device name to remove from the node",
                 "example": "sdb"
             },
             "osdId": {

--- a/internal/apis/v1/handlers/nodes/delegation.go
+++ b/internal/apis/v1/handlers/nodes/delegation.go
@@ -13,17 +13,16 @@ var (
 
 func (h *helper) delegateDeviceReq() error {
 	if nodes.IsLocal(h.node) {
-		req := h.setDeviceCreateReq()
-		h.delegateToLocal(req)
+		h.delegateToLocal()
 		return nil
 	}
 
 	return h.createDeviceOnPeerNode()
 }
 
-func (h *helper) delegateToLocal(req nodes.DeviceReqOpts) {
+func (h *helper) delegateToLocal() {
 	h.upsertDeviceReqRecord()
-	devReqQueue.Add(req)
+	devReqQueue.Add(h.deviceReqOpts)
 }
 
 func (h *helper) createDeviceOnPeerNode() error {

--- a/internal/apis/v1/handlers/nodes/device.go
+++ b/internal/apis/v1/handlers/nodes/device.go
@@ -160,8 +160,14 @@ func (h *helper) setPartitionMounts(mountsMap map[string][]string, rawDev nodes.
 func (h *helper) setBlockDeviceAvailability(blockDevs *[]nodes.BlockDevice, mountsMap map[string][]string) {
 	partitionAvailability := h.genPartitionAvailability(mountsMap)
 	parentDevAvailability := h.genParentDevAvailability(partitionAvailability)
+
 	for i, blockDev := range *blockDevs {
-		(*blockDevs)[i].Availability = parentDevAvailability[blockDev.Name]
+		availability, found := parentDevAvailability[blockDev.Name]
+		if found {
+			(*blockDevs)[i].Availability = availability
+		} else {
+			(*blockDevs)[i].Availability = status.Available
+		}
 	}
 }
 

--- a/internal/apis/v1/handlers/nodes/device.go
+++ b/internal/apis/v1/handlers/nodes/device.go
@@ -112,13 +112,16 @@ func (h *helper) syncCephOsds(blockDevs *[]nodes.BlockDevice) error {
 
 	for i, blockDev := range *blockDevs {
 		cephDev, found := cephDevs[blockDev.Name]
-		if found {
-			(*blockDevs)[i].Class = cephDev.Class
-			(*blockDevs)[i].Osd = nodes.Osd{
-				Pgs:      h.getTotalPgs(cephDev.Osds),
-				Reweigth: cephDev.Reweight,
-				Daemons:  h.convertToOsds(cephDev.Osds),
-			}
+		if !found {
+			(*blockDevs)[i].Osd = nodes.Osd{Daemons: []nodes.Deamon{}}
+			continue
+		}
+
+		(*blockDevs)[i].Class = cephDev.Class
+		(*blockDevs)[i].Osd = nodes.Osd{
+			Pgs:      h.getTotalPgs(cephDev.Osds),
+			Reweigth: cephDev.Reweight,
+			Daemons:  h.convertToOsds(cephDev.Osds),
 		}
 	}
 

--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -74,6 +74,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/nodes/:nodeName/devices/tasks",
+			Func:    patchDeviceTask,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodPost,
 			Path:    "/nodes/:nodeName/osds/:id/restart",
 			Func:    restartNodeOsd,
@@ -89,6 +95,12 @@ var (
 			Method:  http.MethodPatch,
 			Path:    "/nodes/:nodeName/osds/:id",
 			Func:    patchNodeOsd,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/nodes/:nodeName/osds/tasks",
+			Func:    patchOsdTask,
 		},
 	}
 )
@@ -298,7 +310,7 @@ func addNodeDevice(c *gin.Context) {
 		return
 	}
 
-	err = h.validateCreationReq()
+	err = h.validateDeviceReq()
 	if err != nil {
 		bodies.SetBadRequest(c, err)
 		return
@@ -323,7 +335,7 @@ func removeNodeDevice(c *gin.Context) {
 		return
 	}
 
-	err = h.validateRemovalReq()
+	err = h.validateDeviceReq()
 	if err != nil {
 		bodies.SetBadRequest(c, err)
 		return
@@ -398,5 +410,49 @@ func patchNodeOsd(c *gin.Context) {
 	bodies.SetAccepted(
 		c,
 		"the request of patching node osd is accepted and under processing",
+	)
+}
+
+func patchDeviceTask(c *gin.Context) {
+	h, err := initHelper(c, "patchDeviceTask")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.updateDeviceTask()
+	if err != nil {
+		log.Errorf("nodes(%s): failed to update node device task(%v)", h.reqId, err)
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"update node device task successfully",
+		nil,
+	)
+}
+
+func patchOsdTask(c *gin.Context) {
+	h, err := initHelper(c, "patchOsdTask")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.updateOsdTask()
+	if err != nil {
+		log.Errorf("nodes(%s): failed to update node osd task(%v)", h.reqId, err)
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"update node osd task successfully",
+		nil,
 	)
 }

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
-	query "github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
+	nodes "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 )
 
 func (h *helper) parseParamsByHandler() error {
@@ -32,6 +33,10 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseRemoveOsdOptions()
 	case "patchNodeOsd":
 		return h.parsePatchOsdOptions()
+	case "patchDeviceTask":
+		return h.parsePatchDeviceTaskOptions()
+	case "patchOsdTask":
+		return h.parsePatchOsdTaskOptions()
 	default:
 		return fmt.Errorf(
 			"unknown node handler: %s",
@@ -83,13 +88,13 @@ func (h *helper) parseLicenseStatus() {
 
 func (h *helper) parsePage() error {
 	var err error
-	h.page, err = query.GetPage(h.c)
+	h.page, err = queries.GetPage(h.c)
 	return err
 }
 
 func (h *helper) parseWatch() error {
 	var err error
-	h.watch, err = query.GetWatch(h.c)
+	h.watch, err = queries.GetWatch(h.c)
 	if err != nil {
 		return err
 	}
@@ -139,6 +144,16 @@ func (h *helper) parseCreateDeviceOptions() error {
 		)
 	}
 
+	h.deviceReqOpts = nodes.DeviceReqOpts{
+		Device:   fmt.Sprintf("/dev/%s", h.deviceReqOpts.Device),
+		Hostname: h.node,
+		Status: status.BlockDevice{
+			Desired:      status.Added,
+			Current:      status.Adding,
+			IsProcessing: true,
+		},
+	}
+
 	return nil
 }
 
@@ -175,6 +190,10 @@ func (h *helper) parseRemoveDeviceOptions() error {
 		return fmt.Errorf("device name should be provided")
 	}
 
+	h.deviceReqOpts = nodes.DeviceReqOpts{}
+	h.deviceReqOpts.Hostname = h.node
+	h.deviceReqOpts.Device = fmt.Sprintf("/dev/%s", h.device)
+	h.deviceReqOpts.SetRemoving()
 	return nil
 }
 
@@ -221,6 +240,40 @@ func (h *helper) parsePatchOsdOptions() error {
 	if err != nil {
 		return fmt.Errorf(
 			"failed to parse patch osd options(%v)",
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (h *helper) parsePatchDeviceTaskOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	err := h.c.ShouldBindJSON(&h.deviceReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse patch device task options(%v)",
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (h *helper) parsePatchOsdTaskOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("node name should be provided")
+	}
+
+	err := h.c.ShouldBindJSON(&h.osdReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse patch osd task options(%v)",
 			err,
 		)
 	}

--- a/internal/apis/v1/handlers/nodes/req.go
+++ b/internal/apis/v1/handlers/nodes/req.go
@@ -7,9 +7,9 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 )
 
-func (h *helper) setDeviceCreateReq() nodes.DeviceReqOpts {
+func (h *helper) genDeviceCreateReq() nodes.DeviceReqOpts {
 	return nodes.DeviceReqOpts{
-		Device:   fmt.Sprintf("/dev/%s", h.device),
+		Device:   h.deviceReqOpts.Device,
 		Hostname: h.node,
 		Status: status.BlockDevice{
 			Desired:      status.Added,

--- a/internal/apis/v1/handlers/nodes/task.go
+++ b/internal/apis/v1/handlers/nodes/task.go
@@ -1,0 +1,29 @@
+package nodes
+
+import (
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func (h *helper) updateDeviceTask() error {
+	return h.mongo.DeleteOne(
+		nodes.Db,
+		nodes.ReqDeviceCollection,
+		bson.M{
+			"hostname": h.node,
+			"device":   h.device,
+		},
+	)
+}
+
+func (h *helper) updateOsdTask() error {
+	return h.mongo.DeleteOne(
+		nodes.Db,
+		nodes.ReqOsdCollection,
+		bson.M{
+			"hostname": h.node,
+			"device":   h.osdReqOpts.Device,
+			"id":       h.osdReqOpts.Id,
+		},
+	)
+}

--- a/internal/apis/v1/handlers/nodes/verify.go
+++ b/internal/apis/v1/handlers/nodes/verify.go
@@ -2,9 +2,11 @@ package nodes
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	log "go-micro.dev/v5/logger"
 )
@@ -46,34 +48,23 @@ func (h *helper) checkStatusConflict() error {
 	return nil
 }
 
-func (h *helper) validateCreationReq() error {
-	// if !nodes.IsExist(node) {
-	// 	return fmt.Errorf("node(%s) does not exist", h.node)
-	// }
+func (h *helper) validateDeviceReq() error {
+	if !nodes.IsExist(h.node) {
+		err := fmt.Errorf("node(%s) does not exist", h.node)
+		log.Errorf("nodes(%s): %v", h.reqId, err)
+		return err
+	}
 
-	// if !cubecos.HasDevice(h.node, h.createOpts.Device) {
-	// 	return fmt.Errorf(
-	// 		"device(%s) does not exist on node(%s)",
-	// 		h.createOpts.Device,
-	// 		h.node,
-	// 	)
-	// }
+	if !nodes.IsLocal(h.node) {
+		return nil
+	}
 
-	return nil
-}
+	_, err := os.Stat(h.deviceReqOpts.Device)
+	if err == nil {
+		return nil
+	}
 
-func (h *helper) validateRemovalReq() error {
-	// if !nodes.IsExist(node) {
-	// 	return fmt.Errorf("node(%s) does not exist", h.node)
-	// }
-
-	// if !cubecos.HasDevice(h.node, h.createOpts.Device) {
-	// 	return fmt.Errorf(
-	// 		"device(%s) does not exist on node(%s)",
-	// 		h.createOpts.Device,
-	// 		h.node,
-	// 	)
-	// }
-
-	return nil
+	err = fmt.Errorf("device file(%s) does not exist", h.deviceReqOpts.Device)
+	log.Errorf("nodes(%s): %v", h.reqId, err)
+	return err
 }

--- a/internal/definition/v1/nodes/device.go
+++ b/internal/definition/v1/nodes/device.go
@@ -17,6 +17,11 @@ type OsdReqOpts struct {
 	Status   status.Osd `json:"status"`
 }
 
+func (d *DeviceReqOpts) SetRemoving() {
+	d.Status.Desired = status.Removed
+	d.Status.IsProcessing = true
+}
+
 func (d *DeviceReqOpts) SetError() {
 	d.Status.Current = status.Error
 	d.Status.IsProcessing = false

--- a/internal/definition/v1/nodes/node.go
+++ b/internal/definition/v1/nodes/node.go
@@ -25,6 +25,7 @@ const (
 	CollectionIpmiSupport = "ipmiSupport"
 
 	ReqDeviceCollection = "deviceRequests"
+	ReqOsdCollection    = "osdRequests"
 )
 
 var (
@@ -109,6 +110,11 @@ func (n *Node) GenSearchableObject() Node {
 			},
 		},
 	}
+}
+
+func IsExist(hostname string) bool {
+	_, err := Get(hostname)
+	return err == nil
 }
 
 func IsLocal(hostname string) bool {

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -37,6 +37,7 @@ const (
 	Up        = "up"
 	Ng        = "ng"
 	Down      = "down"
+	Available = "available"
 	InUse     = "in-use"
 	System    = "system"
 

--- a/internal/operators/v1/nodes/device.go
+++ b/internal/operators/v1/nodes/device.go
@@ -34,10 +34,10 @@ func (o *Operator) handleDeviceExit(req nodes.DeviceReqOpts, err error) {
 		req.SetCompleted()
 	}
 
-	o.reportToController(req)
+	o.reportDeviceTaskToController(req)
 }
 
-func (o *Operator) reportToController(req nodes.DeviceReqOpts) {
+func (o *Operator) reportDeviceTaskToController(req nodes.DeviceReqOpts) {
 	node, err := nodes.GetController()
 	if err != nil {
 		log.Errorf("nodes: failed to get controller nodes(%v)", err)


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/210

<br/>

### What this PR does?

- Integrate the block device DELETE API with Hex SDK

- Using `force` deletion by default

- Set procedure for status transition

<br/>

### Test results (optional)

make sure the block device can be removed properly

1). execute the DELETE API to remove /dev/sdc

```bash
$ curl -k -X DELETE "https://10.32.45.10/api/v1/datacenters/control/nodes/cube451/devices/sdc" -H "Authorization: Bearer ${TOKEN}"

{"code":202,"msg":"the request of deleting node device is accepted and under processing","status":"accepted"}
```

<br/>

2). check the request has received and hex sdk is being triggered

```bash
2025-07-17T01:41:57.290+0800  INFO  req(bbf1ecd1): DELETE /api/v1/datacenters/control/nodes/cube451/devices/sdc (78.384697ms)
2025-07-17T01:42:29.441+0800  INFO  nodes: removed /dev/sdc successfully
2025-07-17T01:42:29.645+0800  INFO  req(4d4fc602): PATCH /api/v1/datacenters/control/nodes/cube451/devices/tasks (1.694779ms)
```

```bash
[cube451 ~]# ps aux | grep remove_disk
root     2068316  0.3  0.0  11052  7428 ?        S    01:41   0:00 /bin/bash /usr/sbin/hex_sdk ceph_osd_remove_disk /dev/sdc force
```

<br/>

3). check the block device status has been updated

<img width="1908" height="444" alt="Screenshot 2025-07-17 at 1 50 58 AM" src="https://github.com/user-attachments/assets/f65300d7-e0c5-409a-8802-8aa07e613c58" />

