### PR TITLE
Fix the incorrect time zone info for Firmware / Fixpack listing API

### DIFF
--- a/internal/cubecos/firmware.go
+++ b/internal/cubecos/firmware.go
@@ -127,13 +127,13 @@ func appendUninstalledFirmwares(list *[]firmwares.Firmware) {
 }
 
 func convertRawTime(layout, rawTime string) string {
-	t, err := ostime.Parse(layout, rawTime)
+	t, err := ostime.ParseInLocation(layout, rawTime, time.LocalFixedZone)
 	if err != nil {
 		log.Errorf("firmwares: failed to parse time %s (%v)", rawTime, err)
 		return ""
 	}
 
-	return time.Fixpack(t)
+	return time.RFC3339Z(t)
 }
 
 func convertPkgNameToFirmware(pkgname string) (*firmwares.Firmware, error) {

--- a/internal/definition/v1/time/time.go
+++ b/internal/definition/v1/time/time.go
@@ -93,10 +93,6 @@ func Boot() string {
 	return ISO8601Z(bootTime)
 }
 
-func Fixpack(t time.Time) string {
-	return RFC3339Z(t)
-}
-
 func TimeISO8601Z(t time.Time) string {
 	return t.Format(FormatISO8601Z)
 }


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/271

<br/>

### What this PR does?

Fix the incorrect time zone info for Firmware / Fixpack listing API

<br/>

### Test results (optional)

1). make sure the api works properly with correct timezone

<img width="1443" height="934" alt="Screenshot 2025-08-25 at 1 12 08 PM" src="https://github.com/user-attachments/assets/6c0df039-c7c3-4e11-b242-37489968247f" />

<img width="877" height="574" alt="Screenshot 2025-08-25 at 1 12 28 PM" src="https://github.com/user-attachments/assets/7464ca8e-5a33-4535-ade0-094542a37878" />

