### PR TITLE
Add a GET API to list the installed and uninstalled fixpacks

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -14187,6 +14187,106 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/fixpacks": {
+            "get": {
+                "operationId": "listFixpacks",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "List fixpacks",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/pageNum"
+                    },
+                    {
+                        "$ref": "#/components/parameters/pageSize"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List fixpacks successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListFixpacksResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Fixpack list",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "fixpacks": [
+                                                    {
+                                                        "version": "FIX_001",
+                                                        "note": "Diagnostic Tools",
+                                                        "updatedAt": "2025-08-19T19:37:20+08:00",
+                                                        "rebootRequired": false,
+                                                        "status": {
+                                                            "current": "installed",
+                                                            "isInstallable": false,
+                                                            "isRollbackable": false,
+                                                            "isProcessing": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "version": "FIX_003",
+                                                        "note": "A sample fixpack that can not be removed and backs up hex_config",
+                                                        "updatedAt": "2025-08-14T22:59:57+08:00",
+                                                        "rebootRequired": false,
+                                                        "status": {
+                                                            "current": "installed",
+                                                            "isInstallable": false,
+                                                            "isRollbackable": false,
+                                                            "isProcessing": false
+                                                        }
+                                                    }
+                                                ],
+                                                "page": {
+                                                    "total": 1,
+                                                    "number": 1,
+                                                    "size": 2,
+                                                    "totalItemCount": 2
+                                                }
+                                            },
+                                            "msg": "fetch fixpack list successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to list fixpack: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -20092,6 +20192,94 @@ const docTemplate = `{
                                         }
                                     }
                                 }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ListFixpacksResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "fixpacks",
+                            "page"
+                        ],
+                        "properties": {
+                            "fixpacks": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "version",
+                                        "note",
+                                        "updatedAt",
+                                        "rebootRequired",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "version": {
+                                            "type": "string"
+                                        },
+                                        "note": {
+                                            "type": "string"
+                                        },
+                                        "updatedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "rebootRequired": {
+                                            "type": "boolean"
+                                        },
+                                        "status": {
+                                            "type": "object",
+                                            "required": [
+                                                "current",
+                                                "isInstallable",
+                                                "isRollbackable",
+                                                "isProcessing"
+                                            ],
+                                            "properties": {
+                                                "current": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "available",
+                                                        "installing",
+                                                        "installed"
+                                                    ]
+                                                },
+                                                "isInstallable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isRollbackable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isProcessing": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "page": {
+                                "$ref": "#/components/schemas/Page"
                             }
                         }
                     },

--- a/api/docs.json
+++ b/api/docs.json
@@ -14183,6 +14183,106 @@
                     }
                 }
             }
+        },
+        "/api/v1/datacenters/{dataCenter}/fixpacks": {
+            "get": {
+                "operationId": "listFixpacks",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "List fixpacks",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/pageNum"
+                    },
+                    {
+                        "$ref": "#/components/parameters/pageSize"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List fixpacks successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListFixpacksResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Fixpack list",
+                                        "value": {
+                                            "code": 200,
+                                            "data": {
+                                                "fixpacks": [
+                                                    {
+                                                        "version": "FIX_001",
+                                                        "note": "Diagnostic Tools",
+                                                        "updatedAt": "2025-08-19T19:37:20+08:00",
+                                                        "rebootRequired": false,
+                                                        "status": {
+                                                            "current": "installed",
+                                                            "isInstallable": false,
+                                                            "isRollbackable": false,
+                                                            "isProcessing": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "version": "FIX_003",
+                                                        "note": "A sample fixpack that can not be removed and backs up hex_config",
+                                                        "updatedAt": "2025-08-14T22:59:57+08:00",
+                                                        "rebootRequired": false,
+                                                        "status": {
+                                                            "current": "installed",
+                                                            "isInstallable": false,
+                                                            "isRollbackable": false,
+                                                            "isProcessing": false
+                                                        }
+                                                    }
+                                                ],
+                                                "page": {
+                                                    "total": 1,
+                                                    "number": 1,
+                                                    "size": 2,
+                                                    "totalItemCount": 2
+                                                }
+                                            },
+                                            "msg": "fetch fixpack list successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to list fixpack: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -20088,6 +20188,94 @@
                                         }
                                     }
                                 }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ListFixpacksResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "required": [
+                            "fixpacks",
+                            "page"
+                        ],
+                        "properties": {
+                            "fixpacks": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "version",
+                                        "note",
+                                        "updatedAt",
+                                        "rebootRequired",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "version": {
+                                            "type": "string"
+                                        },
+                                        "note": {
+                                            "type": "string"
+                                        },
+                                        "updatedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "rebootRequired": {
+                                            "type": "boolean"
+                                        },
+                                        "status": {
+                                            "type": "object",
+                                            "required": [
+                                                "current",
+                                                "isInstallable",
+                                                "isRollbackable",
+                                                "isProcessing"
+                                            ],
+                                            "properties": {
+                                                "current": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "available",
+                                                        "installing",
+                                                        "installed"
+                                                    ]
+                                                },
+                                                "isInstallable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isRollbackable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isProcessing": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "page": {
+                                "$ref": "#/components/schemas/Page"
                             }
                         }
                     },

