### PR TITLE
Integrate the GET /integrations/storages/models with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3316,7 +3316,7 @@ const docTemplate = `{
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages": {
             "get": {
-                "operationId": "getIntegratedStorages",
+                "operationId": "listIntegratedStorages",
                 "tags": [
                     "Integrations"
                 ],
@@ -3332,7 +3332,7 @@ const docTemplate = `{
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/GetIntegratedStoragesResponse"
+                                    "$ref": "#/components/schemas/ListIntegratedStoragesResponse"
                                 },
                                 "examples": {
                                     "example1": {
@@ -3375,6 +3375,179 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch integrated applications: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/models": {
+            "get": {
+                "operationId": "listStorageModels",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Retrieve the list of storage models",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the list of storage models successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListIntegratedStorageModelsResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Storage models",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "vendor": "Dell",
+                                                    "product": "PowerVault",
+                                                    "multipath": {
+                                                        "defaults": [
+                                                            {
+                                                                "key": "user_friendly_names",
+                                                                "value": "yes"
+                                                            }
+                                                        ],
+                                                        "blacklist": {
+                                                            "devnode": "sda",
+                                                            "devices": [
+                                                                {
+                                                                    "vendor": "Generic",
+                                                                    "product": "USB",
+                                                                    "settings": [
+                                                                        {
+                                                                            "key": "dev_loss_tmo",
+                                                                            "value": "10"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "blacklistExceptions": {
+                                                            "devnode": "sd[b-z]",
+                                                            "devices": [
+                                                                {
+                                                                    "vendor": "HP",
+                                                                    "product": "MSA",
+                                                                    "settings": [
+                                                                        {
+                                                                            "key": "polling_interval",
+                                                                            "value": "5"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "devices": [
+                                                            {
+                                                                "vendor": "EMC",
+                                                                "product": "VNX",
+                                                                "settings": [
+                                                                    {
+                                                                        "key": "no_path_retry",
+                                                                        "value": "fail"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "overrides": [
+                                                            {
+                                                                "key": "checker_timeout",
+                                                                "value": "30"
+                                                            }
+                                                        ],
+                                                        "multipaths": [
+                                                            {
+                                                                "wwid": "3600508b400105e210000900000490000",
+                                                                "settings": [
+                                                                    {
+                                                                        "key": "path_grouping_policy",
+                                                                        "value": "group_by_prio"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "storage": {
+                                                        "service": {
+                                                            "driverSection": [
+                                                                {
+                                                                    "key": "volume_driver",
+                                                                    "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                                }
+                                                            ],
+                                                            "extraSettings": [
+                                                                {
+                                                                    "sectionHeader": "DEFAULT",
+                                                                    "settings": [
+                                                                        {
+                                                                            "key": "enabled_backends",
+                                                                            "value": "lvm"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "extraConfigFiles": [
+                                                                {
+                                                                    "name": "test.conf",
+                                                                    "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                                }
+                                                            ]
+                                                        },
+                                                        "volumeType": {
+                                                            "settings": [
+                                                                {
+                                                                    "key": "volume_backend_name",
+                                                                    "value": "lvm"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "image": {
+                                                            "useMultipath": true,
+                                                            "forceMultipath": true
+                                                        },
+                                                        "updateTime": "2025-09-09T10:30:00Z"
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "fetch storage models successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch storage models: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -17336,7 +17509,7 @@ const docTemplate = `{
                     }
                 }
             },
-            "GetIntegratedStoragesResponse": {
+            "ListIntegratedStoragesResponse": {
                 "type": "object",
                 "required": [
                     "code",
@@ -17409,6 +17582,237 @@ const docTemplate = `{
                     "msg": {
                         "type": "string",
                         "example": "fetch integrated applications successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "ListIntegratedStorageModelsResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "vendor",
+                                "product",
+                                "multipath",
+                                "storage"
+                            ],
+                            "properties": {
+                                "vendor": {
+                                    "type": "string"
+                                },
+                                "product": {
+                                    "type": "string"
+                                },
+                                "multipath": {
+                                    "type": "object",
+                                    "required": [
+                                        "defaults",
+                                        "blacklist",
+                                        "blacklistExceptions",
+                                        "devices",
+                                        "overrides",
+                                        "multipaths"
+                                    ],
+                                    "properties": {
+                                        "defaults": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageKeyValuePair"
+                                            }
+                                        },
+                                        "blacklist": {
+                                            "type": "object",
+                                            "required": [
+                                                "devnode",
+                                                "devices"
+                                            ],
+                                            "properties": {
+                                                "devnode": {
+                                                    "type": "string"
+                                                },
+                                                "devices": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "blacklistExceptions": {
+                                            "type": "object",
+                                            "required": [
+                                                "devnode",
+                                                "devices"
+                                            ],
+                                            "properties": {
+                                                "devnode": {
+                                                    "type": "string"
+                                                },
+                                                "devices": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "devices": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                            }
+                                        },
+                                        "overrides": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageKeyValuePair"
+                                            }
+                                        },
+                                        "multipaths": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "wwid",
+                                                    "settings"
+                                                ],
+                                                "properties": {
+                                                    "wwid": {
+                                                        "type": "string"
+                                                    },
+                                                    "settings": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "storage": {
+                                    "type": "object",
+                                    "required": [
+                                        "service",
+                                        "volumeType",
+                                        "image",
+                                        "updateTime"
+                                    ],
+                                    "properties": {
+                                        "service": {
+                                            "type": "object",
+                                            "required": [
+                                                "driverSection",
+                                                "extraSettings",
+                                                "extraConfigFiles"
+                                            ],
+                                            "properties": {
+                                                "driverSection": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                    }
+                                                },
+                                                "extraSettings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "sectionHeader",
+                                                            "settings"
+                                                        ],
+                                                        "properties": {
+                                                            "sectionHeader": {
+                                                                "type": "string"
+                                                            },
+                                                            "settings": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "extraConfigFiles": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "name",
+                                                            "content"
+                                                        ],
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "content": {
+                                                                "type": "string",
+                                                                "description": "Base64 encoded content of the config file"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "volumeType": {
+                                            "type": "object",
+                                            "required": [
+                                                "settings"
+                                            ],
+                                            "properties": {
+                                                "settings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "image": {
+                                            "type": "object",
+                                            "required": [
+                                                "useMultipath",
+                                                "forceMultipath"
+                                            ],
+                                            "properties": {
+                                                "useMultipath": {
+                                                    "type": "boolean"
+                                                },
+                                                "forceMultipath": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        },
+                                        "updateTime": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "fetch integrated storage models successfully"
                     },
                     "status": {
                         "type": "string",
@@ -23097,6 +23501,43 @@ const docTemplate = `{
                         "OSD00002E": "#/components/schemas/OSD00002E",
                         "OSD00003I": "#/components/schemas/OSD00003I",
                         "OSD00003E": "#/components/schemas/OSD00003E"
+                    }
+                }
+            },
+            "StorageModelVenderSetting": {
+                "type": "object",
+                "required": [
+                    "vendor",
+                    "product",
+                    "settings"
+                ],
+                "properties": {
+                    "vendor": {
+                        "type": "string"
+                    },
+                    "product": {
+                        "type": "string"
+                    },
+                    "settings": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                        }
+                    }
+                }
+            },
+            "StorageKeyValuePair": {
+                "type": "object",
+                "required": [
+                    "key",
+                    "value"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -3312,7 +3312,7 @@
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages": {
             "get": {
-                "operationId": "getIntegratedStorages",
+                "operationId": "listIntegratedStorages",
                 "tags": [
                     "Integrations"
                 ],
@@ -3328,7 +3328,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/GetIntegratedStoragesResponse"
+                                    "$ref": "#/components/schemas/ListIntegratedStoragesResponse"
                                 },
                                 "examples": {
                                     "example1": {
@@ -3371,6 +3371,179 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch integrated applications: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/models": {
+            "get": {
+                "operationId": "listStorageModels",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Retrieve the list of storage models",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the list of storage models successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListIntegratedStorageModelsResponse"
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Storage models",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                {
+                                                    "vendor": "Dell",
+                                                    "product": "PowerVault",
+                                                    "multipath": {
+                                                        "defaults": [
+                                                            {
+                                                                "key": "user_friendly_names",
+                                                                "value": "yes"
+                                                            }
+                                                        ],
+                                                        "blacklist": {
+                                                            "devnode": "sda",
+                                                            "devices": [
+                                                                {
+                                                                    "vendor": "Generic",
+                                                                    "product": "USB",
+                                                                    "settings": [
+                                                                        {
+                                                                            "key": "dev_loss_tmo",
+                                                                            "value": "10"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "blacklistExceptions": {
+                                                            "devnode": "sd[b-z]",
+                                                            "devices": [
+                                                                {
+                                                                    "vendor": "HP",
+                                                                    "product": "MSA",
+                                                                    "settings": [
+                                                                        {
+                                                                            "key": "polling_interval",
+                                                                            "value": "5"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "devices": [
+                                                            {
+                                                                "vendor": "EMC",
+                                                                "product": "VNX",
+                                                                "settings": [
+                                                                    {
+                                                                        "key": "no_path_retry",
+                                                                        "value": "fail"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "overrides": [
+                                                            {
+                                                                "key": "checker_timeout",
+                                                                "value": "30"
+                                                            }
+                                                        ],
+                                                        "multipaths": [
+                                                            {
+                                                                "wwid": "3600508b400105e210000900000490000",
+                                                                "settings": [
+                                                                    {
+                                                                        "key": "path_grouping_policy",
+                                                                        "value": "group_by_prio"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "storage": {
+                                                        "service": {
+                                                            "driverSection": [
+                                                                {
+                                                                    "key": "volume_driver",
+                                                                    "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                                }
+                                                            ],
+                                                            "extraSettings": [
+                                                                {
+                                                                    "sectionHeader": "DEFAULT",
+                                                                    "settings": [
+                                                                        {
+                                                                            "key": "enabled_backends",
+                                                                            "value": "lvm"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "extraConfigFiles": [
+                                                                {
+                                                                    "name": "test.conf",
+                                                                    "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                                }
+                                                            ]
+                                                        },
+                                                        "volumeType": {
+                                                            "settings": [
+                                                                {
+                                                                    "key": "volume_backend_name",
+                                                                    "value": "lvm"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "image": {
+                                                            "useMultipath": true,
+                                                            "forceMultipath": true
+                                                        },
+                                                        "updateTime": "2025-09-09T10:30:00Z"
+                                                    }
+                                                }
+                                            ],
+                                            "msg": "fetch storage models successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch storage models: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -17332,7 +17505,7 @@
                     }
                 }
             },
-            "GetIntegratedStoragesResponse": {
+            "ListIntegratedStoragesResponse": {
                 "type": "object",
                 "required": [
                     "code",
@@ -17405,6 +17578,237 @@
                     "msg": {
                         "type": "string",
                         "example": "fetch integrated applications successfully"
+                    },
+                    "status": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                }
+            },
+            "ListIntegratedStorageModelsResponse": {
+                "type": "object",
+                "required": [
+                    "code",
+                    "data",
+                    "msg",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "example": 200
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "vendor",
+                                "product",
+                                "multipath",
+                                "storage"
+                            ],
+                            "properties": {
+                                "vendor": {
+                                    "type": "string"
+                                },
+                                "product": {
+                                    "type": "string"
+                                },
+                                "multipath": {
+                                    "type": "object",
+                                    "required": [
+                                        "defaults",
+                                        "blacklist",
+                                        "blacklistExceptions",
+                                        "devices",
+                                        "overrides",
+                                        "multipaths"
+                                    ],
+                                    "properties": {
+                                        "defaults": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageKeyValuePair"
+                                            }
+                                        },
+                                        "blacklist": {
+                                            "type": "object",
+                                            "required": [
+                                                "devnode",
+                                                "devices"
+                                            ],
+                                            "properties": {
+                                                "devnode": {
+                                                    "type": "string"
+                                                },
+                                                "devices": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "blacklistExceptions": {
+                                            "type": "object",
+                                            "required": [
+                                                "devnode",
+                                                "devices"
+                                            ],
+                                            "properties": {
+                                                "devnode": {
+                                                    "type": "string"
+                                                },
+                                                "devices": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "devices": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                            }
+                                        },
+                                        "overrides": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageKeyValuePair"
+                                            }
+                                        },
+                                        "multipaths": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "wwid",
+                                                    "settings"
+                                                ],
+                                                "properties": {
+                                                    "wwid": {
+                                                        "type": "string"
+                                                    },
+                                                    "settings": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "storage": {
+                                    "type": "object",
+                                    "required": [
+                                        "service",
+                                        "volumeType",
+                                        "image",
+                                        "updateTime"
+                                    ],
+                                    "properties": {
+                                        "service": {
+                                            "type": "object",
+                                            "required": [
+                                                "driverSection",
+                                                "extraSettings",
+                                                "extraConfigFiles"
+                                            ],
+                                            "properties": {
+                                                "driverSection": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                    }
+                                                },
+                                                "extraSettings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "sectionHeader",
+                                                            "settings"
+                                                        ],
+                                                        "properties": {
+                                                            "sectionHeader": {
+                                                                "type": "string"
+                                                            },
+                                                            "settings": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "extraConfigFiles": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "name",
+                                                            "content"
+                                                        ],
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "content": {
+                                                                "type": "string",
+                                                                "description": "Base64 encoded content of the config file"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "volumeType": {
+                                            "type": "object",
+                                            "required": [
+                                                "settings"
+                                            ],
+                                            "properties": {
+                                                "settings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "image": {
+                                            "type": "object",
+                                            "required": [
+                                                "useMultipath",
+                                                "forceMultipath"
+                                            ],
+                                            "properties": {
+                                                "useMultipath": {
+                                                    "type": "boolean"
+                                                },
+                                                "forceMultipath": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        },
+                                        "updateTime": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "msg": {
+                        "type": "string",
+                        "example": "fetch integrated storage models successfully"
                     },
                     "status": {
                         "type": "string",
@@ -23093,6 +23497,43 @@
                         "OSD00002E": "#/components/schemas/OSD00002E",
                         "OSD00003I": "#/components/schemas/OSD00003I",
                         "OSD00003E": "#/components/schemas/OSD00003E"
+                    }
+                }
+            },
+            "StorageModelVenderSetting": {
+                "type": "object",
+                "required": [
+                    "vendor",
+                    "product",
+                    "settings"
+                ],
+                "properties": {
+                    "vendor": {
+                        "type": "string"
+                    },
+                    "product": {
+                        "type": "string"
+                    },
+                    "settings": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                        }
+                    }
+                }
+            },
+            "StorageKeyValuePair": {
+                "type": "object",
+                "required": [
+                    "key",
+                    "value"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
                     }
                 }
             },

--- a/api/test.json
+++ b/api/test.json
@@ -1,0 +1,113 @@
+[
+    {
+        "vendor": "Dell",
+        "product": "PowerVault",
+        "multipath": {
+            "defaults": [
+                {
+                    "key": "user_friendly_names",
+                    "value": "yes"
+                }
+            ],
+            "blacklist": {
+                "devnode": "sda",
+                "devices": [
+                    {
+                        "vendor": "Generic",
+                        "product": "USB",
+                        "settings": [
+                            {
+                                "key": "dev_loss_tmo",
+                                "value": "10"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "blacklistExceptions": {
+                "devnode": "sd[b-z]",
+                "devices": [
+                    {
+                        "vendor": "HP",
+                        "product": "MSA",
+                        "settings": [
+                            {
+                                "key": "polling_interval",
+                                "value": "5"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "devices": [
+                {
+                    "vendor": "EMC",
+                    "product": "VNX",
+                    "settings": [
+                        {
+                            "key": "no_path_retry",
+                            "value": "fail"
+                        }
+                    ]
+                }
+            ],
+            "overrides": [
+                {
+                    "key": "checker_timeout",
+                    "value": "30"
+                }
+            ],
+            "multipaths": [
+                {
+                    "wwid": "3600508b400105e210000900000490000",
+                    "settings": [
+                        {
+                            "key": "path_grouping_policy",
+                            "value": "group_by_prio"
+                        }
+                    ]
+                }
+            ]
+        },
+        "storage": {
+            "service": {
+                "driverSection": [
+                    {
+                        "key": "volume_driver",
+                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                    }
+                ],
+                "extraSettings": [
+                    {
+                        "sectionHeader": "DEFAULT",
+                        "settings": [
+                            {
+                                "key": "enabled_backends",
+                                "value": "lvm"
+                            }
+                        ]
+                    }
+                ],
+                "extraConfigFiles": [
+                    {
+                        "name": "test.conf",
+                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                    }
+                ]
+            },
+            "volumeType": {
+                "settings": [
+                    {
+                        "key": "volume_backend_name",
+                        "value": "lvm"
+                    }
+                ]
+            },
+            "image": {
+                "useMultipath": true,
+                "forceMultipath": true
+            },
+            "updateTime": "2025-09-09T10:30:00Z"
+        }
+    }
+]

--- a/internal/apis/v1/handlers/integrations/convert.go
+++ b/internal/apis/v1/handlers/integrations/convert.go
@@ -63,3 +63,9 @@ func (h *helper) sortStorages(storages *[]integration.Storage) {
 		return (*storages)[i].Name > (*storages)[j].Name
 	})
 }
+
+func (h *helper) sortModels(models *[]storages.Model) {
+	sort.Slice(*models, func(i, j int) bool {
+		return (*models)[i].Vendor > (*models)[j].Vendor
+	})
+}

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -30,6 +30,12 @@ var (
 			Path:    "/integrations/storages",
 			Func:    listStorages,
 		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/integrations/storages/models",
+			Func:    listModels,
+		},
 	}
 )
 
@@ -59,5 +65,26 @@ func listStorages(c *gin.Context) {
 		c,
 		"fetch integrated storages successfully",
 		storages,
+	)
+}
+
+func listModels(c *gin.Context) {
+	h, err := initHelper(c, "listModels")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	models, err := h.listModels()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"fetch integrated models successfully",
+		models,
 	)
 }

--- a/internal/apis/v1/handlers/integrations/helper.go
+++ b/internal/apis/v1/handlers/integrations/helper.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/integration"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
 )
@@ -34,4 +35,15 @@ func (h *helper) listStorages() ([]integration.Storage, error) {
 	storages := h.convertToStorages(cinders)
 	h.sortStorages(&storages)
 	return storages, nil
+}
+
+func (h *helper) listModels() ([]storages.Model, error) {
+	models, err := cubecos.ListModels()
+	if err != nil {
+		log.Errorf("integrations(%s): failed to list models (%v)", h.reqId, err)
+		return nil, err
+	}
+
+	h.sortModels(&models)
+	return models, nil
 }

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -29,13 +29,13 @@ func ListStorages() ([]storages.Cinder, error) {
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_get_storages").CombinedOutput()
 	if err != nil {
-		err := genIntegrationErr("function exec failure")
+		err := genIntegrationErr("storage exec failure")
 		log.Errorf("storage: %s (%s)", err.Error(), string(out))
 		return nil, err
 	}
 
 	if !IsHexSdkSuccess(err) {
-		err := genIntegrationErr("function output failure")
+		err := genIntegrationErr("storage output failure")
 		log.Errorf("storage: %s (%s)", err.Error(), string(out))
 		return nil, err
 	}
@@ -43,7 +43,34 @@ func ListStorages() ([]storages.Cinder, error) {
 	list := []storages.Cinder{}
 	err = json.Unmarshal(out, &list)
 	if err != nil {
-		err := genIntegrationErr("function parsing failure")
+		err := genIntegrationErr("storage parsing failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return nil, err
+	}
+
+	return list, nil
+}
+
+func ListModels() ([]storages.Model, error) {
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "host_get_models").CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("model exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return nil, err
+	}
+
+	if !IsHexSdkSuccess(err) {
+		err := genIntegrationErr("model output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return nil, err
+	}
+
+	list := []storages.Model{}
+	err = json.Unmarshal(out, &list)
+	if err != nil {
+		err := genIntegrationErr("model parsing failure")
 		log.Errorf("storage: %s (%s)", err.Error(), string(out))
 		return nil, err
 	}


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return 500 RC until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/359

<br/>

### What this PR does?

- Based on the design of https://github.com/bigstack-oss/cubecos/issues/359 to integrate the `GET /integrations/storages/models` with Hex SDK

<br/>

### Test results(optional)

1). make sure the api doc has updated properly

https://github.com/user-attachments/assets/91faef02-1744-4712-b0f1-1e4b3dfc061b
