### PR TITLE
Add a DELETE API to remove the `uninstalled` firmware pkg

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -13420,7 +13420,7 @@ const docTemplate = `{
                 "tags": [
                     "Firmwares"
                 ],
-                "summary": "List a firmware",
+                "summary": "List firmwares",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
@@ -13514,16 +13514,7 @@ const docTemplate = `{
                     }
                 ],
                 "requestBody": {
-                    "description": "for example, in the CURL, the firmware pkg should be set by the '-T /path/to/firmware'.",
-                    "required": true,
-                    "content": {
-                        "application/octet-stream": {
-                            "schema": {
-                                "type": "string",
-                                "format": "binary"
-                            }
-                        }
-                    }
+                    "$ref": "#/components/requestBodies/applicationOctetStream"
                 },
                 "responses": {
                     "200": {
@@ -13548,7 +13539,7 @@ const docTemplate = `{
                                         },
                                         "status": {
                                             "type": "string",
-                                            "example": "accepted"
+                                            "example": "ok"
                                         }
                                     }
                                 }
@@ -13620,7 +13611,7 @@ const docTemplate = `{
                                         },
                                         "status": {
                                             "type": "string",
-                                            "example": "accepted"
+                                            "example": "ok"
                                         }
                                     }
                                 }
@@ -13703,7 +13694,7 @@ const docTemplate = `{
                                         },
                                         "status": {
                                             "type": "string",
-                                            "example": "accepted"
+                                            "example": "ok"
                                         }
                                     }
                                 }

--- a/api/docs.go
+++ b/api/docs.go
@@ -13546,6 +13546,30 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "firmware already exists and under md5 verifying"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "content": {
@@ -13612,6 +13636,30 @@ const docTemplate = `{
                                         "status": {
                                             "type": "string",
                                             "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "md5 already exists and under verifying"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
                                         }
                                     }
                                 }
@@ -13744,6 +13792,30 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "md5 verification is already in progress"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "content": {
@@ -13758,6 +13830,114 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to upload firmware md5: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/firmwares/{version}": {
+            "delete": {
+                "operationId": "deleteFirmware",
+                "tags": [
+                    "Firmwares"
+                ],
+                "summary": "Delete a firmware",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The version of the firmware to delete",
+                        "example": "CUBE Appliance 3.1.0 f45c719"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Firmware deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "Firmware deleted successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "firmware CUBE Appliance 3.1.0 f45c719 not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete firmware: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -13416,7 +13416,7 @@
                 "tags": [
                     "Firmwares"
                 ],
-                "summary": "List a firmware",
+                "summary": "List firmwares",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
@@ -13510,16 +13510,7 @@
                     }
                 ],
                 "requestBody": {
-                    "description": "for example, in the CURL, the firmware pkg should be set by the '-T /path/to/firmware'.",
-                    "required": true,
-                    "content": {
-                        "application/octet-stream": {
-                            "schema": {
-                                "type": "string",
-                                "format": "binary"
-                            }
-                        }
-                    }
+                    "$ref": "#/components/requestBodies/applicationOctetStream"
                 },
                 "responses": {
                     "200": {
@@ -13544,7 +13535,31 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "example": "accepted"
+                                            "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "firmware already exists and under md5 verifying"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
                                         }
                                     }
                                 }
@@ -13616,7 +13631,31 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "example": "accepted"
+                                            "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "md5 already exists and under verifying"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
                                         }
                                     }
                                 }
@@ -13699,7 +13738,7 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "example": "accepted"
+                                            "example": "ok"
                                         }
                                     }
                                 }
@@ -13743,6 +13782,30 @@
                                         "status": {
                                             "type": "string",
                                             "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "md5 verification is already in progress"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
                                         }
                                     }
                                 }