--- a/internal/apis/v1/handlers/fixpacks/handlers.go
+++ b/internal/apis/v1/handlers/fixpacks/handlers.go
@@ -1,0 +1,42 @@
+package fixpacks
+
+import (
+	"net/http"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/apis"
+	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/bodies"
+	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
+)
+
+var (
+	Handlers = []apis.Handler{
+		{
+			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/fixpacks",
+			Func:    listFixpacks,
+		},
+	}
+)
+
+func listFixpacks(c *gin.Context) {
+	h, err := initHelper(c, "listFixpacks")
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	fixpacks, err := h.listFixpacks()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"List of fixpacks",
+		fixpacks,
+	)
+}

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -1,0 +1,51 @@
+package fixpacks
+
+import (
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
+	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/pages"
+	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
+)
+
+type helper struct {
+	c       *gin.Context
+	reqId   string
+	handler string
+
+	http  *http.Helper
+	mongo *mongo.Helper
+
+	file           string
+	installReqOpts fixpacks.InstallReqOpts
+	page           *pages.Page
+}
+
+func initHelper(c *gin.Context, handler string) (*helper, error) {
+	h := &helper{
+		c:       c,
+		http:    http.GetGlobalHelper(),
+		mongo:   mongo.GetGlobalHelper(),
+		reqId:   queries.GetReqId(c),
+		handler: handler,
+	}
+
+	return h, h.parseParamsByHandler()
+}
+
+func (h *helper) listFixpacks() (*fixpacksPage, error) {
+	fixpackss, err := cubecos.ListFixpacks()
+	if err != nil {
+		log.Errorf("fixpackss(%s): failed to list fixpackss(%v)", h.reqId, err)
+		return nil, err
+	}
+
+	h.sortFixpacks(&fixpackss)
+	return &fixpacksPage{
+		Fixpacks: h.paginateFixpacks(fixpackss),
+		Page:     h.genPageInfo(fixpackss),
+	}, nil
+}

--- a/internal/apis/v1/handlers/fixpacks/paginate.go
+++ b/internal/apis/v1/handlers/fixpacks/paginate.go
@@ -1,0 +1,48 @@
+package fixpacks
+
+import (
+	"math"
+	"sort"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/pages"
+)
+
+type fixpacksPage struct {
+	Fixpacks   []fixpacks.Fixpack `json:"fixpacks"`
+	pages.Page `json:"page"`
+}
+
+func (h *helper) paginateFixpacks(list []fixpacks.Fixpack) []fixpacks.Fixpack {
+	if !h.page.IsRequired() {
+		return list
+	}
+
+	left := min((h.page.Number-1)*h.page.Size, len(list))
+	right := min(left+h.page.Size, len(list))
+	return list[left:right]
+}
+
+func (h *helper) sortFixpacks(list *[]fixpacks.Fixpack) {
+	sort.Slice(*list, func(i, j int) bool {
+		return (*list)[i].UpdatedAt > (*list)[j].UpdatedAt
+	})
+}
+
+func (h *helper) genPageInfo(list []fixpacks.Fixpack) pages.Page {
+	if !h.page.IsRequired() {
+		return pages.Page{
+			Total:          1,
+			Number:         1,
+			Size:           len(list),
+			TotalItemCount: int64(len(list)),
+		}
+	}
+
+	return pages.Page{
+		Total:          int64(math.Ceil(float64(len(list)) / float64(h.page.Size))),
+		Number:         h.page.Number,
+		Size:           h.page.Size,
+		TotalItemCount: int64(len(list)),
+	}
+}

