### PR TITLE
Integrate the PUT /integrations/storages/models with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4156,125 +4156,149 @@ const docTemplate = `{
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreateIntegratedStorageModelRequest"
-                            },
-                            "examples": {
-                                "example1": {
-                                    "summary": "Create integrated storage model request",
-                                    "value": {
-                                        "vendor": "Dell",
-                                        "product": "PowerVault",
-                                        "multipath": {
-                                            "defaults": [
-                                                {
-                                                    "key": "user_friendly_names",
-                                                    "value": "yes"
-                                                }
-                                            ],
-                                            "blacklist": {
-                                                "devnode": "sda",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "Generic",
-                                                        "product": "USB",
-                                                        "settings": [
-                                                            {
-                                                                "key": "dev_loss_tmo",
-                                                                "value": "10"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "blacklistExceptions": {
-                                                "devnode": "sd[b-z]",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "HP",
-                                                        "product": "MSA",
-                                                        "settings": [
-                                                            {
-                                                                "key": "polling_interval",
-                                                                "value": "5"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "devices": [
-                                                {
-                                                    "vendor": "EMC",
-                                                    "product": "VNX",
-                                                    "settings": [
-                                                        {
-                                                            "key": "no_path_retry",
-                                                            "value": "fail"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "overrides": [
-                                                {
-                                                    "key": "checker_timeout",
-                                                    "value": "30"
-                                                }
-                                            ],
-                                            "multipaths": [
-                                                {
-                                                    "wwid": "3600508b400105e210000900000490000",
-                                                    "settings": [
-                                                        {
-                                                            "key": "path_grouping_policy",
-                                                            "value": "group_by_prio"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
+                                "$ref": "#/components/schemas/CreateOrUpdateIntegreatedStorageModelsRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to create an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
                                         },
-                                        "storage": {
-                                            "service": {
-                                                "driverSection": [
-                                                    {
-                                                        "key": "volume_driver",
-                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
-                                                    }
-                                                ],
-                                                "extraSettings": [
-                                                    {
-                                                        "sectionHeader": "DEFAULT",
-                                                        "settings": [
-                                                            {
-                                                                "key": "enabled_backends",
-                                                                "value": "lvm"
-                                                            }
-                                                        ]
-                                                    }
-                                                ],
-                                                "extraConfigFiles": [
-                                                    {
-                                                        "name": "test.conf",
-                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
-                                                    }
-                                                ]
-                                            },
-                                            "volumeType": {
-                                                "settings": [
-                                                    {
-                                                        "key": "volume_backend_name",
-                                                        "value": "lvm"
-                                                    }
-                                                ]
-                                            },
-                                            "image": {
-                                                "useMultipath": true,
-                                                "forceMultipath": true
-                                            },
-                                            "updateTime": "2025-09-09T10:30:00Z"
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to create an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
                                         }
                                     }
                                 }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "vendor and product are required fields"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage model: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateAllIntegratedStorageModels",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Update all integrated storage models",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PutIntegreatedStorageModelsRequest"
                             }
                         }
                     }
@@ -4556,125 +4580,9 @@ const docTemplate = `{
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/UpdateIntegratedStorageModelRequest"
-                            },
-                            "examples": {
-                                "example1": {
-                                    "summary": "Update integrated storage model request",
-                                    "value": {
-                                        "vendor": "Dell",
-                                        "product": "PowerVault",
-                                        "multipath": {
-                                            "defaults": [
-                                                {
-                                                    "key": "user_friendly_names",
-                                                    "value": "yes"
-                                                }
-                                            ],
-                                            "blacklist": {
-                                                "devnode": "sda",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "Generic",
-                                                        "product": "USB",
-                                                        "settings": [
-                                                            {
-                                                                "key": "dev_loss_tmo",
-                                                                "value": "10"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "blacklistExceptions": {
-                                                "devnode": "sd[b-z]",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "HP",
-                                                        "product": "MSA",
-                                                        "settings": [
-                                                            {
-                                                                "key": "polling_interval",
-                                                                "value": "5"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "devices": [
-                                                {
-                                                    "vendor": "EMC",
-                                                    "product": "VNX",
-                                                    "settings": [
-                                                        {
-                                                            "key": "no_path_retry",
-                                                            "value": "fail"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "overrides": [
-                                                {
-                                                    "key": "checker_timeout",
-                                                    "value": "30"
-                                                }
-                                            ],
-                                            "multipaths": [
-                                                {
-                                                    "wwid": "3600508b400105e210000900000490000",
-                                                    "settings": [
-                                                        {
-                                                            "key": "path_grouping_policy",
-                                                            "value": "group_by_prio"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "storage": {
-                                            "service": {
-                                                "driverSection": [
-                                                    {
-                                                        "key": "volume_driver",
-                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
-                                                    }
-                                                ],
-                                                "extraSettings": [
-                                                    {
-                                                        "sectionHeader": "DEFAULT",
-                                                        "settings": [
-                                                            {
-                                                                "key": "enabled_backends",
-                                                                "value": "lvm"
-                                                            }
-                                                        ]
-                                                    }
-                                                ],
-                                                "extraConfigFiles": [
-                                                    {
-                                                        "name": "test.conf",
-                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
-                                                    }
-                                                ]
-                                            },
-                                            "volumeType": {
-                                                "settings": [
-                                                    {
-                                                        "key": "volume_backend_name",
-                                                        "value": "lvm"
-                                                    }
-                                                ]
-                                            },
-                                            "image": {
-                                                "useMultipath": true,
-                                                "forceMultipath": true
-                                            },
-                                            "updateTime": "2025-09-09T10:30:00Z"
-                                        }
-                                    }
-                                }
+                                "$ref": "#/components/schemas/CreateOrUpdateIntegreatedStorageModelsRequest"
                             }
                         }
                     }
@@ -19194,12 +19102,6 @@ const docTemplate = `{
                     }
                 }
             },
-            "CreateIntegratedStorageModelRequest": {
-                "$ref": "#/components/schemas/StorageModel"
-            },
-            "UpdateIntegratedStorageModelRequest": {
-                "$ref": "#/components/schemas/StorageModel"
-            },
             "ListIntegratedStorageModelsResponse": {
                 "type": "object",
                 "required": [
@@ -19428,6 +19330,32 @@ const docTemplate = `{
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "PutIntegreatedStorageModelsRequest": {
+                "type": "object",
+                "required": [
+                    "storageModels"
+                ],
+                "properties": {
+                    "storageModels": {
+                        "type": "string",
+                        "format": "text",
+                        "description": "The array YAML content of multiple storage models"
+                    }
+                }
+            },
+            "CreateOrUpdateIntegreatedStorageModelsRequest": {
+                "type": "object",
+                "required": [
+                    "storageModels"
+                ],
+                "properties": {
+                    "storageModels": {
+                        "type": "string",
+                        "format": "text",
+                        "description": "The YAML content of a storage model"
                     }
                 }
             },

--- a/api/docs.json
+++ b/api/docs.json
@@ -4152,125 +4152,149 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreateIntegratedStorageModelRequest"
-                            },
-                            "examples": {
-                                "example1": {
-                                    "summary": "Create integrated storage model request",
-                                    "value": {
-                                        "vendor": "Dell",
-                                        "product": "PowerVault",
-                                        "multipath": {
-                                            "defaults": [
-                                                {
-                                                    "key": "user_friendly_names",
-                                                    "value": "yes"
-                                                }
-                                            ],
-                                            "blacklist": {
-                                                "devnode": "sda",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "Generic",
-                                                        "product": "USB",
-                                                        "settings": [
-                                                            {
-                                                                "key": "dev_loss_tmo",
-                                                                "value": "10"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "blacklistExceptions": {
-                                                "devnode": "sd[b-z]",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "HP",
-                                                        "product": "MSA",
-                                                        "settings": [
-                                                            {
-                                                                "key": "polling_interval",
-                                                                "value": "5"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "devices": [
-                                                {
-                                                    "vendor": "EMC",
-                                                    "product": "VNX",
-                                                    "settings": [
-                                                        {
-                                                            "key": "no_path_retry",
-                                                            "value": "fail"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "overrides": [
-                                                {
-                                                    "key": "checker_timeout",
-                                                    "value": "30"
-                                                }
-                                            ],
-                                            "multipaths": [
-                                                {
-                                                    "wwid": "3600508b400105e210000900000490000",
-                                                    "settings": [
-                                                        {
-                                                            "key": "path_grouping_policy",
-                                                            "value": "group_by_prio"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
+                                "$ref": "#/components/schemas/CreateOrUpdateIntegreatedStorageModelsRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Receive the request to create an integrated storage model successfully, processing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 202
                                         },
-                                        "storage": {
-                                            "service": {
-                                                "driverSection": [
-                                                    {
-                                                        "key": "volume_driver",
-                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
-                                                    }
-                                                ],
-                                                "extraSettings": [
-                                                    {
-                                                        "sectionHeader": "DEFAULT",
-                                                        "settings": [
-                                                            {
-                                                                "key": "enabled_backends",
-                                                                "value": "lvm"
-                                                            }
-                                                        ]
-                                                    }
-                                                ],
-                                                "extraConfigFiles": [
-                                                    {
-                                                        "name": "test.conf",
-                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
-                                                    }
-                                                ]
-                                            },
-                                            "volumeType": {
-                                                "settings": [
-                                                    {
-                                                        "key": "volume_backend_name",
-                                                        "value": "lvm"
-                                                    }
-                                                ]
-                                            },
-                                            "image": {
-                                                "useMultipath": true,
-                                                "forceMultipath": true
-                                            },
-                                            "updateTime": "2025-09-09T10:30:00Z"
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "receive the request to create an integrated storage model successfully, processing"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
                                         }
                                     }
                                 }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "vendor and product are required fields"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 409
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage model Dell PowerVault already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "conflict"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to create integrated storage model: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateAllIntegratedStorageModels",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Update all integrated storage models",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PutIntegreatedStorageModelsRequest"
                             }
                         }
                     }
@@ -4552,125 +4576,9 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/UpdateIntegratedStorageModelRequest"
-                            },
-                            "examples": {
-                                "example1": {
-                                    "summary": "Update integrated storage model request",
-                                    "value": {
-                                        "vendor": "Dell",
-                                        "product": "PowerVault",
-                                        "multipath": {
-                                            "defaults": [
-                                                {
-                                                    "key": "user_friendly_names",
-                                                    "value": "yes"
-                                                }
-                                            ],
-                                            "blacklist": {
-                                                "devnode": "sda",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "Generic",
-                                                        "product": "USB",
-                                                        "settings": [
-                                                            {
-                                                                "key": "dev_loss_tmo",
-                                                                "value": "10"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "blacklistExceptions": {
-                                                "devnode": "sd[b-z]",
-                                                "devices": [
-                                                    {
-                                                        "vendor": "HP",
-                                                        "product": "MSA",
-                                                        "settings": [
-                                                            {
-                                                                "key": "polling_interval",
-                                                                "value": "5"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "devices": [
-                                                {
-                                                    "vendor": "EMC",
-                                                    "product": "VNX",
-                                                    "settings": [
-                                                        {
-                                                            "key": "no_path_retry",
-                                                            "value": "fail"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "overrides": [
-                                                {
-                                                    "key": "checker_timeout",
-                                                    "value": "30"
-                                                }
-                                            ],
-                                            "multipaths": [
-                                                {
-                                                    "wwid": "3600508b400105e210000900000490000",
-                                                    "settings": [
-                                                        {
-                                                            "key": "path_grouping_policy",
-                                                            "value": "group_by_prio"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "storage": {
-                                            "service": {
-                                                "driverSection": [
-                                                    {
-                                                        "key": "volume_driver",
-                                                        "value": "cinder.volume.drivers.lvm.LVMVolumeDriver"
-                                                    }
-                                                ],
-                                                "extraSettings": [
-                                                    {
-                                                        "sectionHeader": "DEFAULT",
-                                                        "settings": [
-                                                            {
-                                                                "key": "enabled_backends",
-                                                                "value": "lvm"
-                                                            }
-                                                        ]
-                                                    }
-                                                ],
-                                                "extraConfigFiles": [
-                                                    {
-                                                        "name": "test.conf",
-                                                        "content": "ZmlsZSBjb250ZW50IGluIGJhc2U2NA=="
-                                                    }
-                                                ]
-                                            },
-                                            "volumeType": {
-                                                "settings": [
-                                                    {
-                                                        "key": "volume_backend_name",
-                                                        "value": "lvm"
-                                                    }
-                                                ]
-                                            },
-                                            "image": {
-                                                "useMultipath": true,
-                                                "forceMultipath": true
-                                            },
-                                            "updateTime": "2025-09-09T10:30:00Z"
-                                        }
-                                    }
-                                }
+                                "$ref": "#/components/schemas/CreateOrUpdateIntegreatedStorageModelsRequest"
                             }
                         }
                     }
@@ -19190,12 +19098,6 @@
                     }
                 }
             },
-            "CreateIntegratedStorageModelRequest": {
-                "$ref": "#/components/schemas/StorageModel"
-            },
-            "UpdateIntegratedStorageModelRequest": {
-                "$ref": "#/components/schemas/StorageModel"
-            },
             "ListIntegratedStorageModelsResponse": {
                 "type": "object",
                 "required": [
@@ -19424,6 +19326,32 @@
                     "status": {
                         "type": "string",
                         "example": "ok"
+                    }
+                }
+            },
+            "PutIntegreatedStorageModelsRequest": {
+                "type": "object",
+                "required": [
+                    "storageModels"
+                ],
+                "properties": {
+                    "storageModels": {
+                        "type": "string",
+                        "format": "text",
+                        "description": "The array YAML content of multiple storage models"
+                    }
+                }
+            },
+            "CreateOrUpdateIntegreatedStorageModelsRequest": {
+                "type": "object",
+                "required": [
+                    "storageModel"
+                ],
+                "properties": {
+                    "storageModel": {
+                        "type": "string",
+                        "format": "text",
+                        "description": "The YAML content of a storage model"
                     }
                 }
             },

--- a/internal/apis/v1/handlers/integrations/delegate.go
+++ b/internal/apis/v1/handlers/integrations/delegate.go
@@ -115,6 +115,45 @@ func (h *helper) convertHeadersToMap(headers http.Header) map[string]string {
 	return headerMap
 }
 
+func (h *helper) updateAllStorageModelsToControllers() {
+	batchStorageModelReqOpts := h.initBatchStorageModelReqOpts()
+	for _, modelReqOpt := range batchStorageModelReqOpts {
+		h.modelReqOpts = modelReqOpt
+		h.updateStorageModelToControllers()
+	}
+}
+
+func (h *helper) initBatchStorageModelReqOpts() []defstorages.ModelReqOpts {
+	currents, err := h.listModels()
+	if err != nil {
+		log.Errorf("storages(%s): failed to list current storage models(%v)", h.reqId, err)
+		return nil
+	}
+
+	inited := []defstorages.ModelReqOpts{}
+	for _, modelReqOpts := range h.batchModelReqOpts {
+		found := false
+		for _, current := range currents {
+			if modelReqOpts.Vendor == current.Vendor && modelReqOpts.Product == current.Product {
+				found = true
+				break
+			}
+		}
+
+		modelReqOpts.ReqId = h.reqId
+		modelReqOpts.Hostname = base.Hostname
+		if found {
+			modelReqOpts.SetUpdating()
+		} else {
+			modelReqOpts.SetDeleting()
+		}
+
+		inited = append(inited, modelReqOpts)
+	}
+
+	return inited
+}
+
 func (h *helper) updateStorageModelToControllers() {
 	h.updateStorageModelToLocal()
 	h.updateStorageModelToPeers()

--- a/internal/apis/v1/handlers/integrations/delegate.go
+++ b/internal/apis/v1/handlers/integrations/delegate.go
@@ -164,7 +164,7 @@ func (h *helper) updateStorageModelToLocal() {
 		h.addReqRecord()
 	}
 
-	reqQueue.Add(&h.storageReqOpts)
+	modelReqQueue.Add(&h.modelReqOpts)
 }
 
 func (h *helper) updateStorageModelToPeers() {

--- a/internal/apis/v1/handlers/integrations/file.go
+++ b/internal/apis/v1/handlers/integrations/file.go
@@ -1,0 +1,61 @@
+package integrations
+
+import (
+	"os"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	log "go-micro.dev/v5/logger"
+	"gopkg.in/yaml.v3"
+)
+
+func (h *helper) loadStorageModel() error {
+	list, err := h.c.FormFile("storageModel")
+	if err != nil {
+		log.Errorf("storages(%s): %v", h.reqId, err)
+		return err
+	}
+
+	err = h.c.SaveUploadedFile(list, storages.TmpUploadedStorageModel)
+	if err != nil {
+		log.Errorf("storages(%s): failed to save storage model(%v)", h.reqId, err)
+		return err
+	}
+
+	defer os.Remove(storages.TmpUploadedStorageModel)
+	payload, err := os.ReadFile(storages.TmpUploadedStorageModel)
+	if err != nil {
+		log.Errorf("storages(%s): failed to read storage model file(%v)", h.reqId, err)
+		return err
+	}
+
+	return yaml.Unmarshal(
+		payload,
+		&h.batchModelReqOpts,
+	)
+}
+
+func (h *helper) loadStorageModelList() error {
+	list, err := h.c.FormFile("storageModels")
+	if err != nil {
+		log.Errorf("storages(%s): %v", h.reqId, err)
+		return err
+	}
+
+	err = h.c.SaveUploadedFile(list, storages.TmpUploadedStorageModelList)
+	if err != nil {
+		log.Errorf("storages(%s): failed to save storage models(%v)", h.reqId, err)
+		return err
+	}
+
+	defer os.Remove(storages.TmpUploadedStorageModelList)
+	payload, err := os.ReadFile(storages.TmpUploadedStorageModelList)
+	if err != nil {
+		log.Errorf("storages(%s): failed to read storage models file(%v)", h.reqId, err)
+		return err
+	}
+
+	return yaml.Unmarshal(
+		payload,
+		&h.batchModelReqOpts,
+	)
+}

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -39,7 +39,7 @@ var (
 		},
 		{
 			Version: apis.V1,
-			Method:  http.MethodPost,
+			Method:  http.MethodPatch,
 			Path:    "/integrations/storages/:storageName",
 			Func:    updateStorage,
 		},
@@ -75,14 +75,20 @@ var (
 		},
 		{
 			Version: apis.V1,
-			Method:  http.MethodPatch,
-			Path:    "/integrations/storages/models/{:vendor}/{:product}",
+			Method:  http.MethodPut,
+			Path:    "/integrations/storages/models",
+			Func:    updateAllStorageModels,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPut,
+			Path:    "/integrations/storages/models/:vendor/:product",
 			Func:    updateStorageModel,
 		},
 		{
 			Version: apis.V1,
 			Method:  http.MethodDelete,
-			Path:    "/integrations/storages/models/{:vendor}/{:product}",
+			Path:    "/integrations/storages/models/:vendor/:product",
 			Func:    deleteStorageModel,
 		},
 		{
@@ -328,6 +334,21 @@ func createStorageModel(c *gin.Context) {
 	bodies.SetAccepted(
 		c,
 		"received create integrated storage model request successfully, processing",
+	)
+}
+
+func updateAllStorageModels(c *gin.Context) {
+	h, err := initHelper(c, "updateAllStorageModels")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	h.updateAllStorageModelsToControllers()
+	bodies.SetAccepted(
+		c,
+		"received update all integrated storage models request successfully, processing",
 	)
 }
 

--- a/internal/apis/v1/handlers/integrations/helper.go
+++ b/internal/apis/v1/handlers/integrations/helper.go
@@ -19,8 +19,9 @@ type helper struct {
 	mongo *mongo.Helper
 	http  *http.Helper
 
-	storageReqOpts storages.ReqOpts
-	modelReqOpts   storages.ModelReqOpts
+	storageReqOpts    storages.ReqOpts
+	modelReqOpts      storages.ModelReqOpts
+	batchModelReqOpts []storages.ModelReqOpts
 }
 
 func initHelper(c *gin.Context, handler string) (*helper, error) {

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -99,12 +99,9 @@ func (h *helper) parseUpdateStorageTaskOptions() error {
 }
 
 func (h *helper) parseCreateStorageModelParams() error {
-	err := h.c.ShouldBindYAML(&h.modelReqOpts)
+	err := h.loadStorageModel()
 	if err != nil {
-		return fmt.Errorf(
-			"failed to parse create storage model options(%v)",
-			err,
-		)
+		return fmt.Errorf("failed to load storage model req(%v)", err)
 	}
 
 	if h.modelReqOpts.Vendor == "" {
@@ -122,12 +119,9 @@ func (h *helper) parseCreateStorageModelParams() error {
 }
 
 func (h *helper) parseUpdateStorageModelParams() error {
-	err := h.c.ShouldBindYAML(&h.modelReqOpts)
+	err := h.loadStorageModel()
 	if err != nil {
-		return fmt.Errorf(
-			"failed to parse update storage model options(%v)",
-			err,
-		)
+		return fmt.Errorf("failed to load storage model req(%v)", err)
 	}
 
 	if h.modelReqOpts.Vendor == "" {
@@ -145,12 +139,9 @@ func (h *helper) parseUpdateStorageModelParams() error {
 }
 
 func (h *helper) parseUpdateAllStorageModelParams() error {
-	err := h.c.ShouldBindYAML(&h.batchModelReqOpts)
+	err := h.loadStorageModelList()
 	if err != nil {
-		return fmt.Errorf(
-			"failed to parse batch storage model options(%v)",
-			err,
-		)
+		return fmt.Errorf("failed to load storage model list(%v)", err)
 	}
 
 	for _, reqOpts := range h.batchModelReqOpts {

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -1,6 +1,7 @@
 package integrations
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -23,6 +24,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseCreateStorageModelParams()
 	case "updateStorageModel":
 		return h.parseUpdateStorageModelParams()
+	case "updateAllStorageModels":
+		return h.parseUpdateAllStorageModelParams()
 	case "deleteStorageModel":
 		return h.parseDeleteStorageModelParams()
 	default:
@@ -138,6 +141,33 @@ func (h *helper) parseUpdateStorageModelParams() error {
 	h.modelReqOpts.ReqId = h.reqId
 	h.modelReqOpts.Hostname = base.Hostname
 	h.modelReqOpts.SetUpdating()
+	return nil
+}
+
+func (h *helper) parseUpdateAllStorageModelParams() error {
+	err := h.c.ShouldBindYAML(&h.batchModelReqOpts)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to parse batch storage model options(%v)",
+			err,
+		)
+	}
+
+	for _, reqOpts := range h.batchModelReqOpts {
+		b, err := json.Marshal(reqOpts)
+		if err != nil {
+			return fmt.Errorf("failed to marshal storage model options(%v)", err)
+		}
+
+		if reqOpts.Vendor == "" {
+			return fmt.Errorf("has empty vendor in the %s", string(b))
+		}
+
+		if reqOpts.Product == "" {
+			return fmt.Errorf("has empty product in the %s", string(b))
+		}
+	}
+
 	return nil
 }
 

--- a/internal/definition/v1/storages/storage.go
+++ b/internal/definition/v1/storages/storage.go
@@ -7,6 +7,9 @@ const (
 	ReqCollection      = "storageRequests"
 	ModelReqCollection = "modelRequests"
 	CinderConf         = "/etc/cinder/cinder.conf"
+
+	TmpUploadedStorageModelList = "/tmp/storage-model-list.yaml"
+	TmpUploadedStorageModel     = "/tmp/storage-model.yaml"
 )
 
 type ReqOpts struct {


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return empty or http 500 until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

- https://github.com/bigstack-oss/cubecos/issues/357

- https://github.com/bigstack-oss/cubecos/issues/358

- https://github.com/bigstack-oss/cubecos/issues/360

<br/>

### What this PR does?

- Integrate the PUT /integrations/storages/models with Hex SDK

- Fix the incorrect request parsing for POST /integrations/storages/models and PUT /integrations/storages/models/{vendor name}/{product name}

- Add the corresponding API docs

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1431" height="830" alt="Screenshot 2025-09-11 at 6 24 32 PM" src="https://github.com/user-attachments/assets/c2e7481d-1232-43b3-ab7a-029e472b07ee" />

<img width="1424" height="661" alt="Screenshot 2025-09-11 at 6 24 53 PM" src="https://github.com/user-attachments/assets/2a415966-5c50-4c97-b27b-4a782501cfa9" />
