### PR TITLE
Enhance the status transition experience during adding disk and osd

### DIFF
--- a/internal/cubecos/device.go
+++ b/internal/cubecos/device.go
@@ -5,8 +5,11 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/blockdevice"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/ceph"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -27,7 +30,7 @@ func AddDevice(req nodes.DeviceReqOpts) error {
 		)
 	}
 
-	return nil
+	return waitDeviceToBeAdded(req)
 }
 
 func PromoteOrDemoteDevice(req nodes.DeviceReqOpts) error {
@@ -73,4 +76,54 @@ func RemoveDevice(req nodes.DeviceReqOpts) error {
 	}
 
 	return nil
+}
+
+func GetOsdsByHostDevice(req nodes.DeviceReqOpts) ([]ceph.Osd, error) {
+	deviceMap, err := ceph.GetDeviceMapByHost(req.Hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	dev := blockdevice.WithDevPath(req.Device)
+	device, found := deviceMap[dev]
+	if !found {
+		return nil, fmt.Errorf(
+			"device %s not found on host %s",
+			req.Device, req.Hostname,
+		)
+	}
+	if len(device.Osds) == 0 {
+		return nil, fmt.Errorf(
+			"device %s has no OSDs on host %s",
+			req.Device, req.Hostname,
+		)
+	}
+
+	return device.Osds, nil
+}
+
+func waitDeviceToBeAdded(req nodes.DeviceReqOpts) error {
+	for range 120 {
+		wait.Seconds(1)
+
+		osds, err := GetOsdsByHostDevice(req)
+		if err != nil {
+			continue
+		}
+
+		if len(osds) <= 0 {
+			continue
+		}
+
+		err = WaitOsdsStatus(osds, status.Up, 2)
+		if err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"failed to wait device %s to be added on the %s after 120 seconds",
+		req.Device,
+		req.Hostname,
+	)
 }

--- a/internal/cubecos/device.go
+++ b/internal/cubecos/device.go
@@ -30,7 +30,7 @@ func AddDevice(req nodes.DeviceReqOpts) error {
 		)
 	}
 