--- a/api/docs.json
+++ b/api/docs.json
@@ -13838,6 +13838,114 @@
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/firmwares/{version}": {
+            "delete": {
+                "operationId": "deleteFirmware",
+                "tags": [
+                    "Firmwares"
+                ],
+                "summary": "Delete a firmware",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "in": "path",
+                        "name": "version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The version of the firmware to delete",
+                        "example": "CUBE Appliance 3.1.0 f45c719"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Firmware deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "Firmware deleted successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "firmware CUBE Appliance 3.1.0 f45c719 not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete firmware: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/internal/apis/v1/handlers/firmwares/handlers.go
+++ b/internal/apis/v1/handlers/firmwares/handlers.go
@@ -48,7 +48,7 @@ var (
 func listFirmwares(c *gin.Context) {
 	h, err := initHelper(c, "listFirmwares")
 	if err != nil {
-		log.Errorf("images(%s): failed to init helper(%v)", h.reqId, err)
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err, nil)
 		return
 	}
@@ -69,7 +69,7 @@ func listFirmwares(c *gin.Context) {
 func uploadFirmware(c *gin.Context) {
 	h, err := initHelper(c, "uploadFirmware")
 	if err != nil {
-		log.Errorf("images(%s): failed to init helper(%v)", h.reqId, err)
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err, nil)
 		return
 	}
@@ -102,7 +102,7 @@ func uploadFirmware(c *gin.Context) {
 func uploadFirmwareMd5Sum(c *gin.Context) {
 	h, err := initHelper(c, "uploadFirmwareMd5Sum")
 	if err != nil {
-		log.Errorf("images(%s): failed to init helper(%v)", h.reqId, err)
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err, nil)
 		return
 	}
@@ -129,7 +129,7 @@ func uploadFirmwareMd5Sum(c *gin.Context) {
 func verfiyFirmwareAndMd5Sum(c *gin.Context) {
 	h, err := initHelper(c, "verfiyFirmwareAndMd5Sum")
 	if err != nil {
-		log.Errorf("images(%s): failed to init helper(%v)", h.reqId, err)
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err, nil)
 		return
 	}
@@ -156,7 +156,7 @@ func verfiyFirmwareAndMd5Sum(c *gin.Context) {
 func deleteFirmware(c *gin.Context) {
 	h, err := initHelper(c, "deleteFirmware")
 	if err != nil {
-		log.Errorf("images(%s): failed to init helper(%v)", h.reqId, err)
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err, nil)
 		return
 	}

--- a/internal/apis/v1/handlers/firmwares/handlers.go
+++ b/internal/apis/v1/handlers/firmwares/handlers.go
@@ -39,7 +39,7 @@ var (
 		{
 			Version: apis.V1,
 			Method:  http.MethodDelete,
-			Path:    "/firmwares/{version}",
+			Path:    "/firmwares/:version",
 			Func:    deleteFirmware,
 		},
 	}

--- a/internal/apis/v1/handlers/firmwares/handlers.go
+++ b/internal/apis/v1/handlers/firmwares/handlers.go
@@ -36,6 +36,12 @@ var (
 			Path:    "/firmwares/md5sum/verify",
 			Func:    verfiyFirmwareAndMd5Sum,
 		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodDelete,
+			Path:    "/firmwares/{version}",
+			Func:    deleteFirmware,
+		},
 	}
 )
 
@@ -144,5 +150,26 @@ func verfiyFirmwareAndMd5Sum(c *gin.Context) {
 		c,
 		"Firmware and MD5 sum verified successfully",
 		result,
+	)
+}
+
+func deleteFirmware(c *gin.Context) {
+	h, err := initHelper(c, "deleteFirmware")
+	if err != nil {
+		log.Errorf("images(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.deleteFirmware()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"Firmware deleted successfully",
+		nil,
 	)
 }

--- a/internal/apis/v1/handlers/firmwares/helper.go
+++ b/internal/apis/v1/handlers/firmwares/helper.go
@@ -51,14 +51,12 @@ func (h *helper) listFirmwares() (*firmwarePage, error) {
 }
 
 func (h *helper) deleteFirmware() error {
-	segments := strings.Split(h.file, " ")
-	if len(segments) < 4 {
-		return fmt.Errorf(
-			"invalid firmware version format: %s, expected format: CUBE Appliance <version> <hash>",
-			h.file,
-		)
+	err := h.checkFirmwarePattern()
+	if err != nil {
+		return err
 	}
 
+	segments := strings.Split(h.file, " ")
 	version := segments[2]
 	hash := segments[3]
 	entries, err := os.ReadDir(firmwares.UpdateDir)

--- a/internal/apis/v1/handlers/firmwares/helper.go
+++ b/internal/apis/v1/handlers/firmwares/helper.go
@@ -1,9 +1,15 @@
 package firmwares
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/firmwares"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/pages"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
@@ -42,4 +48,54 @@ func (h *helper) listFirmwares() (*firmwarePage, error) {
 		Firmwares: h.paginateFirmwares(firmwares),
 		Page:      h.genPageInfo(firmwares),
 	}, nil
+}
+
+func (h *helper) deleteFirmware() error {
+	segments := strings.Split(h.file, " ")
+	if len(segments) < 4 {
+		return fmt.Errorf(
+			"invalid firmware version format: %s, expected format: CUBE Appliance <version> <hash>",
+			h.file,
+		)
+	}
+
+	version := segments[2]
+	hash := segments[3]
+	entries, err := os.ReadDir(firmwares.UpdateDir)
+	if err != nil {
+		log.Errorf("firmwares(%s): failed to read update directory %s(%v)", h.reqId, firmwares.UpdateDir, err)
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		file := filepath.Join(firmwares.UpdateDir, entry.Name())
+		if !strings.HasSuffix(file, ".pkg") {
+			continue
+		}
+
+		if !strings.Contains(file, version) {
+			continue
+		}
+
+		if !strings.Contains(file, hash) {
+			continue
+		}
+
+		err = os.Remove(file)
+		if err == nil {
+			return nil
+		}
+
+		log.Errorf("firmwares(%s): failed to delete firmware file %s (%v)", h.reqId, file, err)
+		return err
+	}
+
+	return fmt.Errorf(
+		"firmware version %s not found",
+		version,
+	)
 }

--- a/internal/apis/v1/handlers/firmwares/parse.go
+++ b/internal/apis/v1/handlers/firmwares/parse.go
@@ -22,6 +22,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseUploadMd5Params()
 	case "verfiyFirmwareAndMd5Sum":
 		return h.parseVerificationParams()
+	case "deleteFirmware":
+		return h.parseDeleteFirmwareParams()
 	default:
 		return nil
 	}
@@ -72,6 +74,23 @@ func (h *helper) parseVerificationParams() error {
 	}
 
 	return fmt.Errorf("no firmware file found in %s", firmwares.TmpUploadDir)
+}
+
+func (h *helper) parseDeleteFirmwareParams() error {
+	h.file = h.c.Param("version")
+	if h.file == "" {
+		return fmt.Errorf("version parameter is required")
+	}
+
+	segments := strings.Split(h.file, " ")
+	if len(segments) < 4 {
+		return fmt.Errorf(
+			"invalid firmware version format: %s, expected format: CUBE Appliance <version> <hash>",
+			h.file,
+		)
+	}
+
+	return nil
 }
 
 func (h *helper) saveUploadFile() error {

--- a/internal/apis/v1/handlers/firmwares/parse.go
+++ b/internal/apis/v1/handlers/firmwares/parse.go
@@ -82,15 +82,7 @@ func (h *helper) parseDeleteFirmwareParams() error {
 		return fmt.Errorf("version parameter is required")
 	}
 
-	segments := strings.Split(h.file, " ")
-	if len(segments) < 4 {
-		return fmt.Errorf(
-			"invalid firmware version format: %s, expected format: CUBE Appliance <version> <hash>",
-			h.file,
-		)
-	}
-
-	return nil
+	return h.checkFirmwarePattern()
 }
 
 func (h *helper) saveUploadFile() error {

--- a/internal/apis/v1/handlers/firmwares/verify.go
+++ b/internal/apis/v1/handlers/firmwares/verify.go
@@ -32,7 +32,7 @@ func (h *helper) setValidFirmware() error {
 	srcPath := filepath.Join(firmwares.TmpUploadDir, h.file)
 	dstPath := filepath.Join(firmwares.UpdateDir, h.file)
 
-	err := h.MoveFile(srcPath, dstPath)
+	err := h.moveFile(srcPath, dstPath)
 	if err != nil {
 		log.Errorf("firmwares(%s): failed to move firmware file from %s to %s (%v)", h.reqId, srcPath, dstPath, err)
 		return err
@@ -41,7 +41,7 @@ func (h *helper) setValidFirmware() error {
 	return nil
 }
 
-func (h *helper) MoveFile(srcPath, dstPath string) error {
+func (h *helper) moveFile(srcPath, dstPath string) error {
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
 		log.Errorf("firmwares(%s): failed to open source file %s (%v)", h.reqId, srcPath, err)

--- a/internal/apis/v1/handlers/firmwares/verify.go
+++ b/internal/apis/v1/handlers/firmwares/verify.go
@@ -11,6 +11,18 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
+func (h *helper) checkFirmwarePattern() error {
+	segments := strings.Split(h.file, " ")
+	if len(segments) < 4 {
+		return fmt.Errorf(
+			"invalid firmware version format: %s, expected format: CUBE Appliance <version> <hash>",
+			h.file,
+		)
+	}
+
+	return nil
+}
+
 func (h *helper) verifyFirmwareAndMd5() (*integrityResult, error) {
 	result, err := h.parseMd5Data()
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/278

<br/>

### What this PR does?

- Add a DELETE API to remove the `uninstalled` firmware pkg

- Add the DELETE API spec in the api doc

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1293" height="884" alt="Screenshot 2025-08-15 at 1 16 07 PM" src="https://github.com/user-attachments/assets/f9941df4-d974-4737-8391-01905e10cc89" />

<br/>
<br/>
<br/>

2). make sure the api works properly

```bash
curl -k -X DELETE "https://10.32.45.10/api/v1/datacenters/control/firmwares/CUBE%20Appliance%203.1.0%20f45c719" -H "Authorization: Bearer ${TOKEN}"
{"code":200,"msg":"Firmware deleted successfully","status":"ok"}
```

```bash
[cube453 ~]# ll /mnt/cephfs/update
total 9235580
drwxrwxr-x 2 root admin          1 Aug 15 02:03 ./
drwxr-xr-x 9 root root           7 Aug  8 20:50 ../
-rw-r--r-- 1 root root  9457233920 Aug 12 01:19 CUBE_3.1.0_20250811-0109_f45c719.pkg
[cube453 ~]#
[cube453 ~]#
[cube453 ~]# ll /mnt/cephfs/update
total 0
drwxrwxr-x 2 root admin 0 Aug 15 13:02 ./
drwxr-xr-x 9 root root  7 Aug  8 20:50 ../
[cube453 ~]#
```