### PR TITLE
Add a POST API to graceful reboot the node

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5532,14 +5532,7 @@ const docTemplate = `{
                         "$ref": "#/components/parameters/watch"
                     },
                     {
-                        "name": "nodeName",
-                        "in": "path",
-                        "description": "The name of the node",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "example-node-0"
+                        "$ref": "#/components/parameters/nodeName"
                     }
                 ],
                 "responses": {
@@ -5681,6 +5674,97 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch node: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/reboot": {
+            "get": {
+                "operationId": "rebootNode",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Reboot the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the reboot request received, the node is rebooting",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node reboot request received, the node is rebooting"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to reboot the node: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -5528,14 +5528,7 @@
                         "$ref": "#/components/parameters/watch"
                     },
                     {
-                        "name": "nodeName",
-                        "in": "path",
-                        "description": "The name of the node",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "example-node-0"
+                        "$ref": "#/components/parameters/nodeName"
                     }
                 ],
                 "responses": {
@@ -5677,6 +5670,97 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch node: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/reboot": {
+            "get": {
+                "operationId": "rebootNode",
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Reboot the node",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/nodeName"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "the reboot request received, the node is rebooting",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node reboot request received, the node is rebooting"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Node not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "node not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to reboot the node: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -27,6 +27,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/nodes/:nodeName/reboot",
+			Func:    rebootNode,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodPost,
 			Path:    "/nodes/:nodeName/ipmi",
 			Func:    setNodeIpmi,
@@ -161,6 +167,26 @@ func getNode(c *gin.Context) {
 		c,
 		"fetch node successfully",
 		node,
+	)
+}
+
+func rebootNode(c *gin.Context) {
+	h, err := initHelper(c, "rebootNode")
+	if err != nil {
+		log.Errorf("nodes(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.rebootNode()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"the request of rebooting node is accepted and under processing",
 	)
 }
 

--- a/internal/apis/v1/handlers/nodes/helper.go
+++ b/internal/apis/v1/handlers/nodes/helper.go
@@ -78,6 +78,15 @@ func (h *helper) parseGetOptions() error {
 	return h.parseWatch()
 }
 
+func (h *helper) parseRebootOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("nodeName should be provided")
+	}
+
+	return nil
+}
+
 func (h *helper) listNodes() (*nodePage, error) {
 	nodes := cubecos.ListNodesWithTimeSensitiveInfo()
 	nodes = h.filterNodes(nodes)
@@ -110,6 +119,44 @@ func (h *helper) getNode() (*nodes.Node, error) {
 	}
 
 	return node, nil
+}
+
+func (h *helper) rebootNode() error {
+	node, err := nodes.Get(h.node)
+	if err != nil {
+		log.Errorf("nodes(%s): failed to get node(%v)", h.reqId, err)
+		return err
+	}
+
+	if node.IsLocal() {
+		return cubecos.GracefulReboot()
+	}
+
+	return h.rebootPeerNode()
+}
+
+func (h *helper) rebootPeerNode() error {
+	node, err := nodes.Get(h.node)
+	if err != nil {
+		log.Errorf("nodes(%s): failed to get node to reboot(%s %v)", h.reqId, h.node, err)
+		return err
+	}
+
+	resp, err := h.http.R().
+		SetHeaders(nodes.GetSecretHeaders()).
+		Post(node.RebootNodeUrl())
+	if err != nil {
+		log.Errorf("nodes(%s): failed to reboot node %s(%v)", h.reqId, h.node, err)
+		return err
+	}
+
+	if resp.IsError() {
+		err := fmt.Errorf("failed to reboot node %s(%s)", h.node, resp.String())
+		log.Errorf("nodes(%s): %v", h.reqId, err)
+		return err
+	}
+
+	return nil
 }
 
 func (h *helper) getNodeIpmi() (*nodes.Ipmi, error) {

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -16,6 +16,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseListOptions()
 	case "getNode", "getNodeIpmi", "disconnectNodeIpmi":
 		return h.parseGetOptions()
+	case "rebootNode":
+		return h.parseRebootOptions()
 	case "setNodeIpmi", "verifyNodeIpmi":
 		return h.parseSetOrVerifyOptions()
 	case "ipmiOperateNode":

--- a/internal/cubecos/os.go
+++ b/internal/cubecos/os.go
@@ -1,10 +1,14 @@
 package cubecos
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
 
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -43,4 +47,46 @@ func IsHexSdkSuccess(err error) bool {
 	}
 
 	return exitErr.ExitCode() == 0
+}
+
+func GracefulReboot() error {
+	node, err := nodes.Get(base.Hostname)
+	if err != nil {
+		log.Errorf("os: failed to get node info(%v)", err)
+		return err
+	}
+
+	if node.IsVirtualIpOwner {
+		MoveVirtualIpOwner()
+	}
+
+	return Reboot()
+}
+
+func Reboot() error {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "reboot").CombinedOutput()
+	if err != nil {
+		err := fmt.Errorf("failed to reboot the system(%v %s)", err, string(out))
+		log.Errorf("os: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func MoveVirtualIpOwner() {
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(5))
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "pcs", "resource", "move", "vip").CombinedOutput()
+	if err != nil {
+		err := fmt.Errorf("failed to move virtual ip owner(%v %s)", err, string(out))
+		log.Errorf("os: %v", err)
+		return
+	}
+
+	log.Infof("os: successfully moved virtual ip owner(%s)", string(out))
 }

--- a/internal/cubecos/os.go
+++ b/internal/cubecos/os.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	log "go-micro.dev/v5/logger"
+	"golang.org/x/sys/unix"
 )
 
 func GetSystemSerial() (string, error) {
@@ -60,11 +61,12 @@ func GracefulReboot() error {
 		MoveVirtualIpOwner()
 	}
 
+	unix.Sync()
 	return Reboot()
 }
 
 func Reboot() error {
-	ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(20))
 	defer cancel()
 
 	out, err := exec.CommandContext(ctx, "reboot").CombinedOutput()

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -43,6 +43,12 @@ func (n *Node) GetNodeUrl() string {
 	return u.String()
 }
 
+func (n *Node) RebootNodeUrl() string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/reboot", n.DataCenter, n.Hostname)
+	return u.String()
+}
+
 func (n *Node) PostLicenseUrl() string {
 	u := url.URL{Scheme: n.Protocol, Host: n.Address}
 	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/licenses/hosts/%s", base.DataCenterName, n.Hostname)


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/276

<br/>

### What this PR does?

- Add a POST API to graceful reboot the node

- Add the corresponding desc in the API doc

- Use unix.Sync() to to force OS flush all tmp/cache data to disk before rebooting

- Will switch the virtual ip owner to other nodes before rebooting the VIP node

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1432" height="646" alt="Screenshot 2025-08-16 at 8 29 09 PM" src="https://github.com/user-attachments/assets/2c9b6a90-be57-42f9-b8b0-f13388972234" />

<img width="1428" height="942" alt="Screenshot 2025-08-16 at 8 29 23 PM" src="https://github.com/user-attachments/assets/3071e187-dbd4-43f0-8f65-17c1e75ff70b" />
