### PR TITLE
Integrate the node osd patch(reweight) api with hex sdk

### DIFF
--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -424,6 +424,17 @@ func patchNodeOsd(c *gin.Context) {
 		return
 	}
 
+	err = h.validateOsdReq()
+	if err != nil {
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.delegateOsdReq()
+	if err != nil {
+		return
+	}
+
 	bodies.SetAccepted(
 		c,
 		"the request of patching node osd is accepted and under processing",

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -253,6 +253,16 @@ func (h *helper) parsePatchOsdOptions() error {
 		)
 	}
 
+	device, err := ceph.GetDeviceByOsdId(h.node, h.osdId)
+	if err != nil {
+		return fmt.Errorf("failed to get device by osd id(%s): %v", h.osdId, err)
+	}
+
+	h.osdReqOpts.Hostname = h.node
+	h.osdReqOpts.Device = fmt.Sprintf("/dev/%s", device.Dev)
+	h.osdReqOpts.Hostname = h.node
+	h.osdReqOpts.Id = h.osdId
+	h.osdReqOpts.SetRewighting()
 	return nil
 }
 

--- a/internal/cubecos/osd.go
+++ b/internal/cubecos/osd.go
@@ -51,9 +51,8 @@ func RemoveOsd(req nodes.OsdReqOpts) error {
 }
 
 func ReweightOsd(req nodes.OsdReqOpts) error {
-	id := fmt.Sprintf("osd.%s", req.Id)
-	reweight := fmt.Sprintf("%f", req.Reweight)
-	out, err := exec.Command("ceph", "osd", "crush", "reweight", id, reweight).CombinedOutput()
+	value := fmt.Sprintf("%f", req.Reweight)
+	out, err := exec.Command("ceph", "osd", "crush", "reweight", req.Id, value).CombinedOutput()
 	if err != nil {
 		log.Errorf(
 			"hexSdk: failed to execute osd reweight cmd %s(%v %s)",


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/214

<br/>

### What this PR does?

- Integrate the node osd patch(reweight) api with hex sdk

- Set procedure for status transition

<br/>

### Test results (optional)

1). execute the PATCH(reweight) API to reweight osd.2

```bash
$ curl -k -X PATCH "https://10.32.45.10/api/v1/datacenters/control/nodes/cube451/osds/osd.2" -H "Authorization: Bearer ${TOKEN}" -d '{"reweight": 0.85}'

{"code":202,"msg":"the request of patching node osd is accepted and under processing","status":"accepted"}
```

<br/>

2). check the request has been received and ceph reweight is being triggered

```bash
Jul 17 04:39:32 cube451 cube-cos-api[623728]: 2025-07-17T04:39:32.976+0800  INFO  req(bd242d08): PATCH /api/v1/datacenters/control/nodes/cube451/osds/osd.2 (3.267874769s)
Jul 17 04:39:34 cube451 cube-cos-api[623728]: 2025-07-17T04:39:34.003+0800  INFO  nodes: reweighted osd.2 successfully
Jul 17 04:39:34 cube451 cube-cos-api[623728]: 2025-07-17T04:39:34.212+0800  INFO  req(38a97ff1): PATCH /api/v1/datacenters/control/nodes/cube451/osds/tasks (5.839427ms)
```

