### PR TITLE
Add a GET API to list the nodes that can be updated with the specified fixpack

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -14169,7 +14169,7 @@ const docTemplate = `{
         },
         "/api/v1/datacenters/{dataCenter}/firmwares/{version}/updatableNodes": {
             "get": {
-                "operationId": "listUpdatableNodes",
+                "operationId": "listFirmwareUpdatableNodes",
                 "tags": [
                     "Firmwares"
                 ],
@@ -14893,6 +14893,120 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to delete fixpack: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/updatableNodes": {
+            "get": {
+                "operationId": "listFixpackUpdatableNodes",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "Get nodes that can be updated with the specified fixpack",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/version"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of nodes that can be updated with the specified fixpack",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListFixpackUpdatableNodesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Updatable nodes",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "name": "cube451",
+                                                    "version": "Cube Appliance 3.1.0",
+                                                    "updatedAt": "2025-08-08T19:51:40+08:00"
+                                                },
+                                                {
+                                                    "name": "cube452",
+                                                    "version": "Cube Appliance 3.1.0",
+                                                    "updatedAt": "2025-08-08T19:51:40+08:00"
+                                                },
+                                                {
+                                                    "name": "cube453",
+                                                    "version": "Cube Appliance 3.1.0",
+                                                    "updatedAt": "2025-08-08T19:51:40+08:00"
+                                                }
+                                            ],
+                                            "msg": "Fetched updatable nodes successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "'FIX_001' not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to list updatable nodes: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -20914,6 +21028,49 @@ const docTemplate = `{
                             },
                             "page": {
                                 "$ref": "#/components/schemas/Page"
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ListFixpackUpdatableNodesResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name",
+                                "version",
+                                "updatedAt"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "type": "string"
+                                },
+                                "updatedAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                }
                             }
                         }
                     },

--- a/api/docs.json
+++ b/api/docs.json
@@ -14165,7 +14165,7 @@
         },
         "/api/v1/datacenters/{dataCenter}/firmwares/{version}/updatableNodes": {
             "get": {
-                "operationId": "listUpdatableNodes",
+                "operationId": "listFirmwareUpdatableNodes",
                 "tags": [
                     "Firmwares"
                 ],
@@ -14889,6 +14889,120 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to delete fixpack: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/updatableNodes": {
+            "get": {
+                "operationId": "listFixpackUpdatableNodes",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "Get nodes that can be updated with the specified fixpack",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/version"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of nodes that can be updated with the specified fixpack",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListFixpackUpdatableNodesResponse"
+                                },
+                                "examples": {
+                                    "example": {
+                                        "summary": "Updatable nodes",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "name": "cube451",
+                                                    "version": "Cube Appliance 3.1.0",
+                                                    "updatedAt": "2025-08-08T19:51:40+08:00"
+                                                },
+                                                {
+                                                    "name": "cube452",
+                                                    "version": "Cube Appliance 3.1.0",
+                                                    "updatedAt": "2025-08-08T19:51:40+08:00"
+                                                },
+                                                {
+                                                    "name": "cube453",
+                                                    "version": "Cube Appliance 3.1.0",
+                                                    "updatedAt": "2025-08-08T19:51:40+08:00"
+                                                }
+                                            ],
+                                            "msg": "Fetched updatable nodes successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "'FIX_001' not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to list updatable nodes: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -20910,6 +21024,49 @@
                             },
                             "page": {
                                 "$ref": "#/components/schemas/Page"
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ListFixpackUpdatableNodesResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name",
+                                "version",
+                                "updatedAt"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "type": "string"
+                                },
+                                "updatedAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                }
                             }
                         }
                     },

--- a/internal/apis/v1/handlers/fixpacks/filter.go
+++ b/internal/apis/v1/handlers/fixpacks/filter.go
@@ -1,0 +1,31 @@
+package fixpacks
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	log "go-micro.dev/v5/logger"
+)
+
+func (h *helper) filterUnsupportedNodes(nodes []node) ([]node, error) {
+	fixpack, found := cubecos.GetFixpackByVersion(h.version)
+	if !found {
+		err := fmt.Errorf("fixpack version %s not found", h.version)
+		log.Errorf("fixpack(%s): %s", h.reqId, err)
+		return nil, err
+	}
+
+	if len(fixpack.SupportedFirmwares) == 0 {
+		return nodes, nil
+	}
+
+	supported := make([]node, 0, len(nodes))
+	for _, node := range nodes {
+		if slices.Contains(fixpack.SupportedFirmwares, node.Version) {
+			supported = append(supported, node)
+		}
+	}
+
+	return supported, nil
+}

--- a/internal/apis/v1/handlers/fixpacks/handlers.go
+++ b/internal/apis/v1/handlers/fixpacks/handlers.go
@@ -37,6 +37,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/fixpacks/:version/updatableNodes",
+			Func:    listUpdatableNodes,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodPost,
 			Path:    "/fixpacks/continueAnyway",
 			Func:    continueInterruptedFixpackUpdate,
@@ -155,6 +161,27 @@ func verfiyFixpackAndMd5Sum(c *gin.Context) {
 		c,
 		"Fixpack and MD5 sum verified successfully",
 		result,
+	)
+}
+
+func listUpdatableNodes(c *gin.Context) {
+	h, err := initHelper(c, "listUpdatableNodes")
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	nodes, err := h.listUpdatableNodes()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"List of updatable nodes",
+		nodes,
 	)
 }
 

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -1,13 +1,16 @@
 package fixpacks
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/pages"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
@@ -51,6 +54,35 @@ func (h *helper) listFixpacks() (*fixpacksPage, error) {
 		Fixpacks: h.paginateFixpacks(fixpackss),
 		Page:     h.genPageInfo(fixpackss),
 	}, nil
