### PR TITLE
Integrate the node osd delete(remove) api with hex sdk

### DIFF
--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -318,6 +318,7 @@ func addNodeDevice(c *gin.Context) {
 
 	err = h.delegateDeviceReq()
 	if err != nil {
+		bodies.SetInternalServerError(c, err)
 		return
 	}
 
@@ -343,6 +344,7 @@ func removeNodeDevice(c *gin.Context) {
 
 	err = h.delegateDeviceReq()
 	if err != nil {
+		bodies.SetInternalServerError(c, err)
 		return
 	}
 
@@ -368,6 +370,7 @@ func updateNodeDevice(c *gin.Context) {
 
 	err = h.delegateDeviceReq()
 	if err != nil {
+		bodies.SetInternalServerError(c, err)
 		return
 	}
 
@@ -393,6 +396,7 @@ func restartNodeOsd(c *gin.Context) {
 
 	err = h.delegateOsdReq()
 	if err != nil {
+		bodies.SetInternalServerError(c, err)
 		return
 	}
 
@@ -407,6 +411,18 @@ func removeNodeOsd(c *gin.Context) {
 	if err != nil {
 		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.validateOsdReq()
+	if err != nil {
+		bodies.SetBadRequest(c, err)
+		return
+	}
+
+	err = h.delegateOsdReq()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
 		return
 	}
 
@@ -432,6 +448,7 @@ func patchNodeOsd(c *gin.Context) {
 
 	err = h.delegateOsdReq()
 	if err != nil {
+		bodies.SetInternalServerError(c, err)
 		return
 	}
 

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -231,6 +231,16 @@ func (h *helper) parseRemoveOsdOptions() error {
 		return fmt.Errorf("osd id should be provided")
 	}
 
+	device, err := ceph.GetDeviceByOsdId(h.node, h.osdId)
+	if err != nil {
+		return fmt.Errorf("failed to get device by osd id(%s): %v", h.osdId, err)
+	}
+
+	h.osdReqOpts = nodes.OsdReqOpts{}
+	h.osdReqOpts.Device = fmt.Sprintf("/dev/%s", device.Dev)
+	h.osdReqOpts.Hostname = h.node
+	h.osdReqOpts.Id = h.osdId
+	h.osdReqOpts.SetRemoving()
 	return nil
 }
 

--- a/internal/cubecos/osd.go
+++ b/internal/cubecos/osd.go
@@ -31,7 +31,7 @@ func RestartOsd(req nodes.OsdReqOpts) error {
 }
 
 func RemoveOsd(req nodes.OsdReqOpts) error {
-	out, err := exec.Command("hex_sdk", "ceph_osd_remove", req.Id).CombinedOutput()
+	out, err := exec.Command("hex_sdk", "ceph_osd_remove", req.Id, "force").CombinedOutput()
 	if err != nil {
 		log.Errorf(
 			"hexSdk: failed to remove osd cmd %s(%v %s)",


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/212

<br/>

### What this PR does?

- Integrate the node osd delete(remove) api with hex sdk

- Set procedure for status transition

<br/>

### Test results (optional)

1). execute the DELETE(remove) API to remove osd.2

```bash
$ curl -k -X DELETE "https://10.32.45.10/api/v1/datacenters/control/nodes/cube451/osds/osd.2" -H "Authorization: Bearer ${TOKEN}"

{"code":202,"msg":"the request of removing node osd is accepted and under processing","status":"accepted"}
```

<br/>

2). check the request has been received and hex sdk is being triggered

success case

```bash
Jul 17 05:20:54 cube451 cube-cos-api[1239213]: 2025-07-17T05:20:54.890+0800  INFO  req(262ec383): DELETE /api/v1/datacenters/control/nodes/cube451/osds/osd.2 (3.316745152s)
Jul 17 05:21:07 cube451 cube-cos-api[1239213]: 2025-07-17T05:21:07.129+0800  INFO  nodes: removed osd.2 successfully
Jul 17 05:21:07 cube451 cube-cos-api[1239213]: 2025-07-17T05:21:07.338+0800  INFO  req(2ec9733c): PATCH /api/v1/datacenters/control/nodes/cube451/osds/tasks (6.115971ms)
```

<br/>

failure case

```bash
Jul 17 04:57:53 cube451 cube-cos-api[911335]: 2025-07-17T04:57:53.279+0800  INFO  req(5fdc250f): DELETE /api/v1/datacenters/control/nodes/cube451/osds/osd.2 (3.308595161s)
Jul 17 05:08:42 cube451 cube-cos-api[911335]: 2025-07-17T05:08:42.587+0800  ERRO  hexSdk: failed to remove osd cmd osd.2(exit status 1 ID  CLASS  WEIGHT  REWEIGHT  SIZE     RAW USE  DATA    OMAP     META     AVAIL    %USE   VAR   PGS  STATUS
Jul 17 05:08:42 cube451 cube-cos-api[911335]:  2    hdd       0   1.00000  279 GiB   42 GiB  41 GiB  974 KiB  281 MiB  237 GiB  14.91  1.00  138      up
Jul 17 05:08:42 cube451 cube-cos-api[911335]:                       TOTAL  279 GiB   42 GiB  41 GiB  975 KiB  281 MiB  237 GiB  14.91
Jul 17 05:08:42 cube451 cube-cos-api[911335]: MIN/MAX VAR: 1.00/1.00  STDDEV: 0
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 138 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 137 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 136 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 134 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 131 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 127 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 126 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 123 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 119 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: OSD(s) 2 have 117 pgs currently mapped to them.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: Restored : osd.2 as pgs could not be moved likely due to too few disks or little space in the failure domain.
Jul 17 05:08:42 cube451 cube-cos-api[911335]: )
Jul 17 05:08:42 cube451 cube-cos-api[911335]: 2025-07-17T05:08:42.587+0800  ERRO  nodes: failed to removed osd.2(exit status 1)
Jul 17 05:08:42 cube451 cube-cos-api[911335]: 2025-07-17T05:08:42.796+0800  INFO  req(01cd8b81): PATCH /api/v1/datacenters/control/nodes/cube451/osds/tasks (6.043851ms)
```

```bash
[cube451 ~]# ps aux | grep ceph_osd_remove
root      936224  0.0  0.0  11056  7412 ?        S    04:57   0:00 /bin/bash /usr/sbin/hex_sdk ceph_osd_remove osd.2
```
