### PR TITLE
Integrate the block device POST API with Hex SDK

### DIFF
--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	nodes "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
-	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 )
 
 func (h *helper) parseParamsByHandler() error {
@@ -143,17 +142,13 @@ func (h *helper) parseCreateDeviceOptions() error {
 			err,
 		)
 	}
-
-	h.deviceReqOpts = nodes.DeviceReqOpts{
-		Device:   fmt.Sprintf("/dev/%s", h.deviceReqOpts.Device),
-		Hostname: h.node,
-		Status: status.BlockDevice{
-			Desired:      status.Added,
-			Current:      status.Adding,
-			IsProcessing: true,
-		},
+	if h.deviceReqOpts.Device == "" {
+		return fmt.Errorf("device name should be provided")
 	}
 
+	h.deviceReqOpts.Hostname = h.node
+	h.deviceReqOpts.Device = fmt.Sprintf("/dev/%s", h.deviceReqOpts.Device)
+	h.deviceReqOpts.SetAdding()
 	return nil
 }
 

--- a/internal/cubecos/device.go
+++ b/internal/cubecos/device.go
@@ -12,7 +12,7 @@ func AddDevice(req nodes.DeviceReqOpts) error {
 	out, err := exec.Command("hex_sdk", "ceph_osd_add_disk_raw", req.Device).CombinedOutput()
 	if err != nil {
 		log.Errorf(
-			"hexSdk: failed to add device cmd %s(%v %s)",
+			"hexSdk: failed to execute device adding cmd %s(%v %s)",
 			req.Device, err, string(out),
 		)
 		return err

--- a/internal/definition/v1/nodes/device.go
+++ b/internal/definition/v1/nodes/device.go
@@ -17,6 +17,11 @@ type OsdReqOpts struct {
 	Status   status.Osd `json:"status"`
 }
 
+func (d *DeviceReqOpts) SetAdding() {
+	d.Status.Desired = status.Added
+	d.Status.IsProcessing = true
+}
+
 func (d *DeviceReqOpts) SetRemoving() {
 	d.Status.Desired = status.Removed
 	d.Status.IsProcessing = true


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/209

<br/>

### What this PR does?

- Integrate the block device POST API with Hex SDK

- Using `raw` type by default

- Set procedure for status transition

<br/>

### Test results (optional)

make sure the block device can be removed properly

1). execute the POST API to add /dev/sdc

```bash
$ curl -k -X POST "https://10.32.45.10/api/v1/datacenters/control/nodes/cube451/devices" -H "Authorization: Bearer ${TOKEN}" -d '{"device": "sdc"}'

{"code":202,"msg":"the request of creating node device is accepted and under processing","status":"accepted"}
```

<br/>

2). check the request has received and hex sdk is being triggered

```bash
Jul 17 02:33:28 cube451 cube-cos-api[2838832]: 2025-07-17T02:33:28.177+0800  INFO  req(cc3ed1c9): POST /api/v1/datacenters/control/nodes/cube451/devices (23.294051ms)
Jul 17 02:33:29 cube451 hex_config[2863468]: Acquring lock: /var/run/hex_config.commit.lock
Jul 17 02:33:29 cube451 hex_config[2863468]: Acqured lock: /var/run/hex_config.commit.lock
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.setting.receiver.emails.0.address" = "hello@bigstack.co" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.setting.receiver.emails.0.note" = "" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.setting.receiver.slacks.0.description" = "Internal" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.resp.0.description" = "" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.resp.1.description" = "" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.setting.receiver.emails.0.address" = "hello@bigstack.co" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.setting.receiver.emails.0.note" = "" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.setting.receiver.slacks.0.description" = "Internal" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.resp.0.description" = "" ignored
Jul 17 02:33:29 cube451 hex_config[2863468]: Warning: Unknown settings name "kapacitor.alert.resp.1.description" = "" ignored
Jul 17 02:33:30 cube451 ovs-vsctl[2864020]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:31 cube451 cube-cos-api[2838832]: 2025-07-17T02:33:31.285+0800  INFO  req(6d7110e0): GET /api/v1/datacenters/control/nodes/cube451 (141.297995ms)
Jul 17 02:33:31 cube451 ovs-vsctl[2864592]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:33 cube451 ovs-vsctl[2865107]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:34 cube451 ovs-vsctl[2865663]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:35 cube451 ovs-vsctl[2866388]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:37 cube451 ovs-vsctl[2866964]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:38 cube451 ovs-vsctl[2867592]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:40 cube451 ovs-vsctl[2868096]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:41 cube451 ovs-vsctl[2869190]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:42 cube451 ovs-vsctl[2869929]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:44 cube451 ovs-vsctl[2870400]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:45 cube451 ovs-vsctl[2870972]: ovs|00001|db_ctl_base|ERR|no port named provider
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)     master: true(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)       ctrl: cube451(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)    ctrl ip: 10.32.45.1(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)  shared id: 10.32.45.10(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)   external: 10.32.45.10(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)       mgmt: eth0(x), provider(v), 10.32.45.1(v), 10.32.0.0/16(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)   provider: eth0(x), eth0(v), dc(dc), dc(dc)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)    overlay: eth0(x), provider(v), 10.32.45.1(v), 10.32.0.0/16(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)      str-f: eth0(x), provider(v), 10.32.45.1(v), 10.32.0.0/16(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: (new)      str-b: eth0(x), provider(v), 10.32.45.1(v), 10.32.0.0/16(v)
Jul 17 02:33:45 cube451 hex_config[2863468]: Released lock: /var/run/hex_config.commit.lock
Jul 17 02:33:46 cube451 hex_config[2863468]: Executing: /usr/sbin/hex_sdk ceph_osd_prepare_bluestore /dev/sdc 2 819200 scsi
Jul 17 02:33:53 cube451 hex_config[2871330]: 100+0 records in
Jul 17 02:33:53 cube451 hex_config[2871330]: 100+0 records out
Jul 17 02:33:53 cube451 hex_config[2871330]: 104857600 bytes (105 MB, 100 MiB) copied, 1.06621 s, 98.3 MB/s
Jul 17 02:33:56 cube451 hex_config[2871330]: 100+0 records in
Jul 17 02:33:56 cube451 hex_config[2871330]: 100+0 records out
Jul 17 02:33:56 cube451 hex_config[2871330]: 104857600 bytes (105 MB, 100 MiB) copied, 1.13033 s, 92.8 MB/s
Jul 17 02:33:57 cube451 cube-cos-api[2838832]: 2025-07-17T02:33:57.506+0800  INFO  req(bd00b00b): GET /api/v1/datacenters/control/nodes/cube451 (137.07579ms)
Jul 17 02:33:59 cube451 hex_config[2871330]: 100+0 records in
Jul 17 02:33:59 cube451 hex_config[2871330]: 100+0 records out
Jul 17 02:33:59 cube451 hex_config[2871330]: 104857600 bytes (105 MB, 100 MiB) copied, 1.0836 s, 96.8 MB/s
Jul 17 02:34:00 cube451 hex_config[2875178]: Checking license App(def) File()
Jul 17 02:34:00 cube451 hex_config[2875178]: License (type: trial) is still valid for 169 days
Jul 17 02:34:00 cube451 hex_config[2875178]: Command license_check def exited with status: 1
Jul 17 02:34:01 cube451 hex_config[2871330]: 100+0 records in
Jul 17 02:34:01 cube451 hex_config[2871330]: 100+0 records out
Jul 17 02:34:01 cube451 hex_config[2871330]: 104857600 bytes (105 MB, 100 MiB) copied, 1.352 s, 77.6 MB/s
Jul 17 02:34:01 cube451 hex_config[2863468]: Executing: /usr/sbin/hex_sdk ceph_osd_relabel
Jul 17 02:34:06 cube451 hex_config[2863468]: Executing: mount /dev/sda1 /var/lib/ceph/osd/ceph-0
Jul 17 02:34:06 cube451 hex_config[2877815]: mount: /var/lib/ceph/osd/ceph-0: /dev/sda1 already mounted on /var/lib/ceph/osd/ceph-0.
Jul 17 02:34:08 cube451 hex_config[2863468]: Executing: mount /dev/sda2 /var/lib/ceph/osd/ceph-1
Jul 17 02:34:08 cube451 hex_config[2879916]: mount: /var/lib/ceph/osd/ceph-1: /dev/sda2 already mounted on /var/lib/ceph/osd/ceph-1.
Jul 17 02:34:12 cube451 cube-cos-api[2838832]: 2025-07-17T02:34:12.304+0800  INFO  req(d471c52b): GET /api/v1/datacenters/control/metrics/cpuUsage/summary/hosts/cube451 (1.001318048s)
Jul 17 02:34:12 cube451 cube-cos-api[2838832]: 2025-07-17T02:34:12.305+0800  INFO  req(1645caf2): GET /api/v1/datacenters/control/metrics/memoryUsage/summary/hosts/cube451 (286.65µs)
Jul 17 02:34:12 cube451 cube-cos-api[2838832]: 2025-07-17T02:34:12.447+0800  INFO  req(ef0fc2a6): GET /api/v1/datacenters/control/metrics/cpuUsage/summary/hosts/cube451 (1.001710133s)
Jul 17 02:34:12 cube451 cube-cos-api[2838832]: 2025-07-17T02:34:12.448+0800  INFO  req(a6d1bc83): GET /api/v1/datacenters/control/metrics/memoryUsage/summary/hosts/cube451 (273.923µs)
Jul 17 02:34:15 cube451 hex_config[2863468]: Executing: ceph-osd -i 2 --mkfs --osd-uuid eb7f9659-b850-4fdd-a1fb-d31d22b9d024 >/dev/null 2>&1
Jul 17 02:34:25 cube451 hex_config[2863468]: Executing: ceph-osd -i 3 --mkfs --osd-uuid 8a5db06e-2796-4681-9913-80f41ad7b526 >/dev/null 2>&1
Jul 17 02:34:25 cube451 cube-cos-api[2838832]: 2025-07-17T02:34:25.571+0800  INFO  req(0177f853): GET /api/v1/datacenters/control/nodes/cube451 (138.16548ms)
Jul 17 02:34:30 cube451 hex_config[2863468]: Executing: /usr/sbin/hex_sdk ceph_osd_create_map
Jul 17 02:34:34 cube451 hex_config[2890656]: /dev/sda3
Jul 17 02:34:34 cube451 hex_config[2890656]: /dev/sda4
Jul 17 02:34:34 cube451 hex_config[2890656]: /dev/sdc3
Jul 17 02:34:34 cube451 hex_config[2890656]: /dev/sdc4
Jul 17 02:34:34 cube451 hex_config[2863468]: Executing: /usr/sbin/hex_sdk ceph_osd_remount
Jul 17 02:34:49 cube451 cube-cos-api[2838832]: 2025-07-17T02:34:49.086+0800  INFO  req(1fe495b6): GET /api/v1/datacenters/control/nodes/cube451 (143.246707ms)
Jul 17 02:34:50 cube451 hex_config[2896328]: Checking license App(def) File()
Jul 17 02:34:50 cube451 hex_config[2896328]: License (type: trial) is still valid for 169 days
Jul 17 02:34:50 cube451 hex_config[2896328]: Command license_check def exited with status: 1
Jul 17 02:35:00 cube451 hex_config[2863468]: Executing: /usr/sbin/hex_sdk ceph_osd_restart 2
Jul 17 02:35:03 cube451 hex_config[2863468]: Executing: /usr/sbin/hex_sdk ceph_osd_restart 3
Jul 17 02:35:04 cube451 hex_config[2863468]: ceph-osd is running
Jul 17 02:35:04 cube451 hex_config[2863468]: Command refresh_ceph_osd exited with status: 0
Jul 17 02:35:06 cube451 cube-cos-api[2838832]: 2025-07-17T02:35:06.465+0800  INFO  nodes: added /dev/sdc successfully
Jul 17 02:35:06 cube451 cube-cos-api[2838832]: 2025-07-17T02:35:06.669+0800  INFO  req(d2da842a): PATCH /api/v1/datacenters/control/nodes/cube451/devices/tasks (1.837292ms)
```

```bash
[cube451 ~]# ps aux | grep add_disk
root     2862724  0.2  0.0  11056  7444 ?        S    02:33   0:00 /bin/bash /usr/sbin/hex_sdk ceph_osd_add_disk_raw /dev/sdc
```

<br/>

3). check the block device status has been updated

<img width="1908" height="774" alt="Screenshot 2025-07-17 at 2 37 30 AM" src="https://github.com/user-attachments/assets/189a12e2-ff9a-4f18-aadc-ed983a84af72" />