--- a/internal/apis/v1/handlers/fixpacks/parse.go
+++ b/internal/apis/v1/handlers/fixpacks/parse.go
@@ -1,0 +1,26 @@
+package fixpacks
+
+import (
+	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
+	log "go-micro.dev/v5/logger"
+)
+
+func (h *helper) parseParamsByHandler() error {
+	switch h.handler {
+	case "listFixpacks":
+		return h.parseListParams()
+	default:
+		return nil
+	}
+}
+
+func (h *helper) parseListParams() error {
+	var err error
+	h.page, err = queries.GetPage(h.c)
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to get page parameters (%v)", h.reqId, err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -1,0 +1,107 @@
+package cubecos
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
+	log "go-micro.dev/v5/logger"
+)
+
+func ListFixpacks() ([]fixpacks.Fixpack, error) {
+	ctx, canel := context.WithTimeout(wait.CtxSeconds(120))
+	defer canel()
+
+	out, err := exec.CommandContext(ctx, "hex_config", "fixpack_get_history").CombinedOutput()
+	if err != nil {
+		log.Errorf("fixpacks: failed to execute fixpack history cmd(%v)", err)
+		return nil, err
+	}
+
+	fixpacks, err := convertToFixpacks(out)
+	if err != nil {
+		log.Errorf("fixpacks: failed to convert fixpacks(%v)", err)
+		return nil, err
+	}
+
+	err = addUninstalledFixpacks(&fixpacks)
+	if err != nil {
+		log.Errorf("fixpacks: failed to add uninstalled fixpacks(%v)", err)
+		return nil, err
+	}
+
+	return fixpacks, nil
+}
+
+func convertToFixpacks(out []byte) ([]fixpacks.Fixpack, error) {
+	fixpacksList := []fixpacks.Fixpack{}
+	lines := strings.SplitSeq(string(out), "\n")
+	for line := range lines {
+		segments := strings.Split(line, "|")
+		if len(segments) < 6 {
+			log.Warnf("fixpacks: invalid fixpack line(%s)", line)
+			continue
+		}
+
+		fixpack := fixpacks.Fixpack{
+			Version:   segments[1],
+			Note:      segments[5],
+			UpdatedAt: convertRawTime(time.FormatFixpack, segments[0]),
+			Status:    convertFixpackStatus(segments[3], segments[4]),
+		}
+
+		fixpacksList = append(fixpacksList, fixpack)
+	}
+
+	return fixpacksList, nil
+}
+
+func addUninstalledFixpacks(list *[]fixpacks.Fixpack) error {
+	entries, err := os.ReadDir(fixpacks.UpdateDir)
+	if err != nil {
+		log.Errorf("fixpack(%s): failed to read update directory %s(%v)", fixpacks.UpdateDir, err)
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		file := filepath.Join(fixpacks.UpdateDir, entry.Name())
+		if !strings.HasSuffix(file, ".fixpack") {
+			continue
+		}
+
+		*list = append(*list, fixpacks.Fixpack{
+			Version: entry.Name(),
+			Note:    "Uninstalled fixpack",
+			Status: status.Fixpack{
+				Current:       status.Available,
+				IsInstallable: true,
+			},
+		})
+	}
+
+	return nil
+}
+
+func convertFixpackStatus(rollback, action string) status.Fixpack {
+	status := status.Fixpack{Current: "installed"}
+
+	if strings.EqualFold(rollback, "yes") {
+		status.IsRollbackable = true
+	}
+
+	if strings.EqualFold(action, "installed") {
+		status.IsInstallable = false
+	}
+
+	return status
+}

