### PR TITLE
Fix the incorrect order for fixpack list

### DIFF
--- a/internal/apis/v1/handlers/fixpacks/paginate.go
+++ b/internal/apis/v1/handlers/fixpacks/paginate.go
@@ -25,7 +25,7 @@ func (h *helper) paginateFixpacks(list []fixpacks.Fixpack) []fixpacks.Fixpack {
 
 func (h *helper) sortFixpacks(list *[]fixpacks.Fixpack) {
 	sort.Slice(*list, func(i, j int) bool {
-		return (*list)[i].Version < (*list)[j].Version
+		return (*list)[i].Version > (*list)[j].Version
 	})
 }
 


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

None

<br/>

### What this PR does?

Fix the incorrect order for fixpack list

<br/>

### Test results (optional)

1). make sure the api works properly

<img width="1379" height="935" alt="Screenshot 2025-08-31 at 3 38 24 PM" src="https://github.com/user-attachments/assets/5e0cec4d-e8e6-42f8-b0d1-35ca45657349" />
