### PR TITLE
Add a POST API to rollback fixpack with a specific version

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -15050,6 +15050,165 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/rollback": {
+            "post": {
+                "operationId": "rollbackFixpack",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "Rollback a fixpack",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/version"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Fixpack rollback started successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "Fixpack rollback started successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "fixpack version FIX_001 is not rollbackable"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "'FIX_001' not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "a fixpack operation is already in progress"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to start fixpack rollback: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/updatableNodes": {
             "get": {
                 "operationId": "listFixpackUpdatableNodes",

--- a/api/docs.json
+++ b/api/docs.json
@@ -15046,6 +15046,165 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/rollback": {
+            "post": {
+                "operationId": "rollbackFixpack",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "Rollback a fixpack",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/version"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Fixpack rollback started successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "Fixpack rollback started successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "fixpack version FIX_001 is not rollbackable"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "'FIX_001' not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "a fixpack operation is already in progress"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to start fixpack rollback: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/updatableNodes": {
             "get": {
                 "operationId": "listFixpackUpdatableNodes",

--- a/internal/apis/v1/handlers/fixpacks/delegation.go
+++ b/internal/apis/v1/handlers/fixpacks/delegation.go
@@ -21,21 +21,21 @@ var (
 	reqQueue = fixpacks.ReqQueue
 )
 
-func (h *helper) delegateToLocal(updatables []node) {
-	for _, updatable := range updatables {
-		if nodes.IsLocal(updatable.Name) {
+func (h *helper) delegateToLocal(list []node) {
+	for _, node := range list {
+		if nodes.IsLocal(node.Name) {
 			reqQueue.Add(&h.reqOpts)
-			h.addReqRecord(updatable.Name)
+			h.addReqRecord(node.Name)
 			return
 		}
 	}
 }
 
-func (h *helper) delegateToPeers(updatables []node) {
-	for _, updatable := range updatables {
-		node, err := nodes.Get(updatable.Name)
+func (h *helper) delegateToPeers(list []node) {
+	for _, peer := range list {
+		node, err := nodes.Get(peer.Name)
 		if err != nil {
-			log.Warnf("fixpacks(%s): failed to get node %s (%v)", h.reqId, updatable.Name, err)
+			log.Warnf("fixpacks(%s): failed to get node %s (%v)", h.reqId, peer.Name, err)
 			continue
 		}
 
@@ -77,6 +77,8 @@ func (h *helper) getUrlByHandler(node nodes.Node) string {
 	switch h.handler {
 	case "installFixpack":
 		return node.PatchFixpackUrl()
+	case "rollbackFixpack":
+		return node.PostFixpackRollbackUrl(h.reqOpts.Version)
 	default:
 		return node.PatchFixpackUrl()
 	}

--- a/internal/apis/v1/handlers/fixpacks/delegation.go
+++ b/internal/apis/v1/handlers/fixpacks/delegation.go
@@ -139,7 +139,7 @@ func (h *helper) syncFixpackToPeerNode(node nodes.Node) error {
 		return err
 	}
 
-	authMethod, err := h.genSshAuth()
+	sshAuth, err := h.genSshAuth()
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (h *helper) syncFixpackToPeerNode(node nodes.Node) error {
 	ssh, err := ssh.NewHelper(
 		ssh.Host(fmt.Sprintf("%s:22", node.Hostname)),
 		ssh.User("root"),
-		ssh.AuthMethod(authMethod),
+		ssh.AuthMethod(sshAuth),
 		ssh.HostKeyCallback(cryptossh.InsecureIgnoreHostKey()),
 	)
 	if err != nil {

--- a/internal/apis/v1/handlers/fixpacks/filter.go
+++ b/internal/apis/v1/handlers/fixpacks/filter.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *helper) filterUnsupportedNodes(nodes []node, version string) ([]node, error) {
-	fixpack, found := cubecos.GetFixpackByVersion(version)
+	fixpack, found := cubecos.GetFixpackRawByVersion(version)
 	if !found {
 		err := fmt.Errorf("fixpack version %s not found", version)
 		log.Errorf("fixpack(%s): %s", h.reqId, err)

--- a/internal/apis/v1/handlers/fixpacks/handlers.go
+++ b/internal/apis/v1/handlers/fixpacks/handlers.go
@@ -50,6 +50,12 @@ var (
 		{
 			Version: apis.V1,
 			Method:  http.MethodPost,
+			Path:    "/fixpacks/rollback",
+			Func:    rollbackFixpack,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPost,
 			Path:    "/fixpacks/continueAnyway",
 			Func:    continueInterruptedFixpackUpdate,
 		},
@@ -226,6 +232,32 @@ func installFixpack(c *gin.Context) {
 	bodies.SetAccepted(
 		c,
 		"Fixpack installation started successfully",
+	)
+}
+
+func rollbackFixpack(c *gin.Context) {
+	h, err := initHelper(c, "rollbackFixpack")
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.checkEnvConditions()
+	if err != nil {
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.rollbackFixpack()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetAccepted(
+		c,
+		"Fixpack rollback started successfully",
 	)
 }
 

--- a/internal/apis/v1/handlers/fixpacks/handlers.go
+++ b/internal/apis/v1/handlers/fixpacks/handlers.go
@@ -50,14 +50,14 @@ var (
 		{
 			Version: apis.V1,
 			Method:  http.MethodPost,
-			Path:    "/fixpacks/rollback",
-			Func:    rollbackFixpack,
+			Path:    "/fixpacks/continueAnyway",
+			Func:    continueInterruptedFixpackUpdate,
 		},
 		{
 			Version: apis.V1,
 			Method:  http.MethodPost,
-			Path:    "/fixpacks/continueAnyway",
-			Func:    continueInterruptedFixpackUpdate,
+			Path:    "/fixpacks/:version/rollback",
+			Func:    rollbackFixpack,
 		},
 		{
 			Version: apis.V1,
@@ -249,7 +249,13 @@ func rollbackFixpack(c *gin.Context) {
 		return
 	}
 
-	err = h.rollbackFixpack()
+	nodes, err := h.listUpdatableNodes(h.reqOpts.Version)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	err = h.rollbackFixpack(nodes)
 	if err != nil {
 		bodies.SetInternalServerError(c, err)
 		return

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -88,6 +88,10 @@ func (h *helper) installFixpack(updatables []node) error {
 	return nil
 }
 
+func (h *helper) rollbackFixpack() error {
+	return nil
+}
+
 func (h *helper) convertToUpdatableNodes(list []nodes.Node) []node {
 	updatables := make([]node, 0, len(list))
 	for _, n := range list {

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -88,7 +88,13 @@ func (h *helper) installFixpack(updatables []node) error {
 	return nil
 }
 
-func (h *helper) rollbackFixpack() error {
+func (h *helper) rollbackFixpack(updateds []node) error {
+	h.delegateToLocal(updateds)
+	if !cubecos.IsVirtualIpOwner(base.Hostname) {
+		return nil
+	}
+
+	h.delegateToPeers(updateds)
 	return nil
 }
 

--- a/internal/apis/v1/handlers/fixpacks/parse.go
+++ b/internal/apis/v1/handlers/fixpacks/parse.go
@@ -94,7 +94,7 @@ func (h *helper) parseListUpdatableParams() error {
 		return fmt.Errorf("version parameter is required")
 	}
 
-	_, found := cubecos.GetFixpackByVersion(h.version)
+	_, found := cubecos.GetFixpackRawByVersion(h.version)
 	if !found {
 		return fmt.Errorf("fixpack version %s not found", h.version)
 	}
@@ -122,6 +122,23 @@ func (h *helper) parseInstallParams() error {
 }
 
 func (h *helper) parseRollbackParams() error {
+	h.reqOpts.Version = h.c.Param("version")
+	if h.reqOpts.Version == "" {
+		return fmt.Errorf("version parameter is required")
+	}
+
+	found := false
+	_, found = cubecos.GetFixpackRawByVersion(h.reqOpts.Version)
+	if !found {
+		return fmt.Errorf("fixpack version %s not found", h.reqOpts.Version)
+	}
+
+	err := h.checkRollback(h.reqOpts.Version)
+	if err != nil {
+		return err
+	}
+
+	h.reqOpts.SetRollingBack()
 	return nil
 }
 

--- a/internal/apis/v1/handlers/fixpacks/parse.go
+++ b/internal/apis/v1/handlers/fixpacks/parse.go
@@ -27,6 +27,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseListUpdatableParams()
 	case "installFixpack":
 		return h.parseInstallParams()
+	case "rollbackFixpack":
+		return h.parseRollbackParams()
 	case "deleteFixpack":
 		return h.parseDeleteFixpackParams()
 	case "updateFixpackTask":
@@ -116,6 +118,10 @@ func (h *helper) parseInstallParams() error {
 
 	h.reqOpts.Path = path
 	h.reqOpts.SetInstalling()
+	return nil
+}
+
+func (h *helper) parseRollbackParams() error {
 	return nil
 }
 

--- a/internal/apis/v1/handlers/fixpacks/verify.go
+++ b/internal/apis/v1/handlers/fixpacks/verify.go
@@ -13,6 +13,19 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
+func (h *helper) checkRollback(version string) error {
+	fixpack, found := cubecos.GetFixpackByVersion(version)
+	if !found {
+		return fmt.Errorf("fixpack version %s not found", version)
+	}
+
+	if !fixpack.Status.IsRollbackable {
+		return fmt.Errorf("fixpack version %s is not rollbackable", version)
+	}
+
+	return nil
+}
+
 func (h *helper) checkEnvConditions() error {
 	if cubecos.IsInStrictMode() {
 		return fmt.Errorf("env is in the strict mode, cannot proceed with fixpack operations")

--- a/internal/cubecos/firmware.go
+++ b/internal/cubecos/firmware.go
@@ -133,7 +133,7 @@ func convertRawTime(layout, rawTime string) string {
 		return ""
 	}
 
-	return time.LocalRFC3339(t)
+	return time.Fixpack(t)
 }
 
 func convertPkgNameToFirmware(pkgname string) (*firmwares.Firmware, error) {

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/wait"
@@ -139,6 +140,16 @@ func RollbackFixpack() error {
 }
 
 func convertHistoryToFixpacks(out []byte) ([]fixpacks.Fixpack, error) {
+	fixpacks := parseHistoryFixpacks(out)
+
+	sort.Slice(fixpacks, func(i, j int) bool {
+		return (fixpacks)[i].UpdatedAt > (fixpacks)[j].UpdatedAt
+	})
+
+	return dedupFixpacks(fixpacks), nil
+}
+
+func parseHistoryFixpacks(out []byte) []fixpacks.Fixpack {
 	list := []fixpacks.Fixpack{}
 	lines := strings.SplitSeq(string(out), "\n")
 	for line := range lines {
@@ -155,7 +166,24 @@ func convertHistoryToFixpacks(out []byte) ([]fixpacks.Fixpack, error) {
 		})
 	}
 
-	return list, nil
+	return list
+}
+
+func dedupFixpacks(list []fixpacks.Fixpack) []fixpacks.Fixpack {
+	seen := make(map[string]fixpacks.Fixpack)
+	for _, fixpack := range list {
+		_, found := seen[fixpack.Version]
+		if !found {
+			seen[fixpack.Version] = fixpack
+		}
+	}
+
+	deduplicated := make([]fixpacks.Fixpack, 0, len(seen))
+	for _, fixpack := range seen {
+		deduplicated = append(deduplicated, fixpack)
+	}
+
+	return deduplicated
 }
 
 func convertPkgToFixpacks() ([]fixpacks.Fixpack, error) {
@@ -224,17 +252,17 @@ func mergeFixpacks(history, pkgs []fixpacks.Fixpack) []fixpacks.Fixpack {
 }
 
 func convertFixpackStatus(rollback, action string) status.Fixpack {
-	status := status.Fixpack{Current: "installed"}
-
+	s := status.Fixpack{Current: "installed"}
 	if strings.EqualFold(rollback, "yes") {
-		status.IsRollbackable = true
+		s.IsRollbackable = true
 	}
 
-	if strings.EqualFold(action, "installed") {
-		status.IsInstallable = false
+	if strings.EqualFold(action, "uninstalled") {
+		s.IsInstallable = true
+		s.Current = status.Available
 	}
 
-	return status
+	return s
 }
 
 func getFixpackInfo(file string) (*fixpacks.Raw, error) {

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -45,7 +45,22 @@ func ListFixpacks() ([]fixpacks.Fixpack, error) {
 	), nil
 }
 
-func GetFixpackByVersion(version string) (*fixpacks.Raw, bool) {
+func GetFixpackByVersion(version string) (*fixpacks.Fixpack, bool) {
+	fixpacks, err := ListFixpacks()
+	if err != nil {
+		return nil, false
+	}
+
+	for _, fixpack := range fixpacks {
+		if strings.EqualFold(fixpack.Version, version) {
+			return &fixpack, true
+		}
+	}
+
+	return nil, false
+}
+
+func GetFixpackRawByVersion(version string) (*fixpacks.Raw, bool) {
 	entries, err := os.ReadDir(fixpacks.UpdateDir)
 	if err != nil {
 		log.Errorf("fixpack(%s): failed to read update directory %s(%v)", fixpacks.UpdateDir, err)

--- a/internal/definition/v1/fixpacks/fixpack.go
+++ b/internal/definition/v1/fixpacks/fixpack.go
@@ -55,8 +55,8 @@ func (r *ReqOpts) SetInstalling() {
 	r.Status.IsProcessing = true
 }
 
-func (r *ReqOpts) SetRollbacking() {
-	r.Status.Current = status.Rollbacking
+func (r *ReqOpts) SetRollingBack() {
+	r.Status.Current = status.RollingBack
 	r.Status.Desired = status.Rollbacked
 	r.Status.IsProcessing = true
 }

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -296,6 +296,12 @@ func (n *Node) PatchFixpackUrl() string {
 	return u.String()
 }
 
+func (n *Node) PostFixpackRollbackUrl(version string) string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/fixpacks/%s/rollback", base.DataCenterName, version)
+	return u.String()
+}
+
 func (n *Node) UpdateFixpackTaskUrl() string {
 	u := n.GenUrl()
 	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/fixpacks/tasks", base.DataCenterName)

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -28,7 +28,7 @@ const (
 	Removing             = "removing"
 	Expairing            = "expairing"
 	Fixing               = "fixing"
-	Rollbacking          = "rollbacking"
+	RollingBack          = "rollingBack"
 	PoweringOn           = "powering on"
 	PoweringOff          = "powering off"
 	PoweringCycle        = "powering cycle"

--- a/internal/definition/v1/time/time.go
+++ b/internal/definition/v1/time/time.go
@@ -93,6 +93,10 @@ func Boot() string {
 	return ISO8601Z(bootTime)
 }
 
+func Fixpack(t time.Time) string {
+	return RFC3339Z(t)
+}
+
 func TimeISO8601Z(t time.Time) string {
 	return t.Format(FormatISO8601Z)
 }


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/319

<br/>

### What this PR does?

- Add a POST API to rollback fixpack with a specific version

- Add the corresponding API doc

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1292" height="448" alt="Screenshot 2025-08-24 at 4 30 00 PM" src="https://github.com/user-attachments/assets/bcf578f0-08b9-4215-8b63-039e3d3ffa91" />

<img width="1142" height="984" alt="Screenshot 2025-08-24 at 4 30 17 PM" src="https://github.com/user-attachments/assets/c947a373-8587-4006-9eea-bd90028f4e08" />

<br/>
<br/>

2). make sure the api works properly

<img width="1231" height="855" alt="Screenshot 2025-08-24 at 4 19 43 PM" src="https://github.com/user-attachments/assets/4a9d66d1-8a05-4f20-bbc9-d85b8f7aa4a7" />

<br/>
<br/>

try to rollback the installed `FIX_001`

```bash
# curl -k -X POST "https://10.32.45.10/api/v1/datacenters/cube450/fixpacks/FIX_001/rollback" -H "Authorization: Bearer ${TOKEN}"
{"code":202,"msg":"Fixpack rollback started successfully","status":"accepted"}
```

<img width="1252" height="850" alt="Screenshot 2025-08-24 at 4 22 26 PM" src="https://github.com/user-attachments/assets/b42cce54-a5fa-41d9-bc96-4d8e4a16a011" />

<br/>
<br/>

make sure the rollback of uninstalled `FIX_002` is being rejected

```bash
# curl -k -X POST "https://10.32.45.10/api/v1/datacenters/cube450/fixpacks/FIX_002/rollback" -H "Authorization: Bearer ${TOKEN}"
{"code":400,"msg":"fixpack version FIX_002 is not rollbackable","status":"bad request"}
```