+}
+
+func (h *helper) listUpdatableNodes() ([]node, error) {
+	list := nodes.List()
+	if len(list) == 0 {
+		return nil, fmt.Errorf("no nodes found")
+	}
+
+	updatables := h.convertToUpdatableNodes(list)
+	updatables, err := h.filterUnsupportedNodes(updatables)
+	if err != nil {
+		return nil, err
+	}
+
+	h.sortUpdatableNodes(&updatables)
+	return updatables, nil
+}
+
+func (h *helper) convertToUpdatableNodes(list []nodes.Node) []node {
+	updatables := make([]node, 0, len(list))
+	for _, n := range list {
+		updatables = append(updatables, node{
+			Name:      n.Hostname,
+			Version:   n.Firmware.Active,
+			UpdatedAt: base.ActiveFirmwareUpdatedAt,
+		})
+	}
+
+	return updatables
 }
 
 func (h *helper) continueInterruptedFixpackUpdate() error {

--- a/internal/apis/v1/handlers/fixpacks/parse.go
+++ b/internal/apis/v1/handlers/fixpacks/parse.go
@@ -23,6 +23,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseUploadMd5Params()
 	case "verfiyFixpackAndMd5Sum":
 		return h.parseVerificationParams()
+	case "listUpdatableNodes":
+		return h.parseListUpdatableParams()
 	case "deleteFixpack":
 		return h.parseDeleteFixpackParams()
 	default:
@@ -74,7 +76,24 @@ func (h *helper) parseVerificationParams() error {
 		}
 	}
 
-	return fmt.Errorf("no fixpack file found in %s", fixpacks.TmpUploadDir)
+	return fmt.Errorf(
+		"no fixpack file found in %s",
+		fixpacks.TmpUploadDir,
+	)
+}
+
+func (h *helper) parseListUpdatableParams() error {
+	h.version = h.c.Param("version")
+	if h.version == "" {
+		return fmt.Errorf("version parameter is required")
+	}
+
+	_, found := cubecos.GetFixpackByVersion(h.version)
+	if !found {
+		return fmt.Errorf("fixpack version %s not found", h.version)
+	}
+
+	return nil
 }
 
 func (h *helper) parseDeleteFixpackParams() error {
@@ -84,7 +103,7 @@ func (h *helper) parseDeleteFixpackParams() error {
 	}
 
 	found := false
-	h.file, found = cubecos.GetFixpackFileByVersion(h.version)
+	h.file, found = cubecos.GetFixpackPathByVersion(h.version)
 	if !found {
 		return fmt.Errorf("fixpack version %s not found", h.version)
 	}

--- a/internal/apis/v1/handlers/fixpacks/resp.go
+++ b/internal/apis/v1/handlers/fixpacks/resp.go
@@ -1,0 +1,7 @@
+package fixpacks
+
+type node struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	UpdatedAt string `json:"updatedAt"`
+}

--- a/internal/apis/v1/handlers/fixpacks/sort.go
+++ b/internal/apis/v1/handlers/fixpacks/sort.go
@@ -1,0 +1,11 @@
+package fixpacks
+
+import (
+	"sort"
+)
+
+func (h *helper) sortUpdatableNodes(nodes *[]node) {
+	sort.Slice(*nodes, func(i, j int) bool {
+		return (*nodes)[i].UpdatedAt > (*nodes)[j].UpdatedAt
+	})
+}

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -44,7 +44,37 @@ func ListFixpacks() ([]fixpacks.Fixpack, error) {
 	), nil
 }
 
-func GetFixpackFileByVersion(version string) (string, bool) {
+func GetFixpackByVersion(version string) (*fixpacks.Raw, bool) {
+	entries, err := os.ReadDir(fixpacks.UpdateDir)
+	if err != nil {
+		log.Errorf("fixpack(%s): failed to read update directory %s(%v)", fixpacks.UpdateDir, err)
+		return nil, false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		file := filepath.Join(fixpacks.UpdateDir, entry.Name())
+		if !strings.HasSuffix(file, ".fixpack") {
+			continue
+		}
+
+		info, err := getFixpackInfo(file)
+		if err != nil {
+			continue
+		}
+
+		if strings.EqualFold(info.Id, version) {
+			return info, true
+		}
+	}
+
+	return nil, false
+}
+
+func GetFixpackPathByVersion(version string) (string, bool) {
 	entries, err := os.ReadDir(fixpacks.UpdateDir)
 	if err != nil {
 		log.Errorf("fixpack(%s): failed to read update directory %s(%v)", fixpacks.UpdateDir, err)


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/286

<br/>

### What this PR does?

- Add a GET API to list the nodes that can be updated with the specified fixpack

- Add the corresponding api doc

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1283" height="926" alt="Screenshot 2025-08-21 at 10 22 25 PM" src="https://github.com/user-attachments/assets/7526dc2b-b754-4463-956e-62a9f5628ea0" />

<br/>
<br/>
<br/>

<img width="1429" height="673" alt="Screenshot 2025-08-21 at 10 21 55 PM" src="https://github.com/user-attachments/assets/443bcb94-9385-4297-962f-bb17082d1169" />

<br/>
<br/>
<br/>

<img width="1434" height="499" alt="Screenshot 2025-08-21 at 10 21 46 PM" src="https://github.com/user-attachments/assets/87fcfabb-6b50-422a-97e9-d8300540d1ac" />

<br/>
<br/>
<br/>

2). make sure the api works properly

<img width="897" height="522" alt="Screenshot 2025-08-21 at 10 16 01 PM" src="https://github.com/user-attachments/assets/9f802cde-ee35-4fb8-a920-1ca64b1fc6e0" />
