### PR TITLE
Integrate the POST /integrations/storages/models and PATCH DELETE /integrations/storages/models/{vendor name}/{product name} with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -320,6 +320,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -344,6 +349,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -368,6 +378,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3462,6 +3477,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3486,6 +3506,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3510,6 +3535,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3615,6 +3645,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3639,6 +3674,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3737,6 +3777,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3761,6 +3806,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3785,6 +3835,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3826,6 +3881,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3850,6 +3910,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3874,6 +3939,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -4047,6 +4117,11 @@ const docTemplate = `{
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -4055,6 +4130,691 @@ const docTemplate = `{
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch storage models: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "createIntegratedStorageModel",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Create an integrated storage model",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegratedStorageModelRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Create integrated storage model request",
+                                    "value": {
+                                        "vendor": "Dell",
+                                        "product": "PowerVault",
+                                        "multipath": {
+                                            "defaults": [
+                                                {
+                                                    "key": "user_friendly_names",
+                                                    "value": "yes"
+                                                }
+                                            ],
+                                            "blacklist": {
+                                                "devnode": "sda",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "Generic",
+                                                        "product": "USB",
+                                                        "settings": [
+                                                            {
+                                                                "key": "dev_loss_tmo",
+                                                                "value": "10"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "blacklistExceptions": {
+                                                "devnode": "sd[b-z]",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "HP",
+                                                        "product": "MSA",
+                                                        "settings": [
+                                                            {
+                                                                "key": "polling_interval",
+                                                                "value": "5"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "devices": [
+                                                {
+                                                    "vendor": "EMC",
+                                                    "product": "VNX",
+                                                    "settings": [
+                                                        {
+                                                            "key": "no_path_retry",
+                                                            "value": "fail"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "overrides": [
+                                                {
+                                                    "key": "checker_timeout",
+                                                    "value": "30"
+                                                }
+                                            ],
+                                            "multipaths": [
+                                                {
+                                                    "wwid": "3600508b400105e210000900000490000",
+                                                    "settings": [
+                                                        {
+                                                            "key": "path_grouping_policy",
+                                                            "value": "group_by_prio"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "lvm"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "extraConfigFiles": [
+                                                    {
+                                                        "name": "test.conf",
+                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "lvm"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            },
+                                            "updateTime": "2025-09-09T10:30:00Z"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to create an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to create an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "vendor and product are required fields"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage model: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/models/{vendorName}/{productName}": {
+            "delete": {
+                "operationId": "deleteIntegratedStorageModel",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Delete an integrated storage model",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/vendorName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/productName"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to delete an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to delete an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault is in use by some integrated storages"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete integrated storage model: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "updateIntegratedStorageModel",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Create an integrated storage model",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/vendorName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/productName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateIntegratedStorageModelRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Update integrated storage model request",
+                                    "value": {
+                                        "vendor": "Dell",
+                                        "product": "PowerVault",
+                                        "multipath": {
+                                            "defaults": [
+                                                {
+                                                    "key": "user_friendly_names",
+                                                    "value": "yes"
+                                                }
+                                            ],
+                                            "blacklist": {
+                                                "devnode": "sda",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "Generic",
+                                                        "product": "USB",
+                                                        "settings": [
+                                                            {
+                                                                "key": "dev_loss_tmo",
+                                                                "value": "10"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "blacklistExceptions": {
+                                                "devnode": "sd[b-z]",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "HP",
+                                                        "product": "MSA",
+                                                        "settings": [
+                                                            {
+                                                                "key": "polling_interval",
+                                                                "value": "5"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "devices": [
+                                                {
+                                                    "vendor": "EMC",
+                                                    "product": "VNX",
+                                                    "settings": [
+                                                        {
+                                                            "key": "no_path_retry",
+                                                            "value": "fail"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "overrides": [
+                                                {
+                                                    "key": "checker_timeout",
+                                                    "value": "30"
+                                                }
+                                            ],
+                                            "multipaths": [
+                                                {
+                                                    "wwid": "3600508b400105e210000900000490000",
+                                                    "settings": [
+                                                        {
+                                                            "key": "path_grouping_policy",
+                                                            "value": "group_by_prio"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "lvm"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "extraConfigFiles": [
+                                                    {
+                                                        "name": "test.conf",
+                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "lvm"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            },
+                                            "updateTime": "2025-09-09T10:30:00Z"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to update an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to update an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "vendor and product are required fields"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault is under processing, try again later"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage model: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -16038,9 +16798,6 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
-                    },
-                    {
-                        "$ref": "#/components/parameters/version"
                     }
                 ],
                 "responses": {
@@ -16949,13 +17706,33 @@ const docTemplate = `{
                 "description": "Visibility setting for the image(only required when sourceFromAnotherHypervisor is false)."
             },
             "storageName": {
-                "name": "storageName",
                 "in": "path",
+                "name": "storageName",
                 "required": true,
                 "schema": {
                     "type": "string"
                 },
                 "description": "The name of the integrated storage."
+            },
+            "vendorName": {
+                "in": "query",
+                "name": "vendorName",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The vendor name to filter models",
+                "example": "example-vendor"
+            },
+            "productName": {
+                "in": "query",
+                "name": "productName",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The product name to filter models",
+                "example": "example-product"
             }
         },
         "schemas": {
@@ -18273,7 +19050,7 @@ const docTemplate = `{
                                 ],
                                 "properties": {
                                     "useMultipath": {
-                                        "type": "boolean"  
+                                        "type": "boolean"
                                     },
                                     "forceMultipath": {
                                         "type": "boolean"
@@ -18415,7 +19192,13 @@ const docTemplate = `{
                     "status": {
                         "type": "string"
                     }
-                }           
+                }
+            },
+            "CreateIntegratedStorageModelRequest": {
+                "$ref": "#/components/schemas/StorageModel"
+            },
+            "UpdateIntegratedStorageModelRequest": {
+                "$ref": "#/components/schemas/StorageModel"
             },
             "ListIntegratedStorageModelsResponse": {
                 "type": "object",
@@ -24329,6 +25112,211 @@ const docTemplate = `{
                         "OSD00002E": "#/components/schemas/OSD00002E",
                         "OSD00003I": "#/components/schemas/OSD00003I",
                         "OSD00003E": "#/components/schemas/OSD00003E"
+                    }
+                }
+            },
+            "StorageModel": {
+                "type": "object",
+                "required": [
+                    "vendor",
+                    "product",
+                    "multipath",
+                    "storage"
+                ],
+                "properties": {
+                    "vendor": {
+                        "type": "string"
+                    },
+                    "product": {
+                        "type": "string"
+                    },
+                    "multipath": {
+                        "type": "object",
+                        "required": [
+                            "defaults",
+                            "blacklist",
+                            "blacklistExceptions",
+                            "devices",
+                            "overrides",
+                            "multipaths"
+                        ],
+                        "properties": {
+                            "defaults": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/StorageKeyValuePair"
+                                }
+                            },
+                            "blacklist": {
+                                "type": "object",
+                                "required": [
+                                    "devnode",
+                                    "devices"
+                                ],
+                                "properties": {
+                                    "devnode": {
+                                        "type": "string"
+                                    },
+                                    "devices": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                        }
+                                    }
+                                }
+                            },
+                            "blacklistExceptions": {
+                                "type": "object",
+                                "required": [
+                                    "devnode",
+                                    "devices"
+                                ],
+                                "properties": {
+                                    "devnode": {
+                                        "type": "string"
+                                    },
+                                    "devices": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                        }
+                                    }
+                                }
+                            },
+                            "devices": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                }
+                            },
+                            "overrides": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/StorageKeyValuePair"
+                                }
+                            },
+                            "multipaths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "wwid",
+                                        "settings"
+                                    ],
+                                    "properties": {
+                                        "wwid": {
+                                            "type": "string"
+                                        },
+                                        "settings": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageKeyValuePair"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "storage": {
+                        "type": "object",
+                        "required": [
+                            "service",
+                            "volumeType",
+                            "image",
+                            "updateTime"
+                        ],
+                        "properties": {
+                            "service": {
+                                "type": "object",
+                                "required": [
+                                    "driverSection",
+                                    "extraSettings",
+                                    "extraConfigFiles"
+                                ],
+                                "properties": {
+                                    "driverSection": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    },
+                                    "extraSettings": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "sectionHeader",
+                                                "settings"
+                                            ],
+                                            "properties": {
+                                                "sectionHeader": {
+                                                    "type": "string"
+                                                },
+                                                "settings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "extraConfigFiles": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "content": {
+                                                    "type": "string",
+                                                    "description": "Base64 encoded content of the config file"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "volumeType": {
+                                "type": "object",
+                                "required": [
+                                    "settings"
+                                ],
+                                "properties": {
+                                    "settings": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "image": {
+                                "type": "object",
+                                "required": [
+                                    "useMultipath",
+                                    "forceMultipath"
+                                ],
+                                "properties": {
+                                    "useMultipath": {
+                                        "type": "boolean"
+                                    },
+                                    "forceMultipath": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "updateTime": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -316,6 +316,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -340,6 +345,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -364,6 +374,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3458,6 +3473,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3482,6 +3502,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3506,6 +3531,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3611,6 +3641,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3635,6 +3670,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3733,6 +3773,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3757,6 +3802,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3781,6 +3831,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3822,6 +3877,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3846,6 +3906,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -3870,6 +3935,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -4043,6 +4113,11 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
                                     "properties": {
                                         "code": {
                                             "type": "integer",
@@ -4051,6 +4126,691 @@
                                         "msg": {
                                             "type": "string",
                                             "example": "failed to fetch storage models: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "createIntegratedStorageModel",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Create an integrated storage model",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegratedStorageModelRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Create integrated storage model request",
+                                    "value": {
+                                        "vendor": "Dell",
+                                        "product": "PowerVault",
+                                        "multipath": {
+                                            "defaults": [
+                                                {
+                                                    "key": "user_friendly_names",
+                                                    "value": "yes"
+                                                }
+                                            ],
+                                            "blacklist": {
+                                                "devnode": "sda",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "Generic",
+                                                        "product": "USB",
+                                                        "settings": [
+                                                            {
+                                                                "key": "dev_loss_tmo",
+                                                                "value": "10"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "blacklistExceptions": {
+                                                "devnode": "sd[b-z]",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "HP",
+                                                        "product": "MSA",
+                                                        "settings": [
+                                                            {
+                                                                "key": "polling_interval",
+                                                                "value": "5"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "devices": [
+                                                {
+                                                    "vendor": "EMC",
+                                                    "product": "VNX",
+                                                    "settings": [
+                                                        {
+                                                            "key": "no_path_retry",
+                                                            "value": "fail"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "overrides": [
+                                                {
+                                                    "key": "checker_timeout",
+                                                    "value": "30"
+                                                }
+                                            ],
+                                            "multipaths": [
+                                                {
+                                                    "wwid": "3600508b400105e210000900000490000",
+                                                    "settings": [
+                                                        {
+                                                            "key": "path_grouping_policy",
+                                                            "value": "group_by_prio"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "lvm"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "extraConfigFiles": [
+                                                    {
+                                                        "name": "test.conf",
+                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "lvm"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            },
+                                            "updateTime": "2025-09-09T10:30:00Z"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to create an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to create an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "vendor and product are required fields"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage model: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/models/{vendorName}/{productName}": {
+            "delete": {
+                "operationId": "deleteIntegratedStorageModel",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Delete an integrated storage model",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/vendorName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/productName"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to delete an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to delete an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault is in use by some integrated storages"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to delete integrated storage model: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "updateIntegratedStorageModel",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Create an integrated storage model",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/vendorName"
+                    },
+                    {
+                        "$ref": "#/components/parameters/productName"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateIntegratedStorageModelRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Update integrated storage model request",
+                                    "value": {
+                                        "vendor": "Dell",
+                                        "product": "PowerVault",
+                                        "multipath": {
+                                            "defaults": [
+                                                {
+                                                    "key": "user_friendly_names",
+                                                    "value": "yes"
+                                                }
+                                            ],
+                                            "blacklist": {
+                                                "devnode": "sda",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "Generic",
+                                                        "product": "USB",
+                                                        "settings": [
+                                                            {
+                                                                "key": "dev_loss_tmo",
+                                                                "value": "10"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "blacklistExceptions": {
+                                                "devnode": "sd[b-z]",
+                                                "devices": [
+                                                    {
+                                                        "vendor": "HP",
+                                                        "product": "MSA",
+                                                        "settings": [
+                                                            {
+                                                                "key": "polling_interval",
+                                                                "value": "5"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "devices": [
+                                                {
+                                                    "vendor": "EMC",
+                                                    "product": "VNX",
+                                                    "settings": [
+                                                        {
+                                                            "key": "no_path_retry",
+                                                            "value": "fail"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "overrides": [
+                                                {
+                                                    "key": "checker_timeout",
+                                                    "value": "30"
+                                                }
+                                            ],
+                                            "multipaths": [
+                                                {
+                                                    "wwid": "3600508b400105e210000900000490000",
+                                                    "settings": [
+                                                        {
+                                                            "key": "path_grouping_policy",
+                                                            "value": "group_by_prio"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "lvm"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "extraConfigFiles": [
+                                                    {
+                                                        "name": "test.conf",
+                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "lvm"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            },
+                                            "updateTime": "2025-09-09T10:30:00Z"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to update an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to update an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "vendor and product are required fields"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 404
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault not found"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault is under processing, try again later"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage model: internal server error"
                                         },
                                         "status": {
                                             "type": "string",
@@ -16034,9 +16794,6 @@
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/dataCenter"
-                    },
-                    {
-                        "$ref": "#/components/parameters/version"
                     }
                 ],
                 "responses": {
@@ -16945,13 +17702,33 @@
                 "description": "Visibility setting for the image(only required when sourceFromAnotherHypervisor is false)."
             },
             "storageName": {
-                "name": "storageName",
                 "in": "path",
+                "name": "storageName",
                 "required": true,
                 "schema": {
                     "type": "string"
                 },
                 "description": "The name of the integrated storage."
+            },
+            "vendorName": {
+                "in": "query",
+                "name": "vendorName",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The vendor name to filter models",
+                "example": "example-vendor"
+            },
+            "productName": {
+                "in": "query",
+                "name": "productName",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "The product name to filter models",
+                "example": "example-product"
             }
         },
         "schemas": {
@@ -18269,7 +19046,7 @@
                                 ],
                                 "properties": {
                                     "useMultipath": {
-                                        "type": "boolean"  
+                                        "type": "boolean"
                                     },
                                     "forceMultipath": {
                                         "type": "boolean"
@@ -18411,7 +19188,13 @@
                     "status": {
                         "type": "string"
                     }
-                }           
+                }
+            },
+            "CreateIntegratedStorageModelRequest": {
+                "$ref": "#/components/schemas/StorageModel"
+            },
+            "UpdateIntegratedStorageModelRequest": {
+                "$ref": "#/components/schemas/StorageModel"
             },
             "ListIntegratedStorageModelsResponse": {
                 "type": "object",
@@ -24325,6 +25108,211 @@
                         "OSD00002E": "#/components/schemas/OSD00002E",
                         "OSD00003I": "#/components/schemas/OSD00003I",
                         "OSD00003E": "#/components/schemas/OSD00003E"
+                    }
+                }
+            },
+            "StorageModel": {
+                "type": "object",
+                "required": [
+                    "vendor",
+                    "product",
+                    "multipath",
+                    "storage"
+                ],
+                "properties": {
+                    "vendor": {
+                        "type": "string"
+                    },
+                    "product": {
+                        "type": "string"
+                    },
+                    "multipath": {
+                        "type": "object",
+                        "required": [
+                            "defaults",
+                            "blacklist",
+                            "blacklistExceptions",
+                            "devices",
+                            "overrides",
+                            "multipaths"
+                        ],
+                        "properties": {
+                            "defaults": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/StorageKeyValuePair"
+                                }
+                            },
+                            "blacklist": {
+                                "type": "object",
+                                "required": [
+                                    "devnode",
+                                    "devices"
+                                ],
+                                "properties": {
+                                    "devnode": {
+                                        "type": "string"
+                                    },
+                                    "devices": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                        }
+                                    }
+                                }
+                            },
+                            "blacklistExceptions": {
+                                "type": "object",
+                                "required": [
+                                    "devnode",
+                                    "devices"
+                                ],
+                                "properties": {
+                                    "devnode": {
+                                        "type": "string"
+                                    },
+                                    "devices": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                        }
+                                    }
+                                }
+                            },
+                            "devices": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/StorageModelVenderSetting"
+                                }
+                            },
+                            "overrides": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/StorageKeyValuePair"
+                                }
+                            },
+                            "multipaths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "wwid",
+                                        "settings"
+                                    ],
+                                    "properties": {
+                                        "wwid": {
+                                            "type": "string"
+                                        },
+                                        "settings": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/StorageKeyValuePair"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "storage": {
+                        "type": "object",
+                        "required": [
+                            "service",
+                            "volumeType",
+                            "image",
+                            "updateTime"
+                        ],
+                        "properties": {
+                            "service": {
+                                "type": "object",
+                                "required": [
+                                    "driverSection",
+                                    "extraSettings",
+                                    "extraConfigFiles"
+                                ],
+                                "properties": {
+                                    "driverSection": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    },
+                                    "extraSettings": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "sectionHeader",
+                                                "settings"
+                                            ],
+                                            "properties": {
+                                                "sectionHeader": {
+                                                    "type": "string"
+                                                },
+                                                "settings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StorageKeyValuePair"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "extraConfigFiles": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "name",
+                                                "content"
+                                            ],
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "content": {
+                                                    "type": "string",
+                                                    "description": "Base64 encoded content of the config file"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "volumeType": {
+                                "type": "object",
+                                "required": [
+                                    "settings"
+                                ],
+                                "properties": {
+                                    "settings": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "image": {
+                                "type": "object",
+                                "required": [
+                                    "useMultipath",
+                                    "forceMultipath"
+                                ],
+                                "properties": {
+                                    "useMultipath": {
+                                        "type": "boolean"
+                                    },
+                                    "forceMultipath": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "updateTime": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        }
                     }
                 }
             },

--- a/internal/apis/v1/handlers/integrations/delegation.go
+++ b/internal/apis/v1/handlers/integrations/delegation.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	reqQueue = storages.ReqQueue
+	reqQueue      = storages.ReqQueue
+	modelReqQueue = storages.ModelReqQueue
 )
 
 func (h *helper) updateStorageToControllers() {
@@ -112,4 +113,88 @@ func (h *helper) convertHeadersToMap(headers http.Header) map[string]string {
 
 	maps.Copy(headerMap, nodes.GetSecretHeaders())
 	return headerMap
+}
+
+func (h *helper) updateStorageModelToControllers() {
+	h.updateStorageModelToLocal()
+	h.updateStorageModelToPeers()
+}
+
+func (h *helper) updateStorageModelToLocal() {
+	if cubecos.IsVirtualIpOwner(base.Hostname) {
+		h.addReqRecord()
+	}
+
+	reqQueue.Add(&h.storageReqOpts)
+}
+
+func (h *helper) updateStorageModelToPeers() {
+	if !cubecos.IsVirtualIpOwner(base.Hostname) {
+		return
+	}
+
+	nodes, err := nodes.GetPeerControls()
+	if err != nil {
+		log.Errorf("storages(%s): failed to get peer controller nodes: %v", h.reqId, err)
+		return
+	}
+
+	for _, node := range nodes {
+		h.updatePeerStorageModel(node)
+	}
+}
+
+func (h *helper) updatePeerStorageModel(node nodes.Node) error {
+	reqOpts, err := h.genPeerStorageModelReq(node.Hostname)
+	if err != nil {
+		return nil
+	}
+
+	url := h.getStorageModelUrlByHandler(node)
+	req := h.http.R().
+		SetHeaders(h.convertHeadersToMap(h.c.Request.Header)).
+		SetBody(string(reqOpts))
+	resp, err := req.Execute(h.c.Request.Method, url)
+	if err != nil {
+		log.Errorf(
+			"storages(%s): failed to update peer storage model %s(%v)",
+			h.reqId, node.Hostname, err,
+		)
+		return err
+	}
+
+	if resp.IsError() {
+		log.Errorf(
+			"storages(%s): has resp error during updating peer storage model on node %s(%s)",
+			h.reqId, node.Hostname, resp.String(),
+		)
+		return err
+	}
+
+	return nil
+}
+
+func (h *helper) getStorageModelUrlByHandler(node nodes.Node) string {
+	switch h.handler {
+	case "creaeteStorage":
+		return node.PostStorageModelUrl()
+	case "updateStorage":
+		return node.PatchStorageModelUrl(h.modelReqOpts.Vendor, h.modelReqOpts.Product)
+	case "deleteStorage":
+		return node.DeleteStorageModelUrl(h.modelReqOpts.Vendor, h.modelReqOpts.Product)
+	default:
+		return node.PostStorageModelUrl()
+	}
+}
+
+func (h *helper) genPeerStorageModelReq(hostname string) ([]byte, error) {
+	modelReqOpts := deepcopy.Copy(h.modelReqOpts).(defstorages.ModelReqOpts)
+	modelReqOpts.Hostname = hostname
+	req, err := json.Marshal(modelReqOpts)
+	if err != nil {
+		log.Errorf("storages(%s): failed to marshal storage model request for node %s(%v)", h.reqId, hostname, err)
+		return nil, err
+	}
+
+	return req, nil
 }

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -69,6 +69,24 @@ var (
 		},
 		{
 			Version: apis.V1,
+			Method:  http.MethodPost,
+			Path:    "/integrations/storages/models",
+			Func:    createStorageModel,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPatch,
+			Path:    "/integrations/storages/models/{:vendor}/{:product}",
+			Func:    updateStorageModel,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodDelete,
+			Path:    "/integrations/storages/models/{:vendor}/{:product}",
+			Func:    deleteStorageModel,
+		},
+		{
+			Version: apis.V1,
 			Method:  http.MethodPatch,
 			Path:    "/integrations/storages/tasks",
 			Func:    updateStorageTask,
@@ -285,6 +303,81 @@ func updateStorageTask(c *gin.Context) {
 		c,
 		"storage status updated",
 		nil,
+	)
+}
+
+func createStorageModel(c *gin.Context) {
+	h, err := initHelper(c, "createStorageModel")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageModelExist(h.modelReqOpts.Vendor, h.modelReqOpts.Product)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if found {
+		bodies.SetConflict(c, fmt.Errorf("storage model '%s %s' already exists", h.modelReqOpts.Vendor, h.modelReqOpts.Product))
+		return
+	}
+
+	h.updateStorageModelToControllers()
+	bodies.SetAccepted(
+		c,
+		"received create integrated storage model request successfully, processing",
+	)
+}
+
+func updateStorageModel(c *gin.Context) {
+	h, err := initHelper(c, "updateStorageModel")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageModelExist(h.modelReqOpts.Vendor, h.modelReqOpts.Product)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if !found {
+		bodies.SetNotFound(c, fmt.Errorf("storage model '%s %s' not found", h.modelReqOpts.Vendor, h.modelReqOpts.Product))
+		return
+	}
+
+	h.updateStorageModelToControllers()
+	bodies.SetAccepted(
+		c,
+		"received update integrated storage model request successfully, processing",
+	)
+}
+
+func deleteStorageModel(c *gin.Context) {
+	h, err := initHelper(c, "deleteStorageModel")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageModelExist(h.modelReqOpts.Vendor, h.modelReqOpts.Product)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if !found {
+		bodies.SetNotFound(c, fmt.Errorf("storage model '%s %s' not found", h.modelReqOpts.Vendor, h.modelReqOpts.Product))
+		return
+	}
+
+	h.updateStorageModelToControllers()
+	bodies.SetAccepted(
+		c,
+		"received delete integrated storage model request successfully, processing",
 	)
 }
 

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -19,6 +19,12 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseDeleteStorageParams()
 	case "updateStorageTask":
 		return h.parseUpdateStorageTaskOptions()
+	case "createStorageModel":
+		return h.parseCreateStorageModelParams()
+	case "updateStorageModel":
+		return h.parseUpdateStorageModelParams()
+	case "deleteStorageModel":
+		return h.parseDeleteStorageModelParams()
 	default:
 		return nil
 	}
@@ -86,5 +92,68 @@ func (h *helper) parseUpdateStorageTaskOptions() error {
 		)
 	}
 
+	return nil
+}
+
+func (h *helper) parseCreateStorageModelParams() error {
+	err := h.c.ShouldBindYAML(&h.modelReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse create storage model options(%v)",
+			err,
+		)
+	}
+
+	if h.modelReqOpts.Vendor == "" {
+		return errors.New("vendor is required")
+	}
+
+	if h.modelReqOpts.Product == "" {
+		return errors.New("product is required")
+	}
+
+	h.modelReqOpts.ReqId = h.reqId
+	h.modelReqOpts.Hostname = base.Hostname
+	h.modelReqOpts.SetCreating()
+	return nil
+}
+
+func (h *helper) parseUpdateStorageModelParams() error {
+	err := h.c.ShouldBindYAML(&h.modelReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse update storage model options(%v)",
+			err,
+		)
+	}
+
+	if h.modelReqOpts.Vendor == "" {
+		return errors.New("vendor is required")
+	}
+
+	if h.modelReqOpts.Product == "" {
+		return errors.New("product is required")
+	}
+
+	h.modelReqOpts.ReqId = h.reqId
+	h.modelReqOpts.Hostname = base.Hostname
+	h.modelReqOpts.SetUpdating()
+	return nil
+}
+
+func (h *helper) parseDeleteStorageModelParams() error {
+	h.modelReqOpts.Vendor = h.c.Param("vendor")
+	if h.modelReqOpts.Vendor == "" {
+		return errors.New("vendor is required")
+	}
+
+	h.modelReqOpts.Product = h.c.Param("product")
+	if h.modelReqOpts.Product == "" {
+		return errors.New("product is required")
+	}
+
+	h.modelReqOpts.ReqId = h.reqId
+	h.modelReqOpts.Hostname = base.Hostname
+	h.modelReqOpts.SetDeleting()
 	return nil
 }

--- a/internal/apis/v1/handlers/integrations/record.go
+++ b/internal/apis/v1/handlers/integrations/record.go
@@ -34,7 +34,7 @@ func (h *helper) updateStorageTask() error {
 		storages.ReqCollection,
 		bson.M{
 			"hostname": h.storageReqOpts.Hostname,
-			"device":   h.storageReqOpts.Name,
+			"name":     h.storageReqOpts.Name,
 			"reqId":    h.storageReqOpts.ReqId,
 		},
 	)
@@ -46,7 +46,8 @@ func (h *helper) updateModelTask() error {
 		storages.ModelReqCollection,
 		bson.M{
 			"hostname": h.modelReqOpts.Hostname,
-			"device":   h.modelReqOpts.Name,
+			"vendor":   h.modelReqOpts.Vendor,
+			"product":  h.modelReqOpts.Product,
 			"reqId":    h.modelReqOpts.ReqId,
 		},
 	)

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -201,6 +201,74 @@ func ListModels() ([]storages.Model, error) {
 	return list, nil
 }
 
+func CheckStorageModelExist(vendor, product string) (bool, error) {
+	models, err := ListModels()
+	if err != nil {
+		return false, err
+	}
+
+	for _, m := range models {
+		if m.Vendor == vendor && m.Product == product {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func UpdateStorageModel(req storages.ModelReqOpts) error {
+	input, err := json.Marshal(req)
+	if err != nil {
+		err := genIntegrationErr("model req parsing failure")
+		log.Errorf("storage: %s (%v)", err.Error(), err)
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "host_put_model", string(input)).CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("model exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	if !IsHexSuccessful(err) {
+		err := genIntegrationErr("model output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	return nil
+}
+
+func DeleteStorageModel(req storages.ModelReqOpts) error {
+	model := map[string]string{"vendor": req.Vendor, "product": req.Product}
+	input, err := json.Marshal(model)
+	if err != nil {
+		err := genIntegrationErr("model req parsing failure")
+		log.Errorf("storage: %s (%v)", err.Error(), err)
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(3))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "host_delete_model", string(input)).CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("model exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	if !IsHexSuccessful(err) {
+		err := genIntegrationErr("model output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return err
+	}
+
+	return nil
+}
+
 func genIntegrationErr(description string) error {
 	return fmt.Errorf(
 		"cubecos has unexpected hex error, please contact support(%s)",

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -332,6 +332,24 @@ func (n *Node) UpdateStorageTaskUrl() string {
 	return u.String()
 }
 
+func (n *Node) PostStorageModelUrl() string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/models", base.DataCenterName)
+	return u.String()
+}
+
+func (n *Node) PatchStorageModelUrl(vendor, product string) string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/models/%s/%s", base.DataCenterName, vendor, product)
+	return u.String()
+}
+
+func (n *Node) DeleteStorageModelUrl(vendor, product string) string {
+	u := n.GenUrl()
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/models/%s/%s", base.DataCenterName, vendor, product)
+	return u.String()
+}
+
 func (n *Node) UpdateModelTaskUrl() string {
 	u := n.GenUrl()
 	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/integrations/storages/models/tasks", base.DataCenterName)

--- a/internal/definition/v1/storages/storage.go
+++ b/internal/definition/v1/storages/storage.go
@@ -19,7 +19,6 @@ type ReqOpts struct {
 
 type ModelReqOpts struct {
 	ReqId    string `json:"reqId" bson:"reqId"`
-	Name     string `json:"name" bson:"name"`
 	Hostname string `json:"hostname" bson:"hostname"`
 	Model    `json:"model" bson:"model"`
 	Status   status.Model `json:"status" bson:"status"`
@@ -95,6 +94,24 @@ func (r *ReqOpts) SetCompleted() {
 func (r *ReqOpts) SetFailed() {
 	r.Status.Current = status.Failed
 	r.Status.IsProcessing = false
+}
+
+func (m *ModelReqOpts) SetCreating() {
+	m.Status.Current = status.Creating
+	m.Status.Desired = status.Created
+	m.Status.IsProcessing = true
+}
+
+func (m *ModelReqOpts) SetUpdating() {
+	m.Status.Current = status.Updating
+	m.Status.Desired = status.Updated
+	m.Status.IsProcessing = true
+}
+
+func (m *ModelReqOpts) SetDeleting() {
+	m.Status.Current = status.Deleting
+	m.Status.Desired = status.Deleted
+	m.Status.IsProcessing = true
 }
 
 func (m *ModelReqOpts) SetCompleted() {

--- a/internal/operators/v1/storages/model.go
+++ b/internal/operators/v1/storages/model.go
@@ -13,32 +13,25 @@ import (
 func (o *Operator) operateModelReq(req storages.ModelReqOpts) error {
 	switch req.Status.Desired {
 	case status.Created, status.Updated:
-		return o.updateModel(req)
+		return cubecos.UpdateStorageModel(req)
 	case status.Deleted:
-		return o.deleteModel(req)
+		return cubecos.DeleteStorageModel(req)
 	}
 
 	return fmt.Errorf(
-		"unknown desired action(%s) for model(%s)",
+		"unknown desired action(%s) for model(%s %s)",
 		req.Status.Desired,
-		req.Name,
+		req.Vendor,
+		req.Product,
 	)
-}
-
-func (o *Operator) updateModel(req storages.ModelReqOpts) error {
-	return nil
-}
-
-func (o *Operator) deleteModel(req storages.ModelReqOpts) error {
-	return nil
 }
 
 func (o *Operator) handleModelExit(req storages.ModelReqOpts, err error) {
 	if err != nil {
-		log.Errorf("storages: failed to %s %s(%v)", req.Status.Desired, req.Name, err)
+		log.Errorf("storages: failed to %s %s %s(%v)", req.Status.Desired, req.Vendor, req.Model, err)
 		req.SetFailed()
 	} else {
-		log.Infof("storages: %s %s successfully", req.Status.Desired, req.Name)
+		log.Infof("storages: %s %s %s successfully", req.Status.Desired, req.Vendor, req.Model)
 		req.SetCompleted()
 	}
 
@@ -48,7 +41,7 @@ func (o *Operator) handleModelExit(req storages.ModelReqOpts, err error) {
 func (o *Operator) reportModelToController(req storages.ModelReqOpts) {
 	node, err := cubecos.GetVirtualIpController()
 	if err != nil {
-		log.Errorf("storages: failed to report %s result to control(%v)", req.Name, err)
+		log.Errorf("storages: failed to report %s %s result to control(%v)", req.Vendor, req.Model, err)
 		return
 	}
 
@@ -57,14 +50,15 @@ func (o *Operator) reportModelToController(req storages.ModelReqOpts) {
 		SetBody(req).
 		Patch(node.UpdateModelTaskUrl())
 	if err != nil {
-		log.Errorf("storages: failed to send model %s to %s(%v)", req.Name, node.Hostname, err)
+		log.Errorf("storages: failed to send model %s %s to %s(%v)", req.Vendor, req.Model, node.Hostname, err)
 		return
 	}
 
 	if resp.IsError() {
 		log.Errorf(
-			"storages: failed to send model %s to %s(%s)",
-			req.Name,
+			"storages: failed to send model %s %s to %s(%s)",
+			req.Vendor,
+			req.Model,
 			node.Hostname,
 			string(resp.Body()),
 		)


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return empty or http 500 until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

- https://github.com/bigstack-oss/cubecos/issues/357

- https://github.com/bigstack-oss/cubecos/issues/358

- https://github.com/bigstack-oss/cubecos/issues/360

<br/>

### What this PR does?

- Integrate the POST /integrations/storages/models with Hex SDK

- Integrate the PATCH DELETE /integrations/storages/models/{vendor name}/{product name} with Hex SDK

- Add the corresponding API docs

<br/>

### Test results (optional)

1). make sure the api docs have been updated

https://github.com/user-attachments/assets/db23d4f3-e03e-49ea-98e2-be864cf2f93d

