### PR TITLE
Integrate the block device PATCH(promote/demote) api with hex sdk

### DIFF
--- a/internal/apis/v1/handlers/nodes/delegation.go
+++ b/internal/apis/v1/handlers/nodes/delegation.go
@@ -17,7 +17,7 @@ func (h *helper) delegateDeviceReq() error {
 		return nil
 	}
 
-	return h.createDeviceOnPeerNode()
+	return h.operateDeviceOnPeerNode()
 }
 
 func (h *helper) delegateToLocal() {
@@ -25,7 +25,7 @@ func (h *helper) delegateToLocal() {
 	devReqQueue.Add(h.deviceReqOpts)
 }
 
-func (h *helper) createDeviceOnPeerNode() error {
+func (h *helper) operateDeviceOnPeerNode() error {
 	node, err := nodes.Get(h.node)
 	if err != nil {
 		log.Errorf("nodes(%s): failed to get node(%s) for device request(%v)", h.reqId, h.node, err)
@@ -36,7 +36,11 @@ func (h *helper) createDeviceOnPeerNode() error {
 	resp, err := http.R().
 		SetHeaders(nodes.GetSecretHeaders()).
 		SetBody(h.deviceReqOpts).
-		Post(node.CreateDeviceUrl())
+		Execute(
+			h.getMethodByHandler(),
+			h.getDeviceUrlByHandler(node),
+		)
+
 	if err != nil {
 		log.Errorf("nodes(%s): failed to send device creation to %s(%v)", h.reqId, node.Hostname, err)
 		return err
@@ -51,4 +55,30 @@ func (h *helper) createDeviceOnPeerNode() error {
 	}
 
 	return nil
+}
+
+func (h *helper) getMethodByHandler() string {
+	switch h.handler {
+	case "addNodeDevice":
+		return "POST"
+	case "updateNodeDevice":
+		return "PATCH"
+	case "removeNodeDevice":
+		return "DELETE"
+	default:
+		return "GET"
+	}
+}
+
+func (h *helper) getDeviceUrlByHandler(node *nodes.Node) string {
+	switch h.handler {
+	case "addNodeDevice":
+		return node.AddDeviceUrl()
+	case "updateNodeDevice":
+		return node.UpdateDeviceUrl(h.deviceReqOpts.Device)
+	case "removeNodeDevice":
+		return node.RemoveDeviceUrl(h.deviceReqOpts.Device)
+	default:
+		return node.GetDeviceUrl(h.deviceReqOpts.Device)
+	}
 }

--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -70,7 +70,7 @@ var (
 			Version: apis.V1,
 			Method:  http.MethodPatch,
 			Path:    "/nodes/:nodeName/devices/:device",
-			Func:    promoteOrDemoteNodeDevice,
+			Func:    updateNodeDevice,
 		},
 		{
 			Version: apis.V1,
@@ -352,10 +352,16 @@ func removeNodeDevice(c *gin.Context) {
 	)
 }
 
-func promoteOrDemoteNodeDevice(c *gin.Context) {
-	h, err := initHelper(c, "promoteOrDemoteNodeDevice")
+func updateNodeDevice(c *gin.Context) {
+	h, err := initHelper(c, "updateNodeDevice")
 	if err != nil {
 		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.validateDeviceReq()
+	if err != nil {
 		bodies.SetBadRequest(c, err)
 		return
 	}

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -22,7 +22,7 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseListDevicesOptions()
 	case "addNodeDevice":
 		return h.parseCreateDeviceOptions()
-	case "promoteOrDemoteNodeDevice":
+	case "updateNodeDevice":
 		return h.parsePromoteOrDemoteOptions()
 	case "removeNodeDevice":
 		return h.parseRemoveDeviceOptions()
@@ -171,6 +171,9 @@ func (h *helper) parsePromoteOrDemoteOptions() error {
 		)
 	}
 
+	h.deviceReqOpts.Hostname = h.node
+	h.deviceReqOpts.Device = fmt.Sprintf("/dev/%s", h.device)
+	h.deviceReqOpts.SetUpdating()
 	return nil
 }
 

--- a/internal/cubecos/device.go
+++ b/internal/cubecos/device.go
@@ -3,6 +3,7 @@ package cubecos
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	log "go-micro.dev/v5/logger"
@@ -21,6 +22,31 @@ func AddDevice(req nodes.DeviceReqOpts) error {
 	if !IsHexSdkSuccess(err) {
 		return fmt.Errorf(
 			"failed to add device %s(%v %s)",
+			req.Device, err, string(out),
+		)
+	}
+
+	return nil
+}
+
+func UpdateDevice(req nodes.DeviceReqOpts) error {
+	promoteOrDemote := "ceph_osd_promote_disk"
+	if strings.EqualFold(req.Class, "hdd") {
+		promoteOrDemote = "ceph_osd_demote_disk"
+	}
+
+	out, err := exec.Command("hex_sdk", promoteOrDemote, req.Device).CombinedOutput()
+	if err != nil {
+		log.Errorf(
+			"hexSdk: failed to execute device update cmd %s(%v %s)",
+			req.Device, err, string(out),
+		)
+		return err
+	}
+
+	if !IsHexSdkSuccess(err) {
+		return fmt.Errorf(
+			"failed to update device %s(%v %s)",
 			req.Device, err, string(out),
 		)
 	}

--- a/internal/definition/v1/nodes/device.go
+++ b/internal/definition/v1/nodes/device.go
@@ -22,6 +22,11 @@ func (d *DeviceReqOpts) SetAdding() {
 	d.Status.IsProcessing = true
 }
 
+func (d *DeviceReqOpts) SetUpdating() {
+	d.Status.Desired = status.Updated
+	d.Status.IsProcessing = true
+}
+
 func (d *DeviceReqOpts) SetRemoving() {
 	d.Status.Desired = status.Removed
 	d.Status.IsProcessing = true

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -149,11 +149,35 @@ func (n *Node) ListDevicesUrl() string {
 	return u.String()
 }
 
-func (n *Node) CreateDeviceUrl() string {
+func (n *Node) GetDeviceUrl(device string) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/devices/%s", base.DataCenterName, n.Hostname, device)
+	return u.String()
+}
+
+func (n *Node) AddDeviceUrl() string {
 	u := url.URL{}
 	u.Scheme = n.Protocol
 	u.Host = n.Address
 	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/devices", base.DataCenterName, n.Hostname)
+	return u.String()
+}
+
+func (n *Node) UpdateDeviceUrl(device string) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/devices/%s", base.DataCenterName, n.Hostname, device)
+	return u.String()
+}
+
+func (n *Node) RemoveDeviceUrl(device string) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/devices/%s", base.DataCenterName, n.Hostname, device)
 	return u.String()
 }
 

--- a/internal/operators/v1/nodes/device.go
+++ b/internal/operators/v1/nodes/device.go
@@ -14,6 +14,8 @@ func (o *Operator) operateDevice(req nodes.DeviceReqOpts) error {
 	switch req.Status.Desired {
 	case status.Added:
 		return cubecos.AddDevice(req)
+	case status.Updated:
+		return cubecos.UpdateDevice(req)
 	case status.Removed:
 		return cubecos.RemoveDevice(req)
 	}


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/211

<br/>

### What this PR does?

- Integrate the block device PATCH(promote/demote) API with Hex SDK

- Set procedure for status transition

<br/>

### Test results (optional)

make sure the block device can be removed properly

1). execute the PATCH API to add /dev/sdc

```bash
curl -k -X PATCH "https://10.32.45.10/api/v1/datacenters/control/nodes/cube451/devices/sdc" -H "Authorization: Bearer ${TOKEN}" -d '{"class": "hdd"}'

{"code":202,"msg":"the request of promoting or demoting node device is accepted and under processing","status":"accepted"}
```

<br/>

2). check the request has been received and hex sdk is being triggered

```bash
Jul 17 03:37:00 cube451 cube-cos-api[3378626]: 2025-07-17T03:37:00.363+0800  INFO  req(0e7b1ffc): PATCH /api/v1/datacenters/control/nodes/cube451/devices/sdc (24.765668ms)
Jul 17 03:37:03 cube451 cube-cos-api[3378626]: 2025-07-17T03:37:03.257+0800  INFO  nodes: updated /dev/sdc successfully
Jul 17 03:37:03 cube451 cube-cos-api[3378626]: 2025-07-17T03:37:03.461+0800  INFO  req(e5d83601): PATCH /api/v1/datacenters/control/nodes/cube451/devices/tasks (1.642652ms)
```

```bash
[cube451 ~]# ps aux | grep demote
root     3886818  3.0  0.0  11056  7408 ?        S    03:38   0:00 /bin/bash /usr/sbin/hex_sdk ceph_osd_demote_disk /dev/sdc
```

also check on the failure case of device promotion when the ceph health is not okay

```bash
Jul 17 03:36:26 cube451 cube-cos-api[3378626]: 2025-07-17T03:36:26.891+0800  INFO  req(b1c42f9b): PATCH /api/v1/datacenters/control/nodes/cube451/devices/sdc (20.411866ms)
Jul 17 03:36:30 cube451 cube-cos-api[3378626]: 2025-07-17T03:36:30.501+0800  ERRO  hexSdk: failed to execute device update cmd /dev/sdc(exit status 1 hex_sdk: Error: ceph health has to be OK to proceed disk promotion
```
