### PR TITLE
Integrate the POST /integrations/storages with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3392,7 +3392,7 @@ const docTemplate = `{
                 "tags": [
                     "Integrations"
                 ],
-                "summary": "Create an integrated storage",
+                "summary": "Integreate a storage",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
@@ -3457,7 +3457,7 @@ const docTemplate = `{
                 },
                 "responses": {
                     "202": {
-                        "description": "Receive the request to create an integrated storage successfully",
+                        "description": "Receive the request to integrate a storage successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3469,7 +3469,7 @@ const docTemplate = `{
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "receive the request to create an integrated storage successfully"
+                                            "example": "receive the request to integrate a storage successfully"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.go
+++ b/api/docs.go
@@ -3386,6 +3386,149 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "post": {
+                "operationId": "createIntegratedStorage",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Create an integrated storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegratedStorageRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Create integrated storage request",
+                                    "value": {
+                                        "asDefault": true,
+                                        "name": "example-storage",
+                                        "isExternal": false,
+                                        "device": {
+                                            "vendor": "Dell",
+                                            "product": "PowerVault ME4024"
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.rbd.RBDDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "ceph"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "ceph"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to create an integrated storage successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to create an integrated storage successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage name example-storage already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/{storageName}": {
@@ -17812,6 +17955,97 @@ const docTemplate = `{
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "CreateIntegratedStorageRequest": {
+                "type": "object",
+                "required": [
+                    "asDefault",
+                    "name",
+                    "isExternal",
+                    "device",
+                    "storage"
+                ],
+                "properties": {
+                    "asDefault": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "isExternal": {
+                        "type": "boolean"
+                    },
+                    "device": {
+                        "type": "object",
+                        "required": [
+                            "vendor",
+                            "product"
+                        ],
+                        "properties": {
+                            "vendor": {
+                                "type": "string"
+                            },
+                            "product": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "storage": {
+                        "type": "object",
+                        "required": [
+                            "service",
+                            "volumeType",
+                            "image"
+                        ],
+                        "properties": {
+                            "service": {
+                                "type": "object",
+                                "required": [
+                                    "driverSection",
+                                    "extraSettings",
+                                    "extraConfigFiles"
+                                ],
+                                "properties": {
+                                    "driverSection": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "volumeType": {
+                                "type": "object",
+                                "required": [
+                                    "settings"
+                                ],
+                                "properties": {
+                                    "settings": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "image": {
+                                "type": "object",
+                                "required": [
+                                    "useMultipath",
+                                    "forceMultipath"
+                                ],
+                                "properties": {
+                                    "useMultipath": {
+                                        "type": "boolean"  
+                                    },
+                                    "forceMultipath": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -3382,6 +3382,149 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "operationId": "createIntegratedStorage",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Create an integrated storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegratedStorageRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Create integrated storage request",
+                                    "value": {
+                                        "asDefault": true,
+                                        "name": "example-storage",
+                                        "isExternal": false,
+                                        "device": {
+                                            "vendor": "Dell",
+                                            "product": "PowerVault ME4024"
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.rbd.RBDDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "ceph"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "ceph"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to create an integrated storage successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to create an integrated storage successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage name example-storage already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/{storageName}": {
@@ -17808,6 +17951,97 @@
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "CreateIntegratedStorageRequest": {
+                "type": "object",
+                "required": [
+                    "asDefault",
+                    "name",
+                    "isExternal",
+                    "device",
+                    "storage"
+                ],
+                "properties": {
+                    "asDefault": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "isExternal": {
+                        "type": "boolean"
+                    },
+                    "device": {
+                        "type": "object",
+                        "required": [
+                            "vendor",
+                            "product"
+                        ],
+                        "properties": {
+                            "vendor": {
+                                "type": "string"
+                            },
+                            "product": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "storage": {
+                        "type": "object",
+                        "required": [
+                            "service",
+                            "volumeType",
+                            "image"
+                        ],
+                        "properties": {
+                            "service": {
+                                "type": "object",
+                                "required": [
+                                    "driverSection",
+                                    "extraSettings",
+                                    "extraConfigFiles"
+                                ],
+                                "properties": {
+                                    "driverSection": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "volumeType": {
+                                "type": "object",
+                                "required": [
+                                    "settings"
+                                ],
+                                "properties": {
+                                    "settings": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "image": {
+                                "type": "object",
+                                "required": [
+                                    "useMultipath",
+                                    "forceMultipath"
+                                ],
+                                "properties": {
+                                    "useMultipath": {
+                                        "type": "boolean"  
+                                    },
+                                    "forceMultipath": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -3388,7 +3388,7 @@
                 "tags": [
                     "Integrations"
                 ],
-                "summary": "Create an integrated storage",
+                "summary": "Integreate a storage",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
@@ -3453,7 +3453,7 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "Receive the request to create an integrated storage successfully",
+                        "description": "Receive the request to integrate a storage successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3465,7 +3465,7 @@
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "receive the request to create an integrated storage successfully"
+                                            "example": "receive the request to integrate a storage successfully"
                                         },
                                         "status": {
                                             "type": "string",

--- a/internal/apis/v1/handlers/integrations/delegation.go
+++ b/internal/apis/v1/handlers/integrations/delegation.go
@@ -1,0 +1,115 @@
+package integrations
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	defstorages "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	"github.com/bigstack-oss/cube-cos-api/internal/operators/v1/storages"
+	"github.com/mohae/deepcopy"
+	log "go-micro.dev/v5/logger"
+)
+
+var (
+	reqQueue = storages.ReqQueue
+)
+
+func (h *helper) updateStorageToControllers() {
+	h.updateStorageToLocal()
+	h.updateStorageToPeers()
+}
+
+func (h *helper) updateStorageToLocal() {
+	if cubecos.IsVirtualIpOwner(base.Hostname) {
+		h.addReqRecord()
+	}
+
+	reqQueue.Add(&h.storageReqOpts)
+}
+
+func (h *helper) updateStorageToPeers() {
+	if !cubecos.IsVirtualIpOwner(base.Hostname) {
+		return
+	}
+
+	nodes, err := nodes.GetPeerControls()
+	if err != nil {
+		log.Errorf("storages(%s): failed to get peer controller nodes: %v", h.reqId, err)
+		return
+	}
+
+	for _, node := range nodes {
+		h.updatePeerStorage(node)
+	}
+}
+
+func (h *helper) updatePeerStorage(node nodes.Node) error {
+	reqOpts, err := h.genPeerStorageReq(node.Hostname)
+	if err != nil {
+		return nil
+	}
+
+	url := h.getStorageUrlByHandler(node)
+	req := h.http.R().
+		SetHeaders(h.convertHeadersToMap(h.c.Request.Header)).
+		SetBody(string(reqOpts))
+	resp, err := req.Execute(h.c.Request.Method, url)
+	if err != nil {
+		log.Errorf(
+			"storages(%s): failed to update peer storage %s(%v)",
+			h.reqId, node.Hostname, err,
+		)
+		return err
+	}
+
+	if resp.IsError() {
+		log.Errorf(
+			"storages(%s): has resp error during updating peer storage on node %s(%s)",
+			h.reqId, node.Hostname, resp.String(),
+		)
+		return err
+	}
+
+	return nil
+}
+
+func (h *helper) getStorageUrlByHandler(node nodes.Node) string {
+	switch h.handler {
+	case "creaeteStorage":
+		return node.PostStorageUrl()
+	case "updateStorage":
+		return node.PatchStorageUrl(h.storageReqOpts.Name)
+	case "deleteStorage":
+		return node.DeleteStorageUrl(h.storageReqOpts.Name)
+	default:
+		return node.PostStorageUrl()
+	}
+}
+
+func (h *helper) genPeerStorageReq(hostname string) ([]byte, error) {
+	reqOpts := deepcopy.Copy(h.storageReqOpts).(defstorages.ReqOpts)
+	reqOpts.Hostname = hostname
+	req, err := json.Marshal(reqOpts)
+	if err != nil {
+		log.Errorf("storages(%s): failed to marshal storage request for node %s(%v)", h.reqId, hostname, err)
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (h *helper) convertHeadersToMap(headers http.Header) map[string]string {
+	headerMap := map[string]string{}
+	for key, values := range headers {
+		if len(values) > 0 {
+			headerMap[key] = values[0]
+		}
+	}
+
+	maps.Copy(headerMap, nodes.GetSecretHeaders())
+	return headerMap
+}

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -33,6 +33,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodPost,
+			Path:    "/integrations/storages",
+			Func:    createStorage,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodGet,
 			Path:    "/integrations/storages/:storageName",
 			Func:    getStorage,
@@ -48,6 +54,18 @@ var (
 			Method:  http.MethodGet,
 			Path:    "/integrations/storages/models",
 			Func:    listModels,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/integrations/storages/tasks",
+			Func:    updateStorageTask,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/integrations/storages/models/tasks",
+			Func:    updateModelTask,
 		},
 	}
 )
@@ -112,6 +130,31 @@ func getStorage(c *gin.Context) {
 	)
 }
 
+func createStorage(c *gin.Context) {
+	h, err := initHelper(c, "createStorage")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageExist(h.storageReqOpts.Name)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if found {
+		bodies.SetNotFound(c, fmt.Errorf("storage %s already exists", h.storageReqOpts.Name))
+		return
+	}
+
+	h.updateStorageToControllers()
+	bodies.SetAccepted(
+		c,
+		"create integrated storage successfully",
+	)
+}
+
 func listVendors(c *gin.Context) {
 	h, err := initHelper(c, "listVendors")
 	if err != nil {
@@ -151,5 +194,63 @@ func listModels(c *gin.Context) {
 		c,
 		"fetch integrated models successfully",
 		models,
+	)
+}
+
+func updateStorageTask(c *gin.Context) {
+	h, err := initHelper(c, "updateStorageTask")
+	if err != nil {
+		log.Errorf("storages(%s): failed to init request helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.checkTaskUpdateReq()
+	if err != nil {
+		log.Errorf("storages(%s): failed to check storage task(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.updateStorageTask()
+	if err != nil {
+		log.Errorf("storages(%s): failed to update storage status(%v)", h.reqId, err)
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"storage status updated",
+		nil,
+	)
+}
+
+func updateModelTask(c *gin.Context) {
+	h, err := initHelper(c, "updateModelTask")
+	if err != nil {
+		log.Errorf("storages(%s): failed to init request helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.checkTaskUpdateReq()
+	if err != nil {
+		log.Errorf("storages(%s): failed to check model task(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	err = h.updateModelTask()
+	if err != nil {
+		log.Errorf("storages(%s): failed to update model status(%v)", h.reqId, err)
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"model status updated",
+		nil,
 	)
 }

--- a/internal/apis/v1/handlers/integrations/helper.go
+++ b/internal/apis/v1/handlers/integrations/helper.go
@@ -1,6 +1,8 @@
 package integrations
 
 import (
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/mongo"
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/integration"
@@ -14,7 +16,11 @@ type helper struct {
 	reqId   string
 	handler string
 
+	mongo *mongo.Helper
+	http  *http.Helper
+
 	storageReqOpts storages.ReqOpts
+	modelReqOpts   storages.ModelReqOpts
 }
 
 func initHelper(c *gin.Context, handler string) (*helper, error) {
@@ -22,6 +28,7 @@ func initHelper(c *gin.Context, handler string) (*helper, error) {
 		c:       c,
 		reqId:   queries.GetReqId(c),
 		handler: handler,
+		mongo:   mongo.GetGlobalHelper(),
 	}
 
 	return h, h.parseParamsByHandler()

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -1,11 +1,20 @@
 package integrations
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+)
 
 func (h *helper) parseParamsByHandler() error {
 	switch h.handler {
 	case "getStorage":
 		return h.parseGetStorageParams()
+	case "createStorage":
+		return h.parseCreateStorageParams()
+	case "updateStorageTask":
+		return h.parseUpdateStorageTaskOptions()
 	default:
 		return nil
 	}
@@ -15,6 +24,34 @@ func (h *helper) parseGetStorageParams() error {
 	h.storageReqOpts.Name = h.c.Param("storageName")
 	if h.storageReqOpts.Name == "" {
 		return errors.New("storage name is required")
+	}
+
+	return nil
+}
+
+func (h *helper) parseCreateStorageParams() error {
+	err := h.c.ShouldBindJSON(&h.storageReqOpts.Cinder)
+	if err != nil {
+		return err
+	}
+
+	if h.storageReqOpts.Name == "" {
+		return errors.New("storage name is required")
+	}
+
+	h.storageReqOpts.ReqId = h.reqId
+	h.storageReqOpts.Hostname = base.Hostname
+	h.storageReqOpts.SetCreating()
+	return nil
+}
+
+func (h *helper) parseUpdateStorageTaskOptions() error {
+	err := h.c.ShouldBindJSON(&h.storageReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse patch storage task options(%v)",
+			err,
+		)
 	}
 
 	return nil

--- a/internal/apis/v1/handlers/integrations/record.go
+++ b/internal/apis/v1/handlers/integrations/record.go
@@ -1,0 +1,53 @@
+package integrations
+
+import (
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/fixpacks"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	log "go-micro.dev/v5/logger"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func (h *helper) addReqRecord() {
+	err := h.mongo.UpdateOne(
+		fixpacks.Db,
+		fixpacks.ReqCollection,
+		bson.M{
+			"hostname": base.Hostname,
+			"name":     h.storageReqOpts.Name,
+		},
+		bson.M{"$set": h.storageReqOpts},
+		options.Update().SetUpsert(true),
+	)
+	if err != nil {
+		log.Errorf(
+			"integrations(%s): failed to add storage request record(%v)",
+			h.reqId, err,
+		)
+	}
+}
+
+func (h *helper) updateStorageTask() error {
+	return h.mongo.DeleteOne(
+		storages.Db,
+		storages.ReqCollection,
+		bson.M{
+			"hostname": h.storageReqOpts.Hostname,
+			"device":   h.storageReqOpts.Name,
+			"reqId":    h.storageReqOpts.ReqId,
+		},
+	)
+}
+
+func (h *helper) updateModelTask() error {
+	return h.mongo.DeleteOne(
+		storages.Db,
+		storages.ModelReqCollection,
+		bson.M{
+			"hostname": h.modelReqOpts.Hostname,
+			"device":   h.modelReqOpts.Name,
+			"reqId":    h.modelReqOpts.ReqId,
+		},
+	)
+}

--- a/internal/apis/v1/handlers/integrations/verify.go
+++ b/internal/apis/v1/handlers/integrations/verify.go
@@ -1,0 +1,15 @@
+package integrations
+
+import "fmt"
+
+func (h *helper) checkTaskUpdateReq() error {
+	if h.storageReqOpts.Name == "" {
+		return fmt.Errorf("storage name is required")
+	}
+
+	if h.storageReqOpts.Hostname == "" {
+		return fmt.Errorf("hostname is required")
+	}
+
+	return nil
+}

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -13,6 +13,25 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
+func SetDefaultStorage(name string) error {
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_set_default_storage", name).CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("set default storage exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	if !IsHexSuccessful(err) {
+		err := genIntegrationErr("set default storage output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	return nil
+}
+
 func ListBuiltInApplications() []integration.Service {
 	if !datacenter.IsCloudType() {
 		return integration.GetCommonServices()
@@ -81,6 +100,32 @@ func GetStorage(name string) (*storages.Cinder, error) {
 	return nil, fmt.Errorf(
 		"storage %s not found", name,
 	)
+}
+
+func CreateStorage(req storages.ReqOpts) error {
+	input, err := json.Marshal(req)
+	if err != nil {
+		err := genIntegrationErr("storage req parsing failure")
+		log.Errorf("storage: %s (%v)", err.Error(), err)
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_put_storage", string(input)).CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("storage exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	if !IsHexSuccessful(err) {
+		err := genIntegrationErr("storage output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	return nil
 }
 
 func ListVendors() ([]string, error) {

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -307,3 +307,33 @@ func (n *Node) UpdateFixpackTaskUrl() string {
 	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/fixpacks/tasks", base.DataCenterName)
 	return u.String()
 }
+
+func (n *Node) PostStorageUrl() string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages", base.DataCenterName)
+	return u.String()
+}
+
+func (n *Node) PatchStorageUrl(name string) string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/%s", base.DataCenterName, name)
+	return u.String()
+}
+
+func (n *Node) DeleteStorageUrl(name string) string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/%s", base.DataCenterName, name)
+	return u.String()
+}
+
+func (n *Node) UpdateStorageTaskUrl() string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/tasks", base.DataCenterName)
+	return u.String()
+}
+
+func (n *Node) UpdateModelTaskUrl() string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/models/tasks", base.DataCenterName)
+	return u.String()
+}

--- a/internal/definition/v1/status/status.go
+++ b/internal/definition/v1/status/status.go
@@ -172,6 +172,20 @@ type Fixpack struct {
 	Description    string `json:"description,omitempty" bson:"description"`
 }
 
+type Storage struct {
+	Current      string `json:"current,omitempty" bson:"current"`
+	Desired      string `json:"-" bson:"desired"`
+	IsProcessing bool   `json:"isProcessing" bson:"isProcessing"`
+	UpdatedAt    string `json:"updatedAt,omitempty" bson:"updatedAt"`
+}
+
+type Model struct {
+	Current      string `json:"current,omitempty" bson:"current"`
+	Desired      string `json:"-" bson:"desired"`
+	IsProcessing bool   `json:"isProcessing" bson:"isProcessing"`
+	UpdatedAt    string `json:"updatedAt,omitempty" bson:"updatedAt"`
+}
+
 type SystemUpdateProgress struct {
 	Current        string  `json:"current" bson:"current"`
 	IsProcessing   bool    `json:"isProcessing" bson:"isProcessing"`

--- a/internal/definition/v1/storages/storage.go
+++ b/internal/definition/v1/storages/storage.go
@@ -26,6 +26,7 @@ type ModelReqOpts struct {
 }
 
 type Cinder struct {
+	AsDefault  bool   `json:"asDefault" yaml:"asDefault" bson:"asDefault"`
 	Name       string `json:"name" yaml:"name" bson:"name"`
 	IsExternal bool   `json:"isExternal" yaml:"isExternal" bson:"isExternal"`
 	Device     `json:"device" yaml:"device" bson:"device"`

--- a/internal/definition/v1/storages/storage.go
+++ b/internal/definition/v1/storages/storage.go
@@ -1,11 +1,28 @@
 package storages
 
+import "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+
 const (
-	CinderConf = "/etc/cinder/cinder.conf"
+	Db                 = "storages"
+	ReqCollection      = "storageRequests"
+	ModelReqCollection = "modelRequests"
+	CinderConf         = "/etc/cinder/cinder.conf"
 )
 
 type ReqOpts struct {
-	Name string
+	ReqId    string `json:"reqId" bson:"reqId"`
+	Name     string `json:"name" bson:"name"`
+	Hostname string `json:"hostname" bson:"hostname"`
+	Cinder   `json:"cinder" bson:"cinder"`
+	Status   status.Storage `json:"status" bson:"status"`
+}
+
+type ModelReqOpts struct {
+	ReqId    string `json:"reqId" bson:"reqId"`
+	Name     string `json:"name" bson:"name"`
+	Hostname string `json:"hostname" bson:"hostname"`
+	Model    `json:"model" bson:"model"`
+	Status   status.Model `json:"status" bson:"status"`
 }
 
 type Cinder struct {
@@ -49,4 +66,42 @@ type VolumeType struct {
 type Image struct {
 	UseMultipath   bool `json:"useMultipath" yaml:"useMultipath" bson:"useMultipath"`
 	ForceMultipath bool `json:"forceMultipath" yaml:"forceMultipath" bson:"forceMultipath"`
+}
+
+func (r *ReqOpts) SetCreating() {
+	r.Status.Current = status.Creating
+	r.Status.Desired = status.Created
+	r.Status.IsProcessing = true
+}
+
+func (r *ReqOpts) SetUpdating() {
+	r.Status.Current = status.Updating
+	r.Status.Desired = status.Updated
+	r.Status.IsProcessing = true
+}
+
+func (r *ReqOpts) SetDeleting() {
+	r.Status.Current = status.Deleting
+	r.Status.Desired = status.Deleted
+	r.Status.IsProcessing = true
+}
+
+func (r *ReqOpts) SetCompleted() {
+	r.Status.Current = status.Completed
+	r.Status.IsProcessing = false
+}
+
+func (r *ReqOpts) SetFailed() {
+	r.Status.Current = status.Failed
+	r.Status.IsProcessing = false
+}
+
+func (m *ModelReqOpts) SetCompleted() {
+	m.Status.Current = status.Completed
+	m.Status.IsProcessing = false
+}
+
+func (m *ModelReqOpts) SetFailed() {
+	m.Status.Current = status.Failed
+	m.Status.IsProcessing = false
 }

--- a/internal/operators/v1/storages/model.go
+++ b/internal/operators/v1/storages/model.go
@@ -1,0 +1,72 @@
+package storages
+
+import (
+	"fmt"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	log "go-micro.dev/v5/logger"
+)
+
+func (o *Operator) operateModelReq(req storages.ModelReqOpts) error {
+	switch req.Status.Desired {
+	case status.Created, status.Updated:
+		return o.updateModel(req)
+	case status.Deleted:
+		return o.deleteModel(req)
+	}
+
+	return fmt.Errorf(
+		"unknown desired action(%s) for model(%s)",
+		req.Status.Desired,
+		req.Name,
+	)
+}
+
+func (o *Operator) updateModel(req storages.ModelReqOpts) error {
+	return nil
+}
+
+func (o *Operator) deleteModel(req storages.ModelReqOpts) error {
+	return nil
+}
+
+func (o *Operator) handleModelExit(req storages.ModelReqOpts, err error) {
+	if err != nil {
+		log.Errorf("storages: failed to %s %s(%v)", req.Status.Desired, req.Name, err)
+		req.SetFailed()
+	} else {
+		log.Infof("storages: %s %s successfully", req.Status.Desired, req.Name)
+		req.SetCompleted()
+	}
+
+	o.reportModelToController(req)
+}
+
+func (o *Operator) reportModelToController(req storages.ModelReqOpts) {
+	node, err := cubecos.GetVirtualIpController()
+	if err != nil {
+		log.Errorf("storages: failed to report %s result to control(%v)", req.Name, err)
+		return
+	}
+
+	resp, err := o.http.R().
+		SetHeaders(nodes.GetSecretHeaders()).
+		SetBody(req).
+		Patch(node.UpdateModelTaskUrl())
+	if err != nil {
+		log.Errorf("storages: failed to send model %s to %s(%v)", req.Name, node.Hostname, err)
+		return
+	}
+
+	if resp.IsError() {
+		log.Errorf(
+			"storages: failed to send model %s to %s(%s)",
+			req.Name,
+			node.Hostname,
+			string(resp.Body()),
+		)
+	}
+}

--- a/internal/operators/v1/storages/operate.go
+++ b/internal/operators/v1/storages/operate.go
@@ -1,0 +1,98 @@
+package storages
+
+import (
+	"context"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	"github.com/bigstack-oss/cube-cos-api/internal/service"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var (
+	ReqQueue      workqueue.TypedInterface[*storages.ReqOpts]
+	ModelReqQueue workqueue.TypedInterface[*storages.ModelReqOpts]
+	module        = "storages"
+)
+
+func init() {
+	ReqQueue = workqueue.NewTyped[*storages.ReqOpts]()
+	ModelReqQueue = workqueue.NewTyped[*storages.ModelReqOpts]()
+	service.RegisterOperator(module, NewOperator())
+}
+
+type Operator struct {
+	http   *http.Helper
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewOperator() *Operator {
+	return &Operator{}
+}
+
+func (o *Operator) Name() string {
+	return module
+}
+
+func (o *Operator) Init() error {
+	o.http = http.GetGlobalHelper()
+	o.ctx, o.cancel = context.WithCancel(context.Background())
+	cubecos.RemoveHostPendingReq(storages.Db, storages.ReqCollection)
+	cubecos.RemoveHostPendingReq(storages.Db, storages.ModelReqCollection)
+	return nil
+}
+
+func (o *Operator) Run() {
+	go o.handleStorageReqs()
+	go o.handleModelReqs()
+}
+
+func (o *Operator) handleStorageReqs() {
+	for {
+		select {
+		case <-o.ctx.Done():
+			return
+		default:
+			req, shutdown := ReqQueue.Get()
+			if shutdown {
+				return
+			}
+
+			ReqQueue.Done(req)
+			if req == nil {
+				continue
+			}
+
+			err := o.operateStorageReq(*req)
+			o.handleStorageExit(*req, err)
+		}
+	}
+}
+
+func (o *Operator) handleModelReqs() {
+	for {
+		select {
+		case <-o.ctx.Done():
+			return
+		default:
+			req, shutdown := ModelReqQueue.Get()
+			if shutdown {
+				return
+			}
+
+			ModelReqQueue.Done(req)
+			if req == nil {
+				continue
+			}
+
+			err := o.operateModelReq(*req)
+			o.handleModelExit(*req, err)
+		}
+	}
+}
+
+func (o *Operator) Stop() {
+	o.cancel()
+}

--- a/internal/operators/v1/storages/storage.go
+++ b/internal/operators/v1/storages/storage.go
@@ -1,0 +1,72 @@
+package storages
+
+import (
+	"fmt"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	log "go-micro.dev/v5/logger"
+)
+
+func (o *Operator) operateStorageReq(req storages.ReqOpts) error {
+	switch req.Status.Desired {
+	case status.Created, status.Updated:
+		return o.updateStorage(req)
+	case status.Deleted:
+		return o.deleteStorage(req)
+	}
+
+	return fmt.Errorf(
+		"unknown desired action(%s) for storage(%s)",
+		req.Status.Desired,
+		req.Name,
+	)
+}
+
+func (o *Operator) updateStorage(req storages.ReqOpts) error {
+	return nil
+}
+
+func (o *Operator) deleteStorage(req storages.ReqOpts) error {
+	return nil
+}
+
+func (o *Operator) handleStorageExit(req storages.ReqOpts, err error) {
+	if err != nil {
+		log.Errorf("storages: failed to %s %s(%v)", req.Status.Desired, req.Name, err)
+		req.SetFailed()
+	} else {
+		log.Infof("storages: %s %s successfully", req.Status.Desired, req.Name)
+		req.SetCompleted()
+	}
+
+	o.reportStorageToController(req)
+}
+
+func (o *Operator) reportStorageToController(req storages.ReqOpts) {
+	node, err := cubecos.GetVirtualIpController()
+	if err != nil {
+		log.Errorf("storages: failed to report %s result to control(%v)", req.Name, err)
+		return
+	}
+
+	resp, err := o.http.R().
+		SetHeaders(nodes.GetSecretHeaders()).
+		SetBody(req).
+		Patch(node.UpdateStorageTaskUrl())
+	if err != nil {
+		log.Errorf("storages: failed to send storage %s to %s(%v)", req.Name, node.Hostname, err)
+		return
+	}
+
+	if resp.IsError() {
+		log.Errorf(
+			"storages: failed to send storage %s to %s(%s)",
+			req.Name,
+			node.Hostname,
+			string(resp.Body()),
+		)
+	}
+}

--- a/internal/operators/v1/storages/storage.go
+++ b/internal/operators/v1/storages/storage.go
@@ -26,7 +26,16 @@ func (o *Operator) operateStorageReq(req storages.ReqOpts) error {
 }
 
 func (o *Operator) updateStorage(req storages.ReqOpts) error {
-	return nil
+	err := cubecos.CreateStorage(req)
+	if err != nil {
+		return err
+	}
+
+	if !req.Cinder.AsDefault {
+		return nil
+	}
+
+	return cubecos.SetDefaultStorage(req.Name)
 }
 
 func (o *Operator) deleteStorage(req storages.ReqOpts) error {


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return empty or http 500 until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/246

<br/>

### What this PR does?

- Integrate the POST /integrations/storages with Hex SDK

- Add the corresponding API docs

<br/>

### Test results (optional)

1). make sure the api docs have been updated

https://github.com/user-attachments/assets/f8de1c98-7791-4277-b693-7531898b0fc4

