### PR TITLE
Integrate the PATCH DELETE /integrations/storages/{storage name} with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3457,7 +3457,7 @@ const docTemplate = `{
                 },
                 "responses": {
                     "202": {
-                        "description": "Receive the request to integrate a storage successfully",
+                        "description": "Receive the request to integrate a storage successfully, processing",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3469,7 +3469,7 @@ const docTemplate = `{
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "receive the request to integrate a storage successfully"
+                                            "example": "receive the request to integrate a storage successfully, processing"
                                         },
                                         "status": {
                                             "type": "string",
@@ -3732,7 +3732,7 @@ const docTemplate = `{
                 },
                 "responses": {
                     "202": {
-                        "description": "Receive the request to update an integrated storage successfully",
+                        "description": "Receive the request to update an integrated storage successfully, processing",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3744,7 +3744,7 @@ const docTemplate = `{
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "receive the request to update an integrated storage successfully"
+                                            "example": "receive the request to update an integrated storage successfully, processing"
                                         },
                                         "status": {
                                             "type": "string",
@@ -3793,6 +3793,95 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to update integrated storage: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteIntegratedStorage",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Delete an integrated storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/storageName"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to delete an integrated storage successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to delete an integrated storage successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage example-storage not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete integrated storage: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.go
+++ b/api/docs.go
@@ -3658,6 +3658,152 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "operationId": "updateIntegratedStorage",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Update an integrated storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/storageName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegratedStorageRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Update integrated storage request",
+                                    "value": {
+                                        "asDefault": true,
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "lvm"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "extraConfigFiles": [
+                                                    {
+                                                        "name": "test.conf",
+                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "lvm"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to update an integrated storage successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to update an integrated storage successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage example-storage not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update integrated storage: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/models": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -3453,7 +3453,7 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "Receive the request to integrate a storage successfully",
+                        "description": "Receive the request to integrate a storage successfully, processing",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3465,7 +3465,7 @@
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "receive the request to integrate a storage successfully"
+                                            "example": "receive the request to integrate a storage successfully, processing"
                                         },
                                         "status": {
                                             "type": "string",
@@ -3728,7 +3728,7 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "Receive the request to update an integrated storage successfully",
+                        "description": "Receive the request to update an integrated storage successfully, processing",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3740,7 +3740,7 @@
                                         },
                                         "msg": {
                                             "type": "string",
-                                            "example": "receive the request to update an integrated storage successfully"
+                                            "example": "receive the request to update an integrated storage successfully, processing"
                                         },
                                         "status": {
                                             "type": "string",
@@ -3789,6 +3789,95 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to update integrated storage: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteIntegratedStorage",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Delete an integrated storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/storageName"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to delete an integrated storage successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to delete an integrated storage successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage example-storage not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete integrated storage: internal server error"
                                         },
                                         "status": {
                                             "type": "string",

--- a/api/docs.json
+++ b/api/docs.json
@@ -3654,6 +3654,152 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "operationId": "updateIntegratedStorage",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Update an integrated storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/storageName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegratedStorageRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Update integrated storage request",
+                                    "value": {
+                                        "asDefault": true,
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "lvm"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "extraConfigFiles": [
+                                                    {
+                                                        "name": "test.conf",
+                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "lvm"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to update an integrated storage successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to update an integrated storage successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage example-storage not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to update integrated storage: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/models": {

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -39,6 +39,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodPost,
+			Path:    "/integrations/storages/:storageName",
+			Func:    updateStorage,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodGet,
 			Path:    "/integrations/storages/:storageName",
 			Func:    getStorage,
@@ -152,6 +158,31 @@ func createStorage(c *gin.Context) {
 	bodies.SetAccepted(
 		c,
 		"create integrated storage successfully",
+	)
+}
+
+func updateStorage(c *gin.Context) {
+	h, err := initHelper(c, "updateStorage")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageExist(h.storageReqOpts.Name)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if !found {
+		bodies.SetNotFound(c, fmt.Errorf("storage %s not found", h.storageReqOpts.Name))
+		return
+	}
+
+	h.updateStorageToControllers()
+	bodies.SetAccepted(
+		c,
+		"update integrated storage successfully",
 	)
 }
 

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -45,6 +45,12 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodDelete,
+			Path:    "/integrations/storages/:storageName",
+			Func:    deleteStorage,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodGet,
 			Path:    "/integrations/storages/:storageName",
 			Func:    getStorage,
@@ -157,7 +163,7 @@ func createStorage(c *gin.Context) {
 	h.updateStorageToControllers()
 	bodies.SetAccepted(
 		c,
-		"create integrated storage successfully",
+		"received create integrated storage request successfully, processing",
 	)
 }
 
@@ -182,7 +188,32 @@ func updateStorage(c *gin.Context) {
 	h.updateStorageToControllers()
 	bodies.SetAccepted(
 		c,
-		"update integrated storage successfully",
+		"received update integrated storage request successfully, processing",
+	)
+}
+
+func deleteStorage(c *gin.Context) {
+	h, err := initHelper(c, "deleteStorage")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageExist(h.storageReqOpts.Name)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if !found {
+		bodies.SetNotFound(c, fmt.Errorf("storage %s not found", h.storageReqOpts.Name))
+		return
+	}
+
+	h.updateStorageToControllers()
+	bodies.SetAccepted(
+		c,
+		"received delete integrated storage request successfully, processing",
 	)
 }
 

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -15,6 +15,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseCreateStorageParams()
 	case "updateStorage":
 		return h.parseUpdateStorageParams()
+	case "deleteStorage":
+		return h.parseDeleteStorageParams()
 	case "updateStorageTask":
 		return h.parseUpdateStorageTaskOptions()
 	default:
@@ -60,6 +62,18 @@ func (h *helper) parseUpdateStorageParams() error {
 	h.storageReqOpts.ReqId = h.reqId
 	h.storageReqOpts.Hostname = base.Hostname
 	h.storageReqOpts.SetUpdating()
+	return nil
+}
+
+func (h *helper) parseDeleteStorageParams() error {
+	h.storageReqOpts.Name = h.c.Param("storageName")
+	if h.storageReqOpts.Name == "" {
+		return errors.New("storage name is required")
+	}
+
+	h.storageReqOpts.ReqId = h.reqId
+	h.storageReqOpts.Hostname = base.Hostname
+	h.storageReqOpts.SetDeleting()
 	return nil
 }
 

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -13,6 +13,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseGetStorageParams()
 	case "createStorage":
 		return h.parseCreateStorageParams()
+	case "updateStorage":
+		return h.parseUpdateStorageParams()
 	case "updateStorageTask":
 		return h.parseUpdateStorageTaskOptions()
 	default:
@@ -42,6 +44,22 @@ func (h *helper) parseCreateStorageParams() error {
 	h.storageReqOpts.ReqId = h.reqId
 	h.storageReqOpts.Hostname = base.Hostname
 	h.storageReqOpts.SetCreating()
+	return nil
+}
+
+func (h *helper) parseUpdateStorageParams() error {
+	err := h.c.ShouldBindJSON(&h.storageReqOpts.Cinder)
+	if err != nil {
+		return err
+	}
+
+	if h.storageReqOpts.Name == "" {
+		return errors.New("storage name is required")
+	}
+
+	h.storageReqOpts.ReqId = h.reqId
+	h.storageReqOpts.Hostname = base.Hostname
+	h.storageReqOpts.SetUpdating()
 	return nil
 }
 

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -128,6 +128,25 @@ func CreateStorage(req storages.ReqOpts) error {
 	return nil
 }
 
+func DeleteStorage(name string) error {
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_delete_storage", name).CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("storage exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	if !IsHexSuccessful(err) {
+		err := genIntegrationErr("storage output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	return nil
+}
+
 func ListVendors() ([]string, error) {
 	models, err := ListModels()
 	if err != nil {

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -129,9 +129,17 @@ func CreateStorage(req storages.ReqOpts) error {
 }
 
 func DeleteStorage(name string) error {
+	nameMap := map[string]string{"name": name}
+	input, err := json.Marshal(nameMap)
+	if err != nil {
+		err := genIntegrationErr("storage req parsing failure")
+		log.Errorf("storage: %s (%v)", err.Error(), err)
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_delete_storage", name).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_delete_storage", string(input)).CombinedOutput()
 	if err != nil {
 		err := genIntegrationErr("storage exec failure")
 		log.Errorf("storage: %s (%s)", err.Error(), string(out))

--- a/internal/operators/v1/storages/storage.go
+++ b/internal/operators/v1/storages/storage.go
@@ -15,7 +15,7 @@ func (o *Operator) operateStorageReq(req storages.ReqOpts) error {
 	case status.Created, status.Updated:
 		return o.updateStorage(req)
 	case status.Deleted:
-		return o.deleteStorage(req)
+		return cubecos.DeleteStorage(req.Name)
 	}
 
 	return fmt.Errorf(
@@ -36,10 +36,6 @@ func (o *Operator) updateStorage(req storages.ReqOpts) error {
 	}
 
 	return cubecos.SetDefaultStorage(req.Name)
-}
-
-func (o *Operator) deleteStorage(req storages.ReqOpts) error {
-	return nil
 }
 
 func (o *Operator) handleStorageExit(req storages.ReqOpts, err error) {


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return empty or http 500 until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/247

https://github.com/bigstack-oss/cubecos/issues/248

<br/>

### What this PR does?

- Integrate the PATCH DELETE /integrations/storages/{storage name} with Hex SDK

- Add the corresponding API docs

<br/>

### Test results (optional)

1). make sure the api docs have been updated

https://github.com/user-attachments/assets/062438f9-f8b5-4d4c-a0fe-248653d2c98c

