### PR TITLE
Add GET /fixpacks/{version} API to list the fixpack operation progress from each host

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -14950,6 +14950,128 @@ const docTemplate = `{
             }
         },
         "/api/v1/datacenters/{dataCenter}/fixpacks/{version}": {
+            "get": {
+                "operationId": "getFixpackProgress",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "Get the progress of a fixpack operation",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/version"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Fixpack operation progress",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FixpackProgressResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Fixpack operation progress",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "host": "example-node-0",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 50,
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-1",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 50,
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-2",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 50,
+                                                        "description": ""
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "Fetched fixpack progress successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "'FIX_001' not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to get fixpack progress: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "'internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "operationId": "deleteFixpack",
                 "tags": [
@@ -21392,6 +21514,75 @@ const docTemplate = `{
                 ],
                 "properties": {
                     "version": {
+                        "type": "string"
+                    }
+                }
+            },
+            "FixpackProgressResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "host",
+                                "phase",
+                                "status"
+                            ],
+                            "properties": {
+                                "host": {
+                                    "type": "string"
+                                },
+                                "phase": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "required": [
+                                        "current",
+                                        "isProcessing",
+                                        "processPercent",
+                                        "description"
+                                    ],
+                                    "properties": {
+                                        "current": {
+                                            "type": "string",
+                                            "enum": [
+                                                "available",
+                                                "installing",
+                                                "installed",
+                                                "rolling back",
+                                                "failed"
+                                            ]
+                                        },
+                                        "isProcessing": {
+                                            "type": "boolean"
+                                        },
+                                        "processPercent": {
+                                            "type": "number"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
                         "type": "string"
                     }
                 }

--- a/api/docs.json
+++ b/api/docs.json
@@ -14946,6 +14946,128 @@
             }
         },
         "/api/v1/datacenters/{dataCenter}/fixpacks/{version}": {
+            "get": {
+                "operationId": "getFixpackProgress",
+                "tags": [
+                    "Fixpacks"
+                ],
+                "summary": "Get the progress of a fixpack operation",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/version"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Fixpack operation progress",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FixpackProgressResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Fixpack operation progress",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "host": "example-node-0",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 50,
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-1",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 50,
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-2",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 50,
+                                                        "description": ""
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "Fetched fixpack progress successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "'FIX_001' not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to get fixpack progress: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "'internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "operationId": "deleteFixpack",
                 "tags": [
@@ -21388,6 +21510,75 @@
                 ],
                 "properties": {
                     "version": {
+                        "type": "string"
+                    }
+                }
+            },
+            "FixpackProgressResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "host",
+                                "phase",
+                                "status"
+                            ],
+                            "properties": {
+                                "host": {
+                                    "type": "string"
+                                },
+                                "phase": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "required": [
+                                        "current",
+                                        "isProcessing",
+                                        "processPercent",
+                                        "description"
+                                    ],
+                                    "properties": {
+                                        "current": {
+                                            "type": "string",
+                                            "enum": [
+                                                "available",
+                                                "installing",
+                                                "installed",
+                                                "rolling back",
+                                                "failed"
+                                            ]
+                                        },
+                                        "isProcessing": {
+                                            "type": "boolean"
+                                        },
+                                        "processPercent": {
+                                            "type": "number"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
                         "type": "string"
                     }
                 }

--- a/internal/apis/v1/handlers/fixpacks/handlers.go
+++ b/internal/apis/v1/handlers/fixpacks/handlers.go
@@ -55,6 +55,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/fixpacks/:version",
+			Func:    listFixpackUpdateProgress,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodPost,
 			Path:    "/fixpacks/:version/rollback",
 			Func:    rollbackFixpack,
@@ -190,7 +196,7 @@ func listUpdatableNodes(c *gin.Context) {
 		return
 	}
 
-	nodes, err := h.listUpdatableNodes(h.version)
+	nodes, err := h.listUpdatableNodes(h.reqOpts.Version)
 	if err != nil {
 		bodies.SetInternalServerError(c, err)
 		return
@@ -232,6 +238,27 @@ func installFixpack(c *gin.Context) {
 	bodies.SetAccepted(
 		c,
 		"Fixpack installation started successfully",
+	)
+}
+
+func listFixpackUpdateProgress(c *gin.Context) {
+	h, err := initHelper(c, "listFixpackUpdateProgress")
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	progress, err := h.listFixpackUpdateProgress(h.reqOpts.Version)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"List of fixpack update progress",
+		progress,
 	)
 }
 

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -206,7 +206,7 @@ func (h *helper) updateFixpackTask() error {
 	switch h.reqOpts.Status.Current {
 	case status.Completed:
 		return h.deleteReqRecord()
-	case status.Error:
+	case status.Failed:
 		return h.markReqRecordAsFailed()
 	default:
 		return fmt.Errorf("invalid status: %s", h.reqOpts.Status.Current)

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -3,7 +3,6 @@ package fixpacks
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
@@ -16,7 +15,6 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 type helper struct {
@@ -66,48 +64,16 @@ func (h *helper) listFixpackUpdateProgress(version string) ([]progress, error) {
 		return nil, err
 	}
 
-	current := status.Available
-	processPercent := float64(0)
-	if h.isVersionInstalled(version) {
-		current = status.Installed
-		processPercent = 100
-	}
-
+	current, processPercent := h.getProgressByVersion(version)
 	progresses := []progress{}
 	for _, node := range updatables {
-		progress := progress{
-			Host: node.Name,
-			Status: status.FixpackProgress{
-				Current:        current,
-				ProcessPercent: processPercent,
-			},
-		}
-
-		filter := bson.M{"hostname": node.Name, "status.current": status.Installing}
-		if h.hasInprogressRecord(filter) {
-			progress.Status.Current = status.Installing
-			progress.Status.IsProcessing = true
-			progress.Status.ProcessPercent = 50
-			progresses = append(progresses, progress)
-			continue
-		}
-
-		filter["status.current"] = status.RollingBack
-		if h.hasInprogressRecord(filter) {
-			progress.Status.Current = status.RollingBack
-			progress.Status.IsProcessing = true
-			progress.Status.ProcessPercent = 50
-			progresses = append(progresses, progress)
-			continue
-		}
-
-		progresses = append(progresses, progress)
+		progresses = append(
+			progresses,
+			h.syncProgress(node, current, processPercent),
+		)
 	}
 
-	sort.Slice(progresses, func(i, j int) bool {
-		return (progresses)[i].Host < (progresses)[j].Host
-	})
-
+	h.sortProgress(&progresses)
 	return progresses, nil
 }
 

--- a/internal/apis/v1/handlers/fixpacks/helper.go
+++ b/internal/apis/v1/handlers/fixpacks/helper.go
@@ -3,6 +3,7 @@ package fixpacks
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
 	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
@@ -15,6 +16,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 type helper struct {
@@ -26,7 +28,6 @@ type helper struct {
 	mongo *mongo.Helper
 
 	file    string
-	version string
 	reqOpts fixpacks.ReqOpts
 	page    *pages.Page
 }
@@ -51,10 +52,63 @@ func (h *helper) listFixpacks() (*fixpacksPage, error) {
 	}
 
 	h.sortFixpacks(&fixpackss)
+	h.syncRequestingRecord(&fixpackss)
 	return &fixpacksPage{
 		Fixpacks: h.paginateFixpacks(fixpackss),
 		Page:     h.genPageInfo(fixpackss),
 	}, nil
+}
+
+func (h *helper) listFixpackUpdateProgress(version string) ([]progress, error) {
+	updatables, err := h.listUpdatableNodes(version)
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to list updatable nodes for fixpack %s(%v)", h.reqId, version, err)
+		return nil, err
+	}
+
+	current := status.Available
+	processPercent := float64(0)
+	if h.isVersionInstalled(version) {
+		current = status.Installed
+		processPercent = 100
+	}
+
+	progresses := []progress{}
+	for _, node := range updatables {
+		progress := progress{
+			Host: node.Name,
+			Status: status.FixpackProgress{
+				Current:        current,
+				ProcessPercent: processPercent,
+			},
+		}
+
+		filter := bson.M{"hostname": node.Name, "status.current": status.Installing}
+		if h.hasInprogressRecord(filter) {
+			progress.Status.Current = status.Installing
+			progress.Status.IsProcessing = true
+			progress.Status.ProcessPercent = 50
+			progresses = append(progresses, progress)
+			continue
+		}
+
+		filter["status.current"] = status.RollingBack
+		if h.hasInprogressRecord(filter) {
+			progress.Status.Current = status.RollingBack
+			progress.Status.IsProcessing = true
+			progress.Status.ProcessPercent = 50
+			progresses = append(progresses, progress)
+			continue
+		}
+
+		progresses = append(progresses, progress)
+	}
+
+	sort.Slice(progresses, func(i, j int) bool {
+		return (progresses)[i].Host < (progresses)[j].Host
+	})
+
+	return progresses, nil
 }
 
 func (h *helper) listUpdatableNodes(version string) ([]node, error) {

--- a/internal/apis/v1/handlers/fixpacks/parse.go
+++ b/internal/apis/v1/handlers/fixpacks/parse.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -204,4 +205,15 @@ func (h *helper) saveUploadFile() error {
 	}
 
 	return nil
+}
+
+func (h *helper) getProgressByVersion(version string) (string, float64) {
+	current := status.Available
+	processPercent := float64(0)
+	if h.isVersionInstalled(version) {
+		current = status.Installed
+		processPercent = 100
+	}
+
+	return current, processPercent
 }

--- a/internal/apis/v1/handlers/fixpacks/parse.go
+++ b/internal/apis/v1/handlers/fixpacks/parse.go
@@ -27,6 +27,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseListUpdatableParams()
 	case "installFixpack":
 		return h.parseInstallParams()
+	case "listFixpackUpdateProgress":
+		return h.parseGetProgressParams()
 	case "rollbackFixpack":
 		return h.parseRollbackParams()
 	case "deleteFixpack":
@@ -89,14 +91,14 @@ func (h *helper) parseVerificationParams() error {
 }
 
 func (h *helper) parseListUpdatableParams() error {
-	h.version = h.c.Param("version")
-	if h.version == "" {
+	h.reqOpts.Version = h.c.Param("version")
+	if h.reqOpts.Version == "" {
 		return fmt.Errorf("version parameter is required")
 	}
 
-	_, found := cubecos.GetFixpackRawByVersion(h.version)
+	_, found := cubecos.GetFixpackByVersion(h.reqOpts.Version)
 	if !found {
-		return fmt.Errorf("fixpack version %s not found", h.version)
+		return fmt.Errorf("fixpack version %s not found", h.reqOpts.Version)
 	}
 
 	return nil
@@ -121,6 +123,21 @@ func (h *helper) parseInstallParams() error {
 	return nil
 }
 
+func (h *helper) parseGetProgressParams() error {
+	h.reqOpts.Version = h.c.Param("version")
+	if h.reqOpts.Version == "" {
+		return fmt.Errorf("version parameter is required")
+	}
+
+	found := false
+	_, found = cubecos.GetFixpackByVersion(h.reqOpts.Version)
+	if !found {
+		return fmt.Errorf("fixpack version %s not found", h.reqOpts.Version)
+	}
+
+	return h.parseListParams()
+}
+
 func (h *helper) parseRollbackParams() error {
 	h.reqOpts.Version = h.c.Param("version")
 	if h.reqOpts.Version == "" {
@@ -143,15 +160,15 @@ func (h *helper) parseRollbackParams() error {
 }
 
 func (h *helper) parseDeleteFixpackParams() error {
-	h.version = h.c.Param("version")
-	if h.version == "" {
+	h.reqOpts.Version = h.c.Param("version")
+	if h.reqOpts.Version == "" {
 		return fmt.Errorf("version parameter is required")
 	}
 
 	found := false
-	h.file, found = cubecos.GetFixpackPathByVersion(h.version)
+	h.file, found = cubecos.GetFixpackPathByVersion(h.reqOpts.Version)
 	if !found {
-		return fmt.Errorf("fixpack version %s not found", h.version)
+		return fmt.Errorf("fixpack version %s not found", h.reqOpts.Version)
 	}
 
 	return nil

--- a/internal/apis/v1/handlers/fixpacks/record.go
+++ b/internal/apis/v1/handlers/fixpacks/record.go
@@ -2,10 +2,42 @@ package fixpacks
 
 import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	log "go-micro.dev/v5/logger"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+func (h *helper) syncRequestingRecord(list *[]fixpacks.Fixpack) {
+	for i, fixpack := range *list {
+		filter := bson.M{"version": fixpack.Version, "status.current": status.Installing}
+		if h.hasInprogressRecord(filter) {
+			(*list)[i].Status.Current = status.Installing
+			(*list)[i].Status.IsProcessing = true
+			continue
+		}
+
+		filter["status.current"] = status.RollingBack
+		if h.hasInprogressRecord(filter) {
+			(*list)[i].Status.Current = status.RollingBack
+			(*list)[i].Status.IsProcessing = true
+		}
+	}
+}
+
+func (h *helper) hasInprogressRecord(filter bson.M) bool {
+	count, err := h.mongo.GetCount(
+		fixpacks.Db,
+		fixpacks.ReqCollection,
+		filter,
+	)
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to count in-progress record(%v)", h.reqId, err)
+		return false
+	}
+
+	return count > 0
+}
 
 func (h *helper) addReqRecord(node string) {
 	h.reqOpts.Hostname = node

--- a/internal/apis/v1/handlers/fixpacks/resp.go
+++ b/internal/apis/v1/handlers/fixpacks/resp.go
@@ -1,6 +1,9 @@
 package fixpacks
 
-import "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+import (
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"go.mongodb.org/mongo-driver/bson"
+)
 
 type node struct {
 	Name      string `json:"name"`
@@ -12,4 +15,30 @@ type progress struct {
 	Host   string                 `json:"host"`
 	Phase  string                 `json:"phase"`
 	Status status.FixpackProgress `json:"status"`
+}
+
+func (h *helper) syncProgress(node node, current string, processPercent float64) progress {
+	progress := progress{
+		Host: node.Name,
+		Status: status.FixpackProgress{
+			Current:        current,
+			ProcessPercent: processPercent,
+		},
+	}
+
+	filter := bson.M{"hostname": node.Name, "status.current": status.Installing}
+	if h.hasInprogressRecord(filter) {
+		progress.Status.Current = status.Installing
+		progress.Status.IsProcessing = true
+		progress.Status.ProcessPercent = 50
+	}
+
+	filter["status.current"] = status.RollingBack
+	if h.hasInprogressRecord(filter) {
+		progress.Status.Current = status.RollingBack
+		progress.Status.IsProcessing = true
+		progress.Status.ProcessPercent = 50
+	}
+
+	return progress
 }

--- a/internal/apis/v1/handlers/fixpacks/resp.go
+++ b/internal/apis/v1/handlers/fixpacks/resp.go
@@ -1,7 +1,15 @@
 package fixpacks
 
+import "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+
 type node struct {
 	Name      string `json:"name"`
 	Version   string `json:"version"`
 	UpdatedAt string `json:"updatedAt"`
+}
+
+type progress struct {
+	Host   string                 `json:"host"`
+	Phase  string                 `json:"phase"`
+	Status status.FixpackProgress `json:"status"`
 }

--- a/internal/apis/v1/handlers/fixpacks/sort.go
+++ b/internal/apis/v1/handlers/fixpacks/sort.go
@@ -9,3 +9,9 @@ func (h *helper) sortUpdatableNodes(nodes *[]node) {
 		return (*nodes)[i].UpdatedAt > (*nodes)[j].UpdatedAt
 	})
 }
+
+func (h *helper) sortProgress(progress *[]progress) {
+	sort.Slice(*progress, func(i, j int) bool {
+		return (*progress)[i].Host < (*progress)[j].Host
+	})
+}

--- a/internal/apis/v1/handlers/fixpacks/verify.go
+++ b/internal/apis/v1/handlers/fixpacks/verify.go
@@ -10,8 +10,29 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/ceph"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	log "go-micro.dev/v5/logger"
 )
+
+func (h *helper) isVersionInstalled(version string) bool {
+	fixpacks, err := h.listFixpacks()
+	if err != nil {
+		log.Errorf("fixpacks(%s): failed to list fixpack for checking installation(%v)", h.reqId, err)
+		return false
+	}
+
+	for _, fixpack := range fixpacks.Fixpacks {
+		if fixpack.Version != version {
+			continue
+		}
+
+		if fixpack.Status.Current == status.Installed {
+			return true
+		}
+	}
+
+	return false
+}
 
 func (h *helper) checkRollback(version string) error {
 	fixpack, found := cubecos.GetFixpackByVersion(version)

--- a/internal/definition/v1/fixpacks/fixpack.go
+++ b/internal/definition/v1/fixpacks/fixpack.go
@@ -44,8 +44,8 @@ func (r *ReqOpts) SetCompleted() {
 	r.Status.IsProcessing = false
 }
 
-func (r *ReqOpts) SetError() {
-	r.Status.Current = status.Error
+func (r *ReqOpts) SetFailed() {
+	r.Status.Current = status.Failed
 	r.Status.IsProcessing = false
 }
 

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -171,6 +171,13 @@ type Fixpack struct {
 	Description    string `json:"description,omitempty" bson:"description"`
 }
 
+type FixpackProgress struct {
+	Current        string  `json:"current" bson:"current"`
+	IsProcessing   bool    `json:"isProcessing" bson:"isProcessing"`
+	ProcessPercent float64 `json:"processPercent" bson:"processPercent"`
+	Description    string  `json:"description" bson:"description"`
+}
+
 func NewHealthOk() *Health {
 	return &Health{Current: Ok}
 }

--- a/internal/operators/v1/fixpacks/operate.go
+++ b/internal/operators/v1/fixpacks/operate.go
@@ -28,7 +28,7 @@ func (o *Operator) operate(req *fixpacks.ReqOpts) error {
 func (o *Operator) handleExit(req *fixpacks.ReqOpts, err error) {
 	if err != nil {
 		log.Errorf("fixpacks: failed to %s %s(%v)", req.Status.Desired, req.Version, err)
-		req.SetError()
+		req.SetFailed()
 	} else {
 		log.Infof("fixpacks: %s %s successfully", req.Status.Desired, req.Version)
 		req.SetCompleted()


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/284

<br/>

### What this PR does?

- Add GET /fixpacks/{version} to list the fixpack operation progress from each host

- Add the corresponding API doc

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1432" height="491" alt="Screenshot 2025-08-24 at 10 32 26 PM" src="https://github.com/user-attachments/assets/d961adba-7e86-44c2-8115-b741bc2c4481" />
<img width="1429" height="634" alt="Screenshot 2025-08-24 at 10 32 53 PM" src="https://github.com/user-attachments/assets/5c7d9dc8-ea90-4f78-bfc8-6f69afbcf275" />
<img width="1428" height="709" alt="Screenshot 2025-08-24 at 10 32 35 PM" src="https://github.com/user-attachments/assets/eff57e13-2554-4cf2-abb0-4428273a2874" />
<img width="1426" height="540" alt="Screenshot 2025-08-24 at 10 33 01 PM" src="https://github.com/user-attachments/assets/16b4f285-1379-4662-a387-a1f0800f9fe1" />

<br/>
<br/>

2). make sure the api works properly

<img width="753" height="737" alt="Screenshot 2025-08-24 at 10 06 28 PM" src="https://github.com/user-attachments/assets/421a7db1-eacd-47e0-82be-84b8d8b3071f" />
<img width="698" height="730" alt="Screenshot 2025-08-24 at 10 08 16 PM" src="https://github.com/user-attachments/assets/e7b91548-ab62-4a89-a1bc-1b88163231a3" />

