### PR TITLE
Add `reservedImages[].reserved.prefix` and remove `reservedImages[].file` in the image materials api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- PROJECT LOGO -->
-<br/>
 <div align="left">
   <h2 align="left">🧬 CubeCOS API </h2>
 </div>

--- a/api/docs.go
+++ b/api/docs.go
@@ -12746,22 +12746,26 @@ const docTemplate = `{
                                             "data": {
                                                 "reservedImages": [
                                                     {
-                                                        "file": "amphora-x64-haproxy-yoga.qcow2",
                                                         "name": "amphora-x64-haproxy",
                                                         "os": "Ubuntu",
                                                         "destination": "CubeStorage",
                                                         "domain": "default",
                                                         "sourceFromAnotherHypervisor": false,
-                                                        "visibility": "private"
+                                                        "visibility": "private",
+                                                        "reserved": {
+                                                            "prefix": "amphora-"
+                                                        }
                                                     },
                                                     {
-                                                        "file": "manila-service-image_yoga.qcow2",
                                                         "name": "manila-service-image",
                                                         "os": "Ubuntu",
                                                         "destination": "CubeStorage",
                                                         "domain": "default",
                                                         "sourceFromAnotherHypervisor": false,
-                                                        "visibility": "private"
+                                                        "visibility": "private",
+                                                        "reserved": {
+                                                            "prefix": "manila-"
+                                                        }
                                                     }
                                                 ],
                                                 "projects": [
@@ -18825,19 +18829,16 @@ const docTemplate = `{
                                 "items": {
                                     "type": "object",
                                     "required": [
-                                        "file",
                                         "name",
                                         "os",
                                         "destination",
                                         "domain",
                                         "project",
                                         "sourceFromAnotherHypervisor",
-                                        "visibility"
+                                        "visibility",
+                                        "reserved"
                                     ],
                                     "properties": {
-                                        "file": {
-                                            "type": "string"
-                                        },
                                         "name": {
                                             "type": "string"
                                         },
@@ -18858,6 +18859,17 @@ const docTemplate = `{
                                         },
                                         "visibility": {
                                             "type": "string"
+                                        },
+                                        "reserved": {
+                                            "type": "object",
+                                            "required": [
+                                                "prefix"
+                                            ],
+                                            "properties": {
+                                                "prefix": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/api/docs.json
+++ b/api/docs.json
@@ -12742,22 +12742,26 @@
                                             "data": {
                                                 "reservedImages": [
                                                     {
-                                                        "file": "amphora-x64-haproxy-yoga.qcow2",
                                                         "name": "amphora-x64-haproxy",
                                                         "os": "Ubuntu",
                                                         "destination": "CubeStorage",
                                                         "domain": "default",
                                                         "sourceFromAnotherHypervisor": false,
-                                                        "visibility": "private"
+                                                        "visibility": "private",
+                                                        "reserved": {
+                                                            "prefix": "amphora-"
+                                                        }
                                                     },
                                                     {
-                                                        "file": "manila-service-image_yoga.qcow2",
                                                         "name": "manila-service-image",
                                                         "os": "Ubuntu",
                                                         "destination": "CubeStorage",
                                                         "domain": "default",
                                                         "sourceFromAnotherHypervisor": false,
-                                                        "visibility": "private"
+                                                        "visibility": "private",
+                                                        "reserved": {
+                                                            "prefix": "manila-"
+                                                        }
                                                     }
                                                 ],
                                                 "projects": [
@@ -18821,19 +18825,16 @@
                                 "items": {
                                     "type": "object",
                                     "required": [
-                                        "file",
                                         "name",
                                         "os",
                                         "destination",
                                         "domain",
                                         "project",
                                         "sourceFromAnotherHypervisor",
-                                        "visibility"
+                                        "visibility",
+                                        "reserved"
                                     ],
                                     "properties": {
-                                        "file": {
-                                            "type": "string"
-                                        },
                                         "name": {
                                             "type": "string"
                                         },
@@ -18854,6 +18855,17 @@
                                         },
                                         "visibility": {
                                             "type": "string"
+                                        },
+                                        "reserved": {
+                                            "type": "object",
+                                            "required": [
+                                                "prefix"
+                                            ],
+                                            "properties": {
+                                                "prefix": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/internal/definition/v1/images/images.go
+++ b/internal/definition/v1/images/images.go
@@ -80,7 +80,7 @@ type Image struct {
 
 type ReqOpts struct {
 	Id                          string        `json:"id,omitempty" bson:"id"`
-	File                        string        `json:"file" bson:"file"`
+	File                        string        `json:"file,omitempty" bson:"file"`
 	Name                        string        `json:"name" bson:"name"`
 	Os                          string        `json:"os" bson:"os"`
 	Destination                 string        `json:"destination" bson:"destination"`


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/239

<br/>

### What this PR does?

Adjust 2 things below in the image materials api

- Add `reservedImages[].reserved.prefix`

- Remove `reservedImages[].file`

<br/>

### Test results (optional)

1). make sure the api doc has been updated.

<img width="888" height="1036" alt="Screenshot 2025-08-11 at 3 52 44 PM" src="https://github.com/user-attachments/assets/c1ca2df1-8dd4-4425-850d-4cb881235271" />

<br/>
<br/>
<br/>

2). make sure the api works well.

<img width="679" height="1031" alt="Screenshot 2025-08-11 at 4 01 26 PM" src="https://github.com/user-attachments/assets/39579333-40e0-454e-9ef2-645bb7e7740f" />