--- a/internal/definition/v1/fixpacks/fixpack.go
+++ b/internal/definition/v1/fixpacks/fixpack.go
@@ -1,0 +1,19 @@
+package fixpacks
+
+import "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+
+const (
+	Module    = "fixpacks"
+	UpdateDir = "/var/fixpack"
+)
+
+type InstallReqOpts struct {
+}
+
+type Fixpack struct {
+	Version        string         `json:"version"`
+	Note           string         `json:"note"`
+	UpdatedAt      string         `json:"updatedAt"`
+	RebootRequired bool           `json:"rebootRequired"`
+	Status         status.Fixpack `json:"status"`
+}

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -39,6 +39,7 @@ const (
 	Added      = "added"
 	Uploaded   = "uploaded"
 	Upgraded   = "upgraded"
+	Installed  = "installed"
 	Removed    = "removed"
 	Updated    = "updated"
 	Promoted   = "promoted"
@@ -154,6 +155,15 @@ type Firmware struct {
 	IsUpdatable  bool   `json:"isUpdatable" bson:"isUpdatable"`
 	IsProcessing bool   `json:"isProcessing" bson:"isProcessing"`
 	Description  string `json:"description,omitempty" bson:"description"`
+}
+
+type Fixpack struct {
+	Current        string `json:"current,omitempty" bson:"current"`
+	Desired        string `json:"-" bson:"desired"`
+	IsInstallable  bool   `json:"isInstallable" bson:"isInstallable"`
+	IsRollbackable bool   `json:"isRollbackable" bson:"isRollbackable"`
+	IsProcessing   bool   `json:"isProcessing" bson:"isProcessing"`
+	Description    string `json:"description,omitempty" bson:"description"`
 }
 
 func NewHealthOk() *Health {

--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -11,6 +11,7 @@ import (
 	datacenterapi "github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/datacenters"
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/events"
 	firmwaresapi "github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/firmwares"
+	fixpacksapi "github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/fixpacks"
 	grafanapi "github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/grafana"
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/healths"
 	imagesapi "github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/images"
@@ -35,6 +36,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/auths"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/firmwares"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/grafana"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/health"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/images"
@@ -293,6 +295,14 @@ func prepareApiHandlersByRole() {
 	apis.RegisterHandlersToRoles(
 		firmwares.Module,
 		firmwaresapi.Handlers,
+		nodes.RoleControl,
+		nodes.RoleModerator,
+		nodes.RoleEdgeCore,
+	)
+
+	apis.RegisterHandlersToRoles(
+		fixpacks.Module,
+		fixpacksapi.Handlers,
 		nodes.RoleControl,
 		nodes.RoleModerator,
 		nodes.RoleEdgeCore,


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/272

<br/>

### What this PR does?

- Add a GET API to list the installed and uninstalled fixpacks

- Add the corresponding api doc

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1431" height="677" alt="Screenshot 2025-08-19 at 12 12 20 PM" src="https://github.com/user-attachments/assets/72c92df0-24a5-40cf-ba76-43d116ce1526" />

<img width="1426" height="850" alt="Screenshot 2025-08-19 at 12 12 31 PM" src="https://github.com/user-attachments/assets/a49b8cf1-d511-4ad3-b99f-3cf994d8633b" />

<br/>

2). make sure the api works properly

<img width="1908" height="1038" alt="Screenshot 2025-08-19 at 12 12 38 PM" src="https://github.com/user-attachments/assets/dc1479f1-bc67-4014-b866-a309317bbe39" />

<img width="1915" height="815" alt="Screenshot 2025-08-19 at 12 13 04 PM" src="https://github.com/user-attachments/assets/56532c6a-af28-4896-92b9-95b7a530e517" />
