### PR TITLE
Add the GET /firmwares/upgradeProgress to fetch the firmware upgrade status from each node

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -14161,6 +14161,127 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/firmwares/upgradeProgress": {
+            "get": {
+                "operationId": "getFirmwareUpgradeProgress",
+                "tags": [
+                    "Firmwares"
+                ],
+                "summary": "Get firmware upgrade progress for all nodes",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Firmware upgrade progress retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetFirmwareUpgradeProgressResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Firmware upgrade progress",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "host": "example-node-0",
+                                                    "phase": "paritioning",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 75,
+                                                        "description": "swapping partition for Cube Appliance 3.1.0"
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-1",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "waiting",
+                                                        "isProcessing": false,
+                                                        "processPercent": 0,
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-2",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "waiting",
+                                                        "isProcessing": false,
+                                                        "processPercent": 0,
+                                                        "description": ""
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "fetch firmware upgrade progress successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "no firmware upgrade in progress"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to get firmware upgrade progress: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/firmwares/{version}": {
             "delete": {
                 "operationId": "deleteFirmware",
@@ -15094,7 +15215,7 @@ const docTemplate = `{
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/FixpackProgressResponse"
+                                    "$ref": "#/components/schemas/GetFixpackProgressResponse"
                                 },
                                 "examples": {
                                     "example1": {
@@ -21488,6 +21609,74 @@ const docTemplate = `{
                     }
                 }
             },
+            "GetFirmwareUpgradeProgressResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "host",
+                                "phase",
+                                "status"
+                            ],
+                            "properties": {
+                                "host": {
+                                    "type": "string"
+                                },
+                                "phase": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "required": [
+                                        "current",
+                                        "isProcessing",
+                                        "processPercent",
+                                        "description"
+                                    ],
+                                    "properties": {
+                                        "current": {
+                                            "type": "string",
+                                            "enum": [
+                                                "waiting",
+                                                "installing",
+                                                "installed",
+                                                "failed"
+                                            ]
+                                        },
+                                        "isProcessing": {
+                                            "type": "boolean"
+                                        },
+                                        "processPercent": {
+                                            "type": "number"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
             "ListFixpacksResponse": {
                 "type": "object",
                 "required": [
@@ -21642,7 +21831,7 @@ const docTemplate = `{
                     }
                 }
             },
-            "FixpackProgressResponse": {
+            "GetFixpackProgressResponse": {
                 "type": "object",
                 "required": [
                     "code",

--- a/api/docs.json
+++ b/api/docs.json
@@ -14157,6 +14157,127 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/firmwares/upgradeProgress": {
+            "get": {
+                "operationId": "getFirmwareUpgradeProgress",
+                "tags": [
+                    "Firmwares"
+                ],
+                "summary": "Get firmware upgrade progress for all nodes",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Firmware upgrade progress retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetFirmwareUpgradeProgressResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Firmware upgrade progress",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "host": "example-node-0",
+                                                    "phase": "paritioning",
+                                                    "status": {
+                                                        "current": "installing",
+                                                        "isProcessing": false,
+                                                        "processPercent": 75,
+                                                        "description": "swapping partition for Cube Appliance 3.1.0"
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-1",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "waiting",
+                                                        "isProcessing": false,
+                                                        "processPercent": 0,
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "host": "example-node-2",
+                                                    "phase": "",
+                                                    "status": {
+                                                        "current": "waiting",
+                                                        "isProcessing": false,
+                                                        "processPercent": 0,
+                                                        "description": ""
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "fetch firmware upgrade progress successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "no firmware upgrade in progress"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to get firmware upgrade progress: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/firmwares/{version}": {
             "delete": {
                 "operationId": "deleteFirmware",
@@ -15090,7 +15211,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/FixpackProgressResponse"
+                                    "$ref": "#/components/schemas/GetFixpackProgressResponse"
                                 },
                                 "examples": {
                                     "example1": {
@@ -21484,6 +21605,74 @@
                     }
                 }
             },
+            "GetFirmwareUpgradeProgressResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "host",
+                                "phase",
+                                "status"
+                            ],
+                            "properties": {
+                                "host": {
+                                    "type": "string"
+                                },
+                                "phase": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "required": [
+                                        "current",
+                                        "isProcessing",
+                                        "processPercent",
+                                        "description"
+                                    ],
+                                    "properties": {
+                                        "current": {
+                                            "type": "string",
+                                            "enum": [
+                                                "waiting",
+                                                "installing",
+                                                "installed",
+                                                "failed"
+                                            ]
+                                        },
+                                        "isProcessing": {
+                                            "type": "boolean"
+                                        },
+                                        "processPercent": {
+                                            "type": "number"
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
             "ListFixpacksResponse": {
                 "type": "object",
                 "required": [
@@ -21638,7 +21827,7 @@
                     }
                 }
             },
-            "FixpackProgressResponse": {
+            "GetFixpackProgressResponse": {
                 "type": "object",
                 "required": [
                     "code",

--- a/internal/apis/v1/handlers/firmwares/handlers.go
+++ b/internal/apis/v1/handlers/firmwares/handlers.go
@@ -1,6 +1,7 @@
 package firmwares
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/apis"
@@ -26,15 +27,21 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodPost,
+			Path:    "/firmwares/md5sum",
+			Func:    uploadFirmwareMd5Sum,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodPatch,
 			Path:    "/firmwares",
 			Func:    updateFirmware,
 		},
 		{
 			Version: apis.V1,
-			Method:  http.MethodPost,
-			Path:    "/firmwares/md5sum",
-			Func:    uploadFirmwareMd5Sum,
+			Method:  http.MethodGet,
+			Path:    "/firmwares/upgradeProgress",
+			Func:    getFirmwareUpgradeProgress,
 		},
 		{
 			Version: apis.V1,
@@ -117,15 +124,15 @@ func uploadFirmware(c *gin.Context) {
 	)
 }
 
-func updateFirmware(c *gin.Context) {
-	h, err := initHelper(c, "updateFirmware")
+func listUpdatableNodes(c *gin.Context) {
+	h, err := initHelper(c, "listUpdatableNodes")
 	if err != nil {
 		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
 		bodies.SetBadRequest(c, err, nil)
 		return
 	}
 
-	err = h.updateFirmware()
+	nodes, err := h.listUpdatableNodes()
 	if err != nil {
 		bodies.SetInternalServerError(c, err)
 		return
@@ -133,8 +140,8 @@ func updateFirmware(c *gin.Context) {
 
 	bodies.SetOk(
 		c,
-		"Firmware updated successfully",
-		nil,
+		"List of updatable nodes",
+		nodes,
 	)
 }
 
@@ -165,48 +172,6 @@ func uploadFirmwareMd5Sum(c *gin.Context) {
 	)
 }
 
-func listUpdatableNodes(c *gin.Context) {
-	h, err := initHelper(c, "listUpdatableNodes")
-	if err != nil {
-		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
-		bodies.SetBadRequest(c, err, nil)
-		return
-	}
-
-	nodes, err := h.listUpdatableNodes()
-	if err != nil {
-		bodies.SetInternalServerError(c, err)
-		return
-	}
-
-	bodies.SetOk(
-		c,
-		"List of updatable nodes",
-		nodes,
-	)
-}
-
-func continueInterruptedFirmwareUpdate(c *gin.Context) {
-	h, err := initHelper(c, "continueInterruptedFirmwareUpdate")
-	if err != nil {
-		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
-		bodies.SetBadRequest(c, err, nil)
-		return
-	}
-
-	err = h.continueInterruptedFirmwareUpdate()
-	if err != nil {
-		bodies.SetInternalServerError(c, err)
-		return
-	}
-
-	bodies.SetOk(
-		c,
-		"Firmware update continued successfully",
-		nil,
-	)
-}
-
 func verfiyFirmwareAndMd5Sum(c *gin.Context) {
 	h, err := initHelper(c, "verfiyFirmwareAndMd5Sum")
 	if err != nil {
@@ -231,6 +196,74 @@ func verfiyFirmwareAndMd5Sum(c *gin.Context) {
 		c,
 		"Firmware and MD5 sum verified successfully",
 		result,
+	)
+}
+
+func continueInterruptedFirmwareUpdate(c *gin.Context) {
+	h, err := initHelper(c, "continueInterruptedFirmwareUpdate")
+	if err != nil {
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.continueInterruptedFirmwareUpdate()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"Firmware update continued successfully",
+		nil,
+	)
+}
+
+func updateFirmware(c *gin.Context) {
+	h, err := initHelper(c, "updateFirmware")
+	if err != nil {
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.updateFirmware()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"Firmware updated successfully",
+		nil,
+	)
+}
+
+func getFirmwareUpgradeProgress(c *gin.Context) {
+	h, err := initHelper(c, "getFirmwareUpgradeProgress")
+	if err != nil {
+		log.Errorf("firmwares(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	if !h.hasInprogressUpdate() {
+		bodies.SetNotFound(c, errors.New("no firmware upgrade in progress"))
+		return
+	}
+
+	progresses, err := h.getFirmwareUpgradeProgress()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"List of firmware upgrade progress",
+		progresses,
 	)
 }
 

--- a/internal/apis/v1/handlers/firmwares/helper.go
+++ b/internal/apis/v1/handlers/firmwares/helper.go
@@ -52,12 +52,6 @@ func (h *helper) listFirmwares() (*firmwarePage, error) {
 	}, nil
 }
 
-func (h *helper) updateFirmware() error {
-	// todo:
-	// deletgate to local and all nodes
-	return nil
-}
-
 func (h *helper) listUpdatableNodes() ([]node, error) {
 	list := nodes.List()
 	if len(list) == 0 {
@@ -76,6 +70,22 @@ func (h *helper) listUpdatableNodes() ([]node, error) {
 	}
 
 	return updatables, nil
+}
+
+func (h *helper) updateFirmware() error {
+	// todo:
+	// deletgate to local and all nodes
+	return nil
+}
+
+func (h *helper) getFirmwareUpgradeProgress() ([]progress, error) {
+	progresses, err := h.getUpgradeProgress()
+	if err != nil {
+		return nil, err
+	}
+
+	h.sortProgress(&progresses)
+	return progresses, nil
 }
 
 func (h *helper) continueInterruptedFirmwareUpdate() error {

--- a/internal/apis/v1/handlers/firmwares/progress.go
+++ b/internal/apis/v1/handlers/firmwares/progress.go
@@ -1,0 +1,64 @@
+package firmwares
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/firmwares"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	log "go-micro.dev/v5/logger"
+)
+
+type node struct {
+	Name           string `json:"name"`
+	nodes.Firmware `json:"firmware"`
+}
+
+type progress struct {
+	Host   string                      `json:"host"`
+	Phase  string                      `json:"phase"`
+	Status status.SystemUpdateProgress `json:"status"`
+}
+
+func (h *helper) hasInprogressUpdate() bool {
+	_, err := os.Stat(firmwares.UpdateProgress)
+	if err == nil {
+		return true
+	}
+
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	log.Errorf(
+		"firmwares(%s): failed to stat progress file(%v)",
+		h.reqId, err,
+	)
+
+	return false
+}
+
+func (h *helper) getUpgradeProgress() ([]progress, error) {
+	out, err := os.ReadFile(firmwares.UpdateProgress)
+	if err != nil {
+		log.Errorf("firmwares(%s): failed to read progress file(%v)", h.reqId, err)
+		return nil, err
+	}
+
+	progresses := []progress{}
+	err = json.Unmarshal(out, &progresses)
+	if err != nil {
+		log.Errorf("firmwares(%s): failed to unmarshal progress file(%v)", h.reqId, err)
+		return nil, err
+	}
+
+	return progresses, nil
+}
+
+func (h *helper) sortProgress(progresses *[]progress) {
+	sort.Slice(*progresses, func(i, j int) bool {
+		return (*progresses)[i].Host < (*progresses)[j].Host
+	})
+}

--- a/internal/apis/v1/handlers/firmwares/resp.go
+++ b/internal/apis/v1/handlers/firmwares/resp.go
@@ -1,8 +1,0 @@
-package firmwares
-
-import "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
-
-type node struct {
-	Name           string `json:"name"`
-	nodes.Firmware `json:"firmware"`
-}

--- a/internal/apis/v1/handlers/fixpacks/resp.go
+++ b/internal/apis/v1/handlers/fixpacks/resp.go
@@ -12,15 +12,15 @@ type node struct {
 }
 
 type progress struct {
-	Host   string                 `json:"host"`
-	Phase  string                 `json:"phase"`
-	Status status.FixpackProgress `json:"status"`
+	Host   string                      `json:"host"`
+	Phase  string                      `json:"phase"`
+	Status status.SystemUpdateProgress `json:"status"`
 }
 
 func (h *helper) syncProgress(node node, current string, processPercent float64) progress {
 	progress := progress{
 		Host: node.Name,
-		Status: status.FixpackProgress{
+		Status: status.SystemUpdateProgress{
 			Current:        current,
 			ProcessPercent: processPercent,
 		},

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -171,7 +171,7 @@ type Fixpack struct {
 	Description    string `json:"description,omitempty" bson:"description"`
 }
 
-type FixpackProgress struct {
+type SystemUpdateProgress struct {
 	Current        string  `json:"current" bson:"current"`
 	IsProcessing   bool    `json:"isProcessing" bson:"isProcessing"`
 	ProcessPercent float64 `json:"processPercent" bson:"processPercent"`


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/279

<br/>

### What this PR does?

- Add the GET /firmwares/upgradeProgress to fetch the firmware upgrade status from each node

- Add the corresponding API doc 

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1426" height="239" alt="Screenshot 2025-08-28 at 5 21 01 PM" src="https://github.com/user-attachments/assets/1f939fcf-0024-4a88-a0ac-322c601efc17" />
<img width="1429" height="633" alt="Screenshot 2025-08-28 at 5 20 49 PM" src="https://github.com/user-attachments/assets/09478efc-c7b8-4eea-b8a8-1f19e0338864" />
 