-	return waitDeviceToBeAdded(req)
+	return WaitDeviceToBeAdded(req, 180)
 }
 
 func PromoteOrDemoteDevice(req nodes.DeviceReqOpts) error {
@@ -102,8 +102,8 @@ func GetOsdsByHostDevice(req nodes.DeviceReqOpts) ([]ceph.Osd, error) {
 	return device.Osds, nil
 }
 
-func waitDeviceToBeAdded(req nodes.DeviceReqOpts) error {
-	for range 120 {
+func WaitDeviceToBeAdded(req nodes.DeviceReqOpts, timeout int) error {
+	for range timeout {
 		wait.Seconds(1)
 
 		osds, err := GetOsdsByHostDevice(req)

--- a/internal/cubecos/device.go
+++ b/internal/cubecos/device.go
@@ -79,13 +79,13 @@ func RemoveDevice(req nodes.DeviceReqOpts) error {
 }
 
 func GetOsdsByHostDevice(req nodes.DeviceReqOpts) ([]ceph.Osd, error) {
-	deviceMap, err := ceph.GetDeviceMapByHost(req.Hostname)
+	devMap, err := ceph.GetDeviceMapByHost(req.Hostname)
 	if err != nil {
 		return nil, err
 	}
 
-	dev := blockdevice.WithDevPath(req.Device)
-	device, found := deviceMap[dev]
+	dev := blockdevice.WithoutDevPath(req.Device)
+	device, found := devMap[dev]
 	if !found {
 		return nil, fmt.Errorf(
 			"device %s not found on host %s",

--- a/internal/cubecos/osd.go
+++ b/internal/cubecos/osd.go
@@ -52,6 +52,17 @@ func WaitOsdStatus(id, status string, timeout int) error {
 	)
 }
 
+func WaitOsdsStatus(osds []ceph.Osd, status string, timeout int) error {
+	for _, osd := range osds {
+		err := WaitOsdStatus(osd.Id, status, timeout)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func RestartOsd(req nodes.OsdReqOpts) error {
 	service := fmt.Sprintf("ceph-osd@%s", strings.TrimPrefix(req.OsdId, "osd."))
 	out, err := exec.Command("systemctl", "restart", service).CombinedOutput()

--- a/internal/definition/v1/blockdevice/blockdevice.go
+++ b/internal/definition/v1/blockdevice/blockdevice.go
@@ -17,3 +17,15 @@ type SmartCtl struct {
 func WithDevPath(name string) string {
 	return fmt.Sprintf("/dev/%s", name)
 }
+
+func WithoutDevPath(name string) string {
+	if len(name) < 5 {
+		return name
+	}
+
+	if name[:5] == "/dev/" {
+		return name[5:]
+	}
+
+	return name
+}

--- a/internal/definition/v1/ceph/device.go
+++ b/internal/definition/v1/ceph/device.go
@@ -150,33 +150,6 @@ func GetDeviceByOsdId(host, id string) (*Device, error) {
 	)
 }
 
-func ListOsdsByHostDevice(host, device string) ([]Osd, error) {
-	out, err := exec.Command("ceph", "osd", "ls-by-device", device, "-f", "json").CombinedOutput()
-	if err != nil {
-		log.Errorf("ceph: failed to list osds by device %s(%v)", device, err)
-		return nil, err
-	}
-
-	rawOsds := []RawOsd{}
-	err = json.Unmarshal(out, &rawOsds)
-	if err != nil {
-		log.Errorf("ceph: failed to unmarshal osds by device %s(%v)", device, err)
-		return nil, err
-	}
-
-	if len(rawOsds) == 0 {
-		log.Errorf("ceph: no osds found for device %s on host %s", device, host)
-		return nil, nil
-	}
-
-	osds := []Osd{}
-	for _, raw := range rawOsds[0].Nodes {
-		osds = append(osds, convertToOsd(raw))
-	}
-
-	return osds, nil
-}
-
 func convertToDevices(raws []RawDevice) ([]Device, error) {
 	devices := []Device{}
 	for _, raw := range raws {

--- a/internal/operators/v1/nodes/device.go
+++ b/internal/operators/v1/nodes/device.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
@@ -31,7 +32,9 @@ func (o *Operator) addDevice(req nodes.DeviceReqOpts) error {
 	maxRetries := 3
 	for range maxRetries {
 		err := cubecos.AddDevice(req)
-		if err == nil {
+		if err != nil {
+			wait.Seconds(3)
+		} else {
 			return nil
 		}
 	}

--- a/internal/operators/v1/nodes/device.go
+++ b/internal/operators/v1/nodes/device.go
@@ -13,7 +13,7 @@ import (
 func (o *Operator) operateDevice(req nodes.DeviceReqOpts) error {
 	switch req.Status.Desired {
 	case status.Added:
-		return cubecos.AddDevice(req)
+		return o.addDevice(req)
 	case status.Promoted, status.Demoted:
 		return cubecos.PromoteOrDemoteDevice(req)
 	case status.Removed:
@@ -24,6 +24,21 @@ func (o *Operator) operateDevice(req nodes.DeviceReqOpts) error {
 		"unknown desired action(%s) for node device(%s)",
 		req.Status.Desired,
 		req.Device,
+	)
+}
+
+func (o *Operator) addDevice(req nodes.DeviceReqOpts) error {
+	maxRetries := 3
+	for range maxRetries {
+		err := cubecos.AddDevice(req)
+		if err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"failed to add device %s after %d retries",
+		req.Device, maxRetries,
 	)
 }
 


### PR DESCRIPTION
### What type of PR is this?

Refactor and Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/190

<br/>

### What this PR does?

Enhance the status transition experience for adding disk and osd by

- make sure that all device's osds are `up` before report the status

- retry the adding logic once hex sdk get failed or status is not matched between hex sdk and ceph
