### PR TITLE
Adjust and enrich the listing content for firmware API and fixpack API

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -13601,13 +13601,14 @@ const docTemplate = `{
                                             "data": {
                                                 "firmwares": [
                                                     {
-                                                        "version": "CUBE Appliance 3.1.0 f45c719",
-                                                        "releaseNotes": "",
+                                                        "version": "CUBE Appliance 3.1.0",
+                                                        "releaseNotes": "The CubeCOS 3.1.0(f45c719) firmware release since 2025-08-11T09:09:00+08:00",
                                                         "updatedAt": "2025-08-11T09:09:00+08:00",
                                                         "status": {
                                                             "current": "available",
                                                             "isUpdatable": true,
-                                                            "isProcessing": false
+                                                            "isProcessing": false,
+                                                            "isRemovable": true
                                                         }
                                                     }
                                                 ],
@@ -20591,7 +20592,8 @@ const docTemplate = `{
                                             "required": [
                                                 "current",
                                                 "isUpdatable",
-                                                "isProcessing"
+                                                "isProcessing",
+                                                "isRemovable"
                                             ],
                                             "properties": {
                                                 "current": {
@@ -20606,6 +20608,9 @@ const docTemplate = `{
                                                     "type": "boolean"
                                                 },
                                                 "isProcessing": {
+                                                    "type": "boolean"
+                                                },
+                                                "isRemovable": {
                                                     "type": "boolean"
                                                 }
                                             }

--- a/api/docs.go
+++ b/api/docs.go
@@ -14224,26 +14224,32 @@ const docTemplate = `{
                                                 "fixpacks": [
                                                     {
                                                         "version": "FIX_001",
-                                                        "note": "Diagnostic Tools",
+                                                        "name": "Need_Reboot",
+                                                        "note": "Test need reboot -- DO NOT DISTRIBUTE",
+                                                        "details": "FIXPACK_ID=\"FIX_001\"\nFIXPACK_NAME=\"Need_Reboot\"\nFIXPACK_DESCRIPTION=\"Test need reboot -- DO NOT DISTRIBUTE\"\n",
                                                         "updatedAt": "2025-08-19T19:37:20+08:00",
                                                         "rebootRequired": false,
                                                         "status": {
                                                             "current": "installed",
                                                             "isInstallable": false,
-                                                            "isRollbackable": false,
-                                                            "isProcessing": false
+                                                            "isRollbackable": true,
+                                                            "isProcessing": false,
+                                                            "isRemovable": false
                                                         }
                                                     },
                                                     {
-                                                        "version": "FIX_003",
-                                                        "note": "A sample fixpack that can not be removed and backs up hex_config",
-                                                        "updatedAt": "2025-08-14T22:59:57+08:00",
+                                                        "version": "FIX_002",
+                                                        "name": "Success",
+                                                        "note": "A sample fixpack that touches a single file and backups hex_config",
+                                                        "details": "FIXPACK_ID=\"FIX_002\"\nFIXPACK_NAME=\"Success\"\nFIXPACK_DESCRIPTION=\"A sample fixpack that touches a single file and backups hex_config\"\n",
+                                                        "updatedAt": "2025-08-14T22:58:44+08:00",
                                                         "rebootRequired": false,
                                                         "status": {
                                                             "current": "installed",
                                                             "isInstallable": false,
-                                                            "isRollbackable": false,
-                                                            "isProcessing": false
+                                                            "isRollbackable": true,
+                                                            "isProcessing": false,
+                                                            "isRemovable": false
                                                         }
                                                     }
                                                 ],
@@ -20706,7 +20712,9 @@ const docTemplate = `{
                                     "type": "object",
                                     "required": [
                                         "version",
+                                        "name",
                                         "note",
+                                        "details",
                                         "updatedAt",
                                         "rebootRequired",
                                         "status"
@@ -20715,7 +20723,13 @@ const docTemplate = `{
                                         "version": {
                                             "type": "string"
                                         },
+                                        "name": {
+                                            "type": "string"
+                                        },
                                         "note": {
+                                            "type": "string"
+                                        },
+                                        "details": {
                                             "type": "string"
                                         },
                                         "updatedAt": {
@@ -20731,7 +20745,8 @@ const docTemplate = `{
                                                 "current",
                                                 "isInstallable",
                                                 "isRollbackable",
-                                                "isProcessing"
+                                                "isProcessing",
+                                                "isRemovable"
                                             ],
                                             "properties": {
                                                 "current": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -14220,26 +14220,32 @@
                                                 "fixpacks": [
                                                     {
                                                         "version": "FIX_001",
-                                                        "note": "Diagnostic Tools",
+                                                        "name": "Need_Reboot",
+                                                        "note": "Test need reboot -- DO NOT DISTRIBUTE",
+                                                        "details": "FIXPACK_ID=\"FIX_001\"\nFIXPACK_NAME=\"Need_Reboot\"\nFIXPACK_DESCRIPTION=\"Test need reboot -- DO NOT DISTRIBUTE\"\n",
                                                         "updatedAt": "2025-08-19T19:37:20+08:00",
                                                         "rebootRequired": false,
                                                         "status": {
                                                             "current": "installed",
                                                             "isInstallable": false,
-                                                            "isRollbackable": false,
-                                                            "isProcessing": false
+                                                            "isRollbackable": true,
+                                                            "isProcessing": false,
+                                                            "isRemovable": false
                                                         }
                                                     },
                                                     {
-                                                        "version": "FIX_003",
-                                                        "note": "A sample fixpack that can not be removed and backs up hex_config",
-                                                        "updatedAt": "2025-08-14T22:59:57+08:00",
+                                                        "version": "FIX_002",
+                                                        "name": "Success",
+                                                        "note": "A sample fixpack that touches a single file and backups hex_config",
+                                                        "details": "FIXPACK_ID=\"FIX_002\"\nFIXPACK_NAME=\"Success\"\nFIXPACK_DESCRIPTION=\"A sample fixpack that touches a single file and backups hex_config\"\n",
+                                                        "updatedAt": "2025-08-14T22:58:44+08:00",
                                                         "rebootRequired": false,
                                                         "status": {
                                                             "current": "installed",
                                                             "isInstallable": false,
-                                                            "isRollbackable": false,
-                                                            "isProcessing": false
+                                                            "isRollbackable": true,
+                                                            "isProcessing": false,
+                                                            "isRemovable": false
                                                         }
                                                     }
                                                 ],
@@ -20702,7 +20708,9 @@
                                     "type": "object",
                                     "required": [
                                         "version",
+                                        "name",
                                         "note",
+                                        "details",
                                         "updatedAt",
                                         "rebootRequired",
                                         "status"
@@ -20711,7 +20719,13 @@
                                         "version": {
                                             "type": "string"
                                         },
+                                        "name": {
+                                            "type": "string"
+                                        },
                                         "note": {
+                                            "type": "string"
+                                        },
+                                        "details": {
                                             "type": "string"
                                         },
                                         "updatedAt": {
@@ -20727,7 +20741,8 @@
                                                 "current",
                                                 "isInstallable",
                                                 "isRollbackable",
-                                                "isProcessing"
+                                                "isProcessing",
+                                                "isRemovable"
                                             ],
                                             "properties": {
                                                 "current": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -13597,13 +13597,14 @@
                                             "data": {
                                                 "firmwares": [
                                                     {
-                                                        "version": "CUBE Appliance 3.1.0 f45c719",
-                                                        "releaseNotes": "",
+                                                        "version": "CUBE Appliance 3.1.0",
+                                                        "releaseNotes": "The CubeCOS 3.1.0(f45c719) firmware release since 2025-08-11T09:09:00+08:00",
                                                         "updatedAt": "2025-08-11T09:09:00+08:00",
                                                         "status": {
                                                             "current": "available",
                                                             "isUpdatable": true,
-                                                            "isProcessing": false
+                                                            "isProcessing": false,
+                                                            "isRemovable": true
                                                         }
                                                     }
                                                 ],
@@ -20587,7 +20588,8 @@
                                             "required": [
                                                 "current",
                                                 "isUpdatable",
-                                                "isProcessing"
+                                                "isProcessing",
+                                                "isRemovable"
                                             ],
                                             "properties": {
                                                 "current": {
@@ -20602,6 +20604,9 @@
                                                     "type": "boolean"
                                                 },
                                                 "isProcessing": {
+                                                    "type": "boolean"
+                                                },
+                                                "isRemovable": {
                                                     "type": "boolean"
                                                 }
                                             }

--- a/internal/apis/v1/handlers/fixpacks/paginate.go
+++ b/internal/apis/v1/handlers/fixpacks/paginate.go
@@ -25,7 +25,7 @@ func (h *helper) paginateFixpacks(list []fixpacks.Fixpack) []fixpacks.Fixpack {
 
 func (h *helper) sortFixpacks(list *[]fixpacks.Fixpack) {
 	sort.Slice(*list, func(i, j int) bool {
-		return (*list)[i].UpdatedAt > (*list)[j].UpdatedAt
+		return (*list)[i].Version < (*list)[j].Version
 	})
 }
 

--- a/internal/cubecos/firmware.go
+++ b/internal/cubecos/firmware.go
@@ -20,7 +20,7 @@ func ListFirmwares() ([]firmwares.Firmware, error) {
 		return nil, err
 	}
 
-	firmwares := convertToFirmwares(update)
+	firmwares := convertHistoryToFirmwares(update)
 	firmwares = removeFreshInstalledFirmwares(firmwares)
 	appendUninstalledFirmwares(&firmwares)
 
@@ -62,14 +62,19 @@ func parseUpdateHistory() (*firmwares.Upadte, error) {
 	return update, nil
 }
 
-func convertToFirmwares(update *firmwares.Upadte) []firmwares.Firmware {
+func convertHistoryToFirmwares(update *firmwares.Upadte) []firmwares.Firmware {
 	firmwaresList := make([]firmwares.Firmware, 0, len(update.History))
 
 	for _, raw := range update.History {
+		date := convertRawTime(time.FormatFirmware, raw.CreatedAt)
 		firmwaresList = append(firmwaresList, firmwares.Firmware{
-			Version:   fmt.Sprintf("%s Appliance %s %s", raw.Image, raw.Version, raw.Variant),
-			UpdatedAt: convertRawTime(time.FormatFirmware, raw.CreatedAt),
-			Status:    status.Firmware{Current: status.Updated},
+			Version:      convertFirmwareVersion(raw.Version),
+			ReleaseNotes: convertReleaseNotes(raw.Version, raw.Variant, date),
+			UpdatedAt:    date,
+			Status: status.Firmware{
+				Current:     status.Updated,
+				IsRemovable: false,
+			},
 		})
 	}
 
@@ -135,12 +140,23 @@ func convertPkgNameToFirmware(pkgname string) (*firmwares.Firmware, error) {
 		return nil, err
 	}
 
+	date := convertRawTime(time.FormatFirmwarePkg, segment[2])
 	return &firmwares.Firmware{
-		Version:   fmt.Sprintf("%s Appliance %s %s", segment[0], segment[1], segment[3]),
-		UpdatedAt: convertRawTime(time.FormatFirmwarePkg, segment[2]),
+		Version:      convertFirmwareVersion(segment[1]),
+		ReleaseNotes: convertReleaseNotes(segment[1], segment[3], date),
+		UpdatedAt:    date,
 		Status: status.Firmware{
 			Current:     status.Available,
 			IsUpdatable: true,
+			IsRemovable: true,
 		},
 	}, nil
+}
+
+func convertFirmwareVersion(version string) string {
+	return fmt.Sprintf("Cube Appliance %s", version)
+}
+
+func convertReleaseNotes(version, variant, date string) string {
+	return fmt.Sprintf("The CubeCOS %s(%s) firmware release since %s", version, variant, date)
 }

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -152,8 +152,8 @@ func getFixpackInfo(file string) (*fixpacks.Raw, error) {
 	}
 
 	raw := &fixpacks.Raw{Details: string(info)}
-	lines := strings.Split(string(info), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(info), "\n")
+	for line := range lines {
 		segment := strings.Split(line, "=")
 		if len(segment) < 2 {
 			continue

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -2,6 +2,7 @@ package cubecos
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
+	"github.com/google/uuid"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -24,28 +26,30 @@ func ListFixpacks() ([]fixpacks.Fixpack, error) {
 		return nil, err
 	}
 
-	fixpacks, err := convertToFixpacks(out)
+	historyFixpacks, err := convertHistoryToFixpacks(out)
 	if err != nil {
 		log.Errorf("fixpacks: failed to convert fixpacks(%v)", err)
 		return nil, err
 	}
 
-	err = addUninstalledFixpacks(&fixpacks)
+	pkgFixpacks, err := convertPkgToFixpacks()
 	if err != nil {
-		log.Errorf("fixpacks: failed to add uninstalled fixpacks(%v)", err)
+		log.Errorf("fixpacks: failed to convert pkg to fixpacks(%v)", err)
 		return nil, err
 	}
 
-	return fixpacks, nil
+	return mergeFixpacks(
+		historyFixpacks,
+		pkgFixpacks,
+	), nil
 }
 
-func convertToFixpacks(out []byte) ([]fixpacks.Fixpack, error) {
+func convertHistoryToFixpacks(out []byte) ([]fixpacks.Fixpack, error) {
 	fixpacksList := []fixpacks.Fixpack{}
 	lines := strings.SplitSeq(string(out), "\n")
 	for line := range lines {
 		segments := strings.Split(line, "|")
 		if len(segments) < 6 {
-			log.Warnf("fixpacks: invalid fixpack line(%s)", line)
 			continue
 		}
 
@@ -62,11 +66,12 @@ func convertToFixpacks(out []byte) ([]fixpacks.Fixpack, error) {
 	return fixpacksList, nil
 }
 
-func addUninstalledFixpacks(list *[]fixpacks.Fixpack) error {
+func convertPkgToFixpacks() ([]fixpacks.Fixpack, error) {
+	list := []fixpacks.Fixpack{}
 	entries, err := os.ReadDir(fixpacks.UpdateDir)
 	if err != nil {
 		log.Errorf("fixpack(%s): failed to read update directory %s(%v)", fixpacks.UpdateDir, err)
-		return err
+		return nil, err
 	}
 
 	for _, entry := range entries {
@@ -79,9 +84,16 @@ func addUninstalledFixpacks(list *[]fixpacks.Fixpack) error {
 			continue
 		}
 
-		*list = append(*list, fixpacks.Fixpack{
-			Version: entry.Name(),
-			Note:    "Uninstalled fixpack",
+		info, err := getFixpackInfo(file)
+		if err != nil {
+			continue
+		}
+
+		list = append(list, fixpacks.Fixpack{
+			Version: info.Id,
+			Name:    info.Name,
+			Note:    info.Description,
+			Details: info.Details,
 			Status: status.Fixpack{
 				Current:       status.Available,
 				IsInstallable: true,
@@ -89,7 +101,34 @@ func addUninstalledFixpacks(list *[]fixpacks.Fixpack) error {
 		})
 	}
 
-	return nil
+	return list, nil
+}
+
+func mergeFixpacks(history, pkgs []fixpacks.Fixpack) []fixpacks.Fixpack {
+	merged := make(map[string]fixpacks.Fixpack)
+	for _, fixpack := range history {
+		merged[fixpack.Version] = fixpack
+	}
+
+	for _, pkg := range pkgs {
+		history, found := merged[pkg.Version]
+		if !found {
+			merged[pkg.Version] = pkg
+			continue
+		}
+
+		history.Name = pkg.Name
+		history.Note = pkg.Note
+		history.Details = pkg.Details
+		merged[pkg.Version] = history
+	}
+
+	fixpacks := make([]fixpacks.Fixpack, 0, len(merged))
+	for _, fixpack := range merged {
+		fixpacks = append(fixpacks, fixpack)
+	}
+
+	return fixpacks
 }
 
 func convertFixpackStatus(rollback, action string) status.Fixpack {
@@ -104,4 +143,90 @@ func convertFixpackStatus(rollback, action string) status.Fixpack {
 	}
 
 	return status
+}
+
+func getFixpackInfo(file string) (*fixpacks.Raw, error) {
+	info, err := parseFixpackInfo(file)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := &fixpacks.Raw{Details: string(info)}
+	lines := strings.Split(string(info), "\n")
+	for _, line := range lines {
+		segment := strings.Split(line, "=")
+		if len(segment) < 2 {
+			continue
+		}
+
+		key := segment[0]
+		val := strings.ReplaceAll(segment[1], "\"", "")
+		switch key {
+		case "FIXPACK_ID":
+			raw.Id = val
+		case "FIXPACK_NAME":
+			raw.Name = val
+		case "SUPPORTED_FIRMWARES":
+			raw.SupportedFirmwares = strings.Split(val, ",")
+		case "FIXPACK_DESCRIPTION":
+			raw.Description = val
+		}
+	}
+
+	return raw, nil
+}
+
+func genTmpFixpackDir() (string, error) {
+	hash := uuid.New().String()[:8]
+	dir := fmt.Sprintf("/tmp/fixpack-%s", hash)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		log.Errorf("fixpack: failed to create tmp fixpack dir %s(%v)", dir, err)
+		return "", err
+	}
+
+	return dir, nil
+}
+
+func parseFixpackInfo(file string) ([]byte, error) {
+	tmpDir, err := genTmpFixpackDir()
+	if err != nil {
+		return nil, err
+	}
+
+	defer unmountTmpDir(tmpDir)
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "mount", file, tmpDir).CombinedOutput()
+	if err != nil {
+		err := fmt.Errorf("failed to mount fixpack %s(%v %s)", file, err, string(out))
+		log.Errorf("fixpack: %v", err)
+		return nil, err
+	}
+
+	infoPath := filepath.Join(tmpDir, "fixpack.info")
+	bytes, err := os.ReadFile(infoPath)
+	if err != nil {
+		err := fmt.Errorf("failed to read fixpack info(%v)", err)
+		log.Errorf("fixpack: %v", err)
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+func unmountTmpDir(tmpDir string) {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "umount", tmpDir).CombinedOutput()
+	if err != nil {
+		log.Errorf("fixpack: failed to unmount tmp dir %s(%v %s)", tmpDir, err, string(out))
+	}
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		log.Errorf("fixpack: failed to remove tmp dir %s(%v)", tmpDir, err)
+	}
 }

--- a/internal/definition/v1/fixpacks/fixpack.go
+++ b/internal/definition/v1/fixpacks/fixpack.go
@@ -15,9 +15,19 @@ const (
 type InstallReqOpts struct {
 }
 
+type Raw struct {
+	Id                 string   `json:"id" bson:"id"`
+	Name               string   `json:"name" bson:"name"`
+	SupportedFirmwares []string `json:"supportedFirmwares" bson:"supportedFirmwares"`
+	Description        string   `json:"description" bson:"description"`
+	Details            string   `json:"details"`
+}
+
 type Fixpack struct {
 	Version        string         `json:"version"`
+	Name           string         `json:"name"`
 	Note           string         `json:"note"`
+	Details        string         `json:"details"`
 	UpdatedAt      string         `json:"updatedAt"`
 	RebootRequired bool           `json:"rebootRequired"`
 	Status         status.Fixpack `json:"status"`

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -164,6 +164,7 @@ type Fixpack struct {
 	IsInstallable  bool   `json:"isInstallable" bson:"isInstallable"`
 	IsRollbackable bool   `json:"isRollbackable" bson:"isRollbackable"`
 	IsProcessing   bool   `json:"isProcessing" bson:"isProcessing"`
+	IsRemovable    bool   `json:"isRemovable" bson:"isRemovable"`
 	Description    string `json:"description,omitempty" bson:"description"`
 }
 

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -154,6 +154,7 @@ type Firmware struct {
 	Desired      string `json:"-" bson:"desired"`
 	IsUpdatable  bool   `json:"isUpdatable" bson:"isUpdatable"`
 	IsProcessing bool   `json:"isProcessing" bson:"isProcessing"`
+	IsRemovable  bool   `json:"isRemovable" bson:"isRemovable"`
 	Description  string `json:"description,omitempty" bson:"description"`
 }
 


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/272

https://github.com/bigstack-oss/cubecos/issues/271

<br/>

### What this PR does?

- Firmware listing api: adjust the content convention

- Fixpack listing api: enrich the fixpack details by correcting the parsing logic for fixpack info

- Both: add `status.IsRemovable` for both items 

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1435" height="814" alt="Screenshot 2025-08-20 at 4 48 52 PM" src="https://github.com/user-attachments/assets/564e3c21-0e60-4223-a828-a281fa0d47a9" />

<img width="1435" height="711" alt="Screenshot 2025-08-20 at 4 49 05 PM" src="https://github.com/user-attachments/assets/ed69c51d-2ade-4fbf-87ee-ca67651c96c0" />

<br/>
<br/>
<br/>

2). make sure the api works properly

<img width="1493" height="1035" alt="Screenshot 2025-08-20 at 4 47 59 PM" src="https://github.com/user-attachments/assets/5c38120b-9673-45a1-8f6f-ae0ada571193" />

<img width="935" height="583" alt="Screenshot 2025-08-20 at 4 48 10 PM" src="https://github.com/user-attachments/assets/03ae847a-03a6-43e1-aa73-66c7e3ae8587" />
