### PR TITLE
Integrate the GET /integrations/storages/vendors with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3519,11 +3519,11 @@ const docTemplate = `{
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/models": {
             "get": {
-                "operationId": "listStorageModels",
+                "operationId": "listIntegratedStorageModels",
                 "tags": [
                     "Integrations"
                 ],
-                "summary": "Retrieve the list of storage models",
+                "summary": "Retrieve the list of integrated storage models",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
@@ -3531,7 +3531,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Retrieve the list of storage models successfully",
+                        "description": "Retrieve the list of integrated storage models successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3539,7 +3539,7 @@ const docTemplate = `{
                                 },
                                 "examples": {
                                     "example1": {
-                                        "summary": "Storage models",
+                                        "summary": "Integrated storage models",
                                         "value": {
                                             "code": 200,
                                             "data": [
@@ -3677,6 +3677,94 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch storage models: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/vendors": {
+            "get": {
+                "operationId": "listIntegratedStorageVendors",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Retrieve the list of integrated storage vendors",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the list of integrated storage vendors successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Integrated storage vendors",
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "data",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Storage vendors",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                "NetApp",
+                                                "Dell"
+                                            ],
+                                            "msg": "fetch integrated storage vendors successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch integrated storage vendors: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -3515,11 +3515,11 @@
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/models": {
             "get": {
-                "operationId": "listStorageModels",
+                "operationId": "listIntegratedStorageModels",
                 "tags": [
                     "Integrations"
                 ],
-                "summary": "Retrieve the list of storage models",
+                "summary": "Retrieve the list of integrated storage models",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
@@ -3527,7 +3527,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Retrieve the list of storage models successfully",
+                        "description": "Retrieve the list of integrated storage models successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3535,7 +3535,7 @@
                                 },
                                 "examples": {
                                     "example1": {
-                                        "summary": "Storage models",
+                                        "summary": "Integrated storage models",
                                         "value": {
                                             "code": 200,
                                             "data": [
@@ -3673,6 +3673,94 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch storage models: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/vendors": {
+            "get": {
+                "operationId": "listIntegratedStorageVendors",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Retrieve the list of integrated storage vendors",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieve the list of integrated storage vendors successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Integrated storage vendors",
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "data",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "example1": {
+                                        "summary": "Storage vendors",
+                                        "value": {
+                                            "code": 200,
+                                            "data": [
+                                                "NetApp",
+                                                "Dell"
+                                            ],
+                                            "msg": "fetch integrated storage vendors successfully",
+                                            "status": "ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to fetch integrated storage vendors: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/internal/apis/v1/handlers/integrations/convert.go
+++ b/internal/apis/v1/handlers/integrations/convert.go
@@ -64,6 +64,12 @@ func (h *helper) sortStorages(storages *[]integration.Storage) {
 	})
 }
 
+func (h *helper) sortVendors(vendors *[]string) {
+	sort.Slice(*vendors, func(i, j int) bool {
+		return (*vendors)[i] > (*vendors)[j]
+	})
+}
+
 func (h *helper) sortModels(models *[]storages.Model) {
 	sort.Slice(*models, func(i, j int) bool {
 		return (*models)[i].Vendor > (*models)[j].Vendor

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -40,6 +40,12 @@ var (
 		{
 			Version: apis.V1,
 			Method:  http.MethodGet,
+			Path:    "/integrations/storages/vendors",
+			Func:    listVendors,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodGet,
 			Path:    "/integrations/storages/models",
 			Func:    listModels,
 		},
@@ -103,6 +109,27 @@ func getStorage(c *gin.Context) {
 		c,
 		"fetch integrated storage details successfully",
 		storage,
+	)
+}
+
+func listVendors(c *gin.Context) {
+	h, err := initHelper(c, "listVendors")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	vendors, err := h.listVendors()
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"fetch integrated storage vendors successfully",
+		vendors,
 	)
 }
 

--- a/internal/apis/v1/handlers/integrations/helper.go
+++ b/internal/apis/v1/handlers/integrations/helper.go
@@ -39,6 +39,17 @@ func (h *helper) listStorages() ([]integration.Storage, error) {
 	return storages, nil
 }
 
+func (h *helper) listVendors() ([]string, error) {
+	vendors, err := cubecos.ListVendors()
+	if err != nil {
+		log.Errorf("integrations(%s): failed to list vendors (%v)", h.reqId, err)
+		return nil, err
+	}
+
+	h.sortVendors(&vendors)
+	return vendors, nil
+}
+
 func (h *helper) listModels() ([]storages.Model, error) {
 	models, err := cubecos.ListModels()
 	if err != nil {

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -83,6 +83,25 @@ func GetStorage(name string) (*storages.Cinder, error) {
 	)
 }
 
+func ListVendors() ([]string, error) {
+	models, err := ListModels()
+	if err != nil {
+		return nil, err
+	}
+
+	vendors := []string{}
+	isAdded := map[string]bool{}
+	for _, model := range models {
+		_, found := isAdded[model.Vendor]
+		if !found {
+			vendors = append(vendors, model.Vendor)
+			isAdded[model.Vendor] = true
+		}
+	}
+
+	return vendors, nil
+}
+
 func ListModels() ([]storages.Model, error) {
 	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
 	defer cancel()


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return empty or http 500 until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/244

<br/>

### What this PR does?

- Integrate the GET /integrations/storages/vendors with Hex SDK

- Add the corresponding API docs

<br/>

### Test results (optional)

1). make sure the api docs have been updated

https://github.com/user-attachments/assets/f737eeda-9825-4957-a4a9-d8df6e3c03e2

