### PR TITLE
Integrate the POST /integrations/storages/verify with Hex SDK

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3561,6 +3561,207 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/verify": {
+            "post": {
+                "operationId": "verifyStorageIntegration",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Verify the connectivity of an external storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/VerifyStorageIntegrationRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Verify the connectivity of an external storage",
+                                    "value": {
+                                        "name": "example-storage",
+                                        "device": {
+                                            "vendor": "Dell",
+                                            "product": "PowerVault ME4024"
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.rbd.RBDDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "ceph"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "ceph"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Verify the connectivity of an external storage successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "data",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCinderServiceUp": {
+                                                    "type": "boolean",
+                                                    "example": true
+                                                },
+                                                "isTestVolumeSuccessful": {
+                                                    "type": "boolean",
+                                                    "example": true
+                                                }
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "verify the connectivity of an external storage successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid request body: missing required field 'name'"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage name example-storage already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to verify the storage connectivity: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/{storageName}": {
             "get": {
                 "operationId": "getIntegratedStorage",
@@ -16727,7 +16928,6 @@ const docTemplate = `{
                                                 "progresses": [
                                                     {
                                                         "host": "example-node-0",
-                                                        "phase": "",
                                                         "status": {
                                                             "current": "installing",
                                                             "isProcessing": true,
@@ -16737,7 +16937,6 @@ const docTemplate = `{
                                                     },
                                                     {
                                                         "host": "example-node-1",
-                                                        "phase": "",
                                                         "status": {
                                                             "current": "installing",
                                                             "isProcessing": true,
@@ -16747,7 +16946,6 @@ const docTemplate = `{
                                                     },
                                                     {
                                                         "host": "example-node-2",
-                                                        "phase": "",
                                                         "status": {
                                                             "current": "installing",
                                                             "isProcessing": true,
@@ -18969,6 +19167,93 @@ const docTemplate = `{
                     }
                 }
             },
+            "VerifyStorageIntegrationRequest": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "isExternal",
+                    "device",
+                    "storage"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "isExternal": {
+                        "type": "boolean"
+                    },
+                    "device": {
+                        "type": "object",
+                        "required": [
+                            "vendor",
+                            "product"
+                        ],
+                        "properties": {
+                            "vendor": {
+                                "type": "string"
+                            },
+                            "product": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "storage": {
+                        "type": "object",
+                        "required": [
+                            "service",
+                            "volumeType",
+                            "image"
+                        ],
+                        "properties": {
+                            "service": {
+                                "type": "object",
+                                "required": [
+                                    "driverSection",
+                                    "extraSettings",
+                                    "extraConfigFiles"
+                                ],
+                                "properties": {
+                                    "driverSection": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "volumeType": {
+                                "type": "object",
+                                "required": [
+                                    "settings"
+                                ],
+                                "properties": {
+                                    "settings": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "image": {
+                                "type": "object",
+                                "required": [
+                                    "useMultipath",
+                                    "forceMultipath"
+                                ],
+                                "properties": {
+                                    "useMultipath": {
+                                        "type": "boolean"
+                                    },
+                                    "forceMultipath": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "GetIntegratedStorageResponse": {
                 "type": "object",
                 "required": [
@@ -19349,10 +19634,10 @@ const docTemplate = `{
             "CreateOrUpdateIntegreatedStorageModelsRequest": {
                 "type": "object",
                 "required": [
-                    "storageModels"
+                    "storageModel"
                 ],
                 "properties": {
-                    "storageModels": {
+                    "storageModel": {
                         "type": "string",
                         "format": "text",
                         "description": "The YAML content of a storage model"
@@ -23901,14 +24186,10 @@ const docTemplate = `{
                                     "type": "object",
                                     "required": [
                                         "host",
-                                        "phase",
                                         "status"
                                     ],
                                     "properties": {
                                         "host": {
-                                            "type": "string"
-                                        },
-                                        "phase": {
                                             "type": "string"
                                         },
                                         "status": {

--- a/api/docs.json
+++ b/api/docs.json
@@ -3557,6 +3557,207 @@
                 }
             }
         },
+        "/api/v1/datacenters/{dataCenter}/integrations/storages/verify": {
+            "post": {
+                "operationId": "verifyStorageIntegration",
+                "tags": [
+                    "Integrations"
+                ],
+                "summary": "Verify the connectivity of an external storage",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dataCenter"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/VerifyStorageIntegrationRequest"
+                            },
+                            "examples": {
+                                "example1": {
+                                    "summary": "Verify the connectivity of an external storage",
+                                    "value": {
+                                        "name": "example-storage",
+                                        "device": {
+                                            "vendor": "Dell",
+                                            "product": "PowerVault ME4024"
+                                        },
+                                        "storage": {
+                                            "service": {
+                                                "driverSection": [
+                                                    {
+                                                        "key": "volume_driver",
+                                                        "value": "cinder.volume.drivers.rbd.RBDDriver"
+                                                    }
+                                                ],
+                                                "extraSettings": [
+                                                    {
+                                                        "sectionHeader": "DEFAULT",
+                                                        "settings": [
+                                                            {
+                                                                "key": "enabled_backends",
+                                                                "value": "ceph"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "volumeType": {
+                                                "settings": [
+                                                    {
+                                                        "key": "volume_backend_name",
+                                                        "value": "ceph"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "useMultipath": true,
+                                                "forceMultipath": true
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Verify the connectivity of an external storage successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "data",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCinderServiceUp": {
+                                                    "type": "boolean",
+                                                    "example": true
+                                                },
+                                                "isTestVolumeSuccessful": {
+                                                    "type": "boolean",
+                                                    "example": true
+                                                }
+                                            }
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "verify the connectivity of an external storage successfully"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "accepted"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "invalid request body: missing required field 'name'"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "storage name example-storage already exists"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "bad request"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "code",
+                                        "msg",
+                                        "status"
+                                    ],
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "msg": {
+                                            "type": "string",
+                                            "example": "failed to verify the storage connectivity: internal server error"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "example": "internal server error"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datacenters/{dataCenter}/integrations/storages/{storageName}": {
             "get": {
                 "operationId": "getIntegratedStorage",
@@ -16723,7 +16924,6 @@
                                                 "progresses": [
                                                     {
                                                         "host": "example-node-0",
-                                                        "phase": "",
                                                         "status": {
                                                             "current": "installing",
                                                             "isProcessing": true,
@@ -16733,7 +16933,6 @@
                                                     },
                                                     {
                                                         "host": "example-node-1",
-                                                        "phase": "",
                                                         "status": {
                                                             "current": "installing",
                                                             "isProcessing": true,
@@ -16743,7 +16942,6 @@
                                                     },
                                                     {
                                                         "host": "example-node-2",
-                                                        "phase": "",
                                                         "status": {
                                                             "current": "installing",
                                                             "isProcessing": true,
@@ -18887,6 +19085,93 @@
                     "asDefault": {
                         "type": "boolean"
                     },
+                    "name": {
+                        "type": "string"
+                    },
+                    "isExternal": {
+                        "type": "boolean"
+                    },
+                    "device": {
+                        "type": "object",
+                        "required": [
+                            "vendor",
+                            "product"
+                        ],
+                        "properties": {
+                            "vendor": {
+                                "type": "string"
+                            },
+                            "product": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "storage": {
+                        "type": "object",
+                        "required": [
+                            "service",
+                            "volumeType",
+                            "image"
+                        ],
+                        "properties": {
+                            "service": {
+                                "type": "object",
+                                "required": [
+                                    "driverSection",
+                                    "extraSettings",
+                                    "extraConfigFiles"
+                                ],
+                                "properties": {
+                                    "driverSection": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "volumeType": {
+                                "type": "object",
+                                "required": [
+                                    "settings"
+                                ],
+                                "properties": {
+                                    "settings": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/StorageKeyValuePair"
+                                        }
+                                    }
+                                }
+                            },
+                            "image": {
+                                "type": "object",
+                                "required": [
+                                    "useMultipath",
+                                    "forceMultipath"
+                                ],
+                                "properties": {
+                                    "useMultipath": {
+                                        "type": "boolean"
+                                    },
+                                    "forceMultipath": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "VerifyStorageIntegrationRequest": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "isExternal",
+                    "device",
+                    "storage"
+                ],
+                "properties": {
                     "name": {
                         "type": "string"
                     },
@@ -23897,14 +24182,10 @@
                                     "type": "object",
                                     "required": [
                                         "host",
-                                        "phase",
                                         "status"
                                     ],
                                     "properties": {
                                         "host": {
-                                            "type": "string"
-                                        },
-                                        "phase": {
                                             "type": "string"
                                         },
                                         "status": {

--- a/internal/apis/v1/handlers/integrations/handlers.go
+++ b/internal/apis/v1/handlers/integrations/handlers.go
@@ -34,6 +34,12 @@ var (
 		{
 			Version: apis.V1,
 			Method:  http.MethodPost,
+			Path:    "/integrations/storages/verify",
+			Func:    verifyStorage,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPost,
 			Path:    "/integrations/storages",
 			Func:    createStorage,
 		},
@@ -163,6 +169,36 @@ func getStorage(c *gin.Context) {
 		c,
 		"fetch integrated storage details successfully",
 		storage,
+	)
+}
+
+func verifyStorage(c *gin.Context) {
+	h, err := initHelper(c, "verifyStorage")
+	if err != nil {
+		log.Errorf("integrations(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	found, err := cubecos.CheckStorageExist(h.storageReqOpts.Name)
+	if err != nil {
+		bodies.SetInternalServerError(c, err)
+		return
+	}
+	if !found {
+		bodies.SetConflict(c, fmt.Errorf("storage %s already exists", h.storageReqOpts.Name))
+		return
+	}
+
+	verification, err := h.verifyStorage()
+	if err != nil {
+		return
+	}
+
+	bodies.SetOk(
+		c,
+		"verify integrated storage successfully",
+		verification,
 	)
 }
 

--- a/internal/apis/v1/handlers/integrations/helper.go
+++ b/internal/apis/v1/handlers/integrations/helper.go
@@ -68,3 +68,29 @@ func (h *helper) listModels() ([]storages.Model, error) {
 	h.sortModels(&models)
 	return models, nil
 }
+
+func (h *helper) verifyStorage() (*storages.VerficationResult, error) {
+	err := cubecos.CreateStorage(h.storageReqOpts)
+	if err != nil {
+		log.Errorf("integrations(%s): failed to create storage (%v)", h.reqId, err)
+		return &storages.VerficationResult{
+			IsCinderServiceUp:      false,
+			IsTestVolumeSuccessful: false,
+		}, nil
+	}
+
+	defer func() {
+		err := cubecos.DeleteStorage(h.storageReqOpts.Name)
+		if err != nil {
+			log.Errorf("integrations(%s): failed to delete storage after verification (%v)", h.reqId, err)
+		}
+	}()
+
+	result, err := cubecos.VerifyStorage(h.storageReqOpts.Name)
+	if err != nil {
+		log.Errorf("integrations(%s): storage verification failed (%v)", h.reqId, err)
+		return result, err
+	}
+
+	return result, nil
+}

--- a/internal/apis/v1/handlers/integrations/parse.go
+++ b/internal/apis/v1/handlers/integrations/parse.go
@@ -12,6 +12,8 @@ func (h *helper) parseParamsByHandler() error {
 	switch h.handler {
 	case "getStorage":
 		return h.parseGetStorageParams()
+	case "verifyStorage":
+		return h.parseVerifyStorageParams()
 	case "createStorage":
 		return h.parseCreateStorageParams()
 	case "updateStorage":
@@ -39,6 +41,21 @@ func (h *helper) parseGetStorageParams() error {
 		return errors.New("storage name is required")
 	}
 
+	return nil
+}
+
+func (h *helper) parseVerifyStorageParams() error {
+	err := h.c.ShouldBindJSON(&h.storageReqOpts.Cinder)
+	if err != nil {
+		return err
+	}
+
+	if h.storageReqOpts.Name == "" {
+		return errors.New("storage name is required")
+	}
+
+	h.storageReqOpts.ReqId = h.reqId
+	h.storageReqOpts.Hostname = base.Hostname
 	return nil
 }
 

--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -128,6 +128,41 @@ func CreateStorage(req storages.ReqOpts) error {
 	return nil
 }
 
+func VerifyStorage(name string) (*storages.VerficationResult, error) {
+	nameMap := map[string]string{"name": name}
+	input, err := json.Marshal(nameMap)
+	if err != nil {
+		err := genIntegrationErr("storage req parsing failure")
+		log.Errorf("storage: %s (%v)", err.Error(), err)
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(wait.CtxMinutes(10))
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "hex_sdk", "cinder_test_storage", string(input)).CombinedOutput()
+	if err != nil {
+		err := genIntegrationErr("storage verify exec failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return nil, err
+	}
+
+	if !IsHexSuccessful(err) {
+		err := genIntegrationErr("storage verify output failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return nil, err
+	}
+
+	result := &storages.VerficationResult{}
+	err = json.Unmarshal(out, result)
+	if err != nil {
+		err := genIntegrationErr("storage verify parsing failure")
+		log.Errorf("storage: %s (%s)", err.Error(), string(out))
+		return nil, err
+	}
+
+	return result, err
+}
+
 func DeleteStorage(name string) error {
 	nameMap := map[string]string{"name": name}
 	input, err := json.Marshal(nameMap)

--- a/internal/definition/v1/storages/storage.go
+++ b/internal/definition/v1/storages/storage.go
@@ -71,6 +71,11 @@ type Image struct {
 	ForceMultipath bool `json:"forceMultipath" yaml:"forceMultipath" bson:"forceMultipath"`
 }
 
+type VerficationResult struct {
+	IsCinderServiceUp      bool `json:"isCinderServiceUp"`
+	IsTestVolumeSuccessful bool `json:"isTestVolumeSuccessful"`
+}
+
 func (r *ReqOpts) SetCreating() {
 	r.Status.Current = status.Creating
 	r.Status.Desired = status.Created


### PR DESCRIPTION
### What type of PR is this?

Feat

⚠️ Currently, the actual Hex SDK is not implemented in the 45.10 yet, so the API call will return empty or http 500 until COS dev update the Hex module.

<br/>

### Which issue(s) this PR fixes?

- https://github.com/bigstack-oss/cubecos/issues/249

<br/>

### What this PR does?

- Integrate the POST /integrations/storages/verify with Hex SDK

- Add the corresponding API docs

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1428" height="820" alt="Screenshot 2025-09-12 at 10 48 00 AM" src="https://github.com/user-attachments/assets/dabb5600-783d-498c-bd50-c3a30c44e8b8" />

<img width="1426" height="966" alt="Screenshot 2025-09-12 at 10 48 34 AM" src="https://github.com/user-attachments/assets/f4cb1c09-5a17-4aa5-b86d-f27656d064f8" />

