### PR TITLE
feat(service): set stderr output to journal

### DIFF
--- a/init/cube-cos-api.service
+++ b/init/cube-cos-api.service
@@ -19,7 +19,7 @@ BlockIOAccounting=true
 MemoryAccounting=true
 TasksAccounting=true
 StandardOutput=null
-StandardError=syslog
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What type of PR is this?

- feature

### Which issue(s) this PR fixes?

- Systemd is complaining that `Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.`

### What this PR does?

- Set standard error output of `cube-cos-api` service to `journal`, which currently, Systemd already set output from `syslog` to `journal`.
  - https://man7.org/linux/man-pages/man5/systemd.exec.5.html

### Test results (optional)
