### PR TITLE
Fix GET /notifications's incorrect default stop time 

### DIFF
--- a/internal/apis/v1/queries/time.go
+++ b/internal/apis/v1/queries/time.go
@@ -16,13 +16,15 @@ func GetPeriod(c *gin.Context) (*time.Period, error) {
 		return nil, fmt.Errorf("'past' and 'start'/'stop' cannot be used together")
 	}
 
-	timeStart := c.DefaultQuery("start", time.RFC3339(-24*ostime.Hour))
+	defaultStart := time.LocalRFC3339AddDuration(ostime.Now().Local(), -24*ostime.Hour)
+	timeStart := c.DefaultQuery("start", defaultStart)
 	_, err := ostime.Parse(time.FormatRFC3339, timeStart)
 	if err != nil {
 		return nil, fmt.Errorf("'start' time format should be aligned with RFC3339: %s", timeStart)
 	}
 
-	timeStop := c.DefaultQuery("stop", time.NowRFC3339())
+	defaultStop := time.LocalRFC3339(ostime.Now())
+	timeStop := c.DefaultQuery("stop", defaultStop)
 	_, err = ostime.Parse(time.FormatRFC3339, timeStop)
 	if err != nil {
 		return nil, fmt.Errorf("'stop' time format should be aligned with RFC3339: %s", timeStop)


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

Non

<br/>

### What this PR does?

- Fix GET /notifications's incorrect default stop time 

<br/>

### Test results (optional)

1). make sure the fixed part works well

<img width="969" height="730" alt="Screenshot 2025-07-28 at 2 48 08 PM" src="https://github.com/user-attachments/assets/94d223f7-9c3f-475f-acbd-f859787d0fb3" />
