### PR TITLE
Fix the node name parsing issue for POST /firmwares/continueAnyway/:nodeName

### DIFF
--- a/internal/apis/v1/handlers/firmwares/parse.go
+++ b/internal/apis/v1/handlers/firmwares/parse.go
@@ -30,6 +30,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseDeleteParams()
 	case "updateFirmwareTask":
 		return h.parseUpdateFirmwareTaskParams()
+	case "continueInterruptedFirmwareUpdate":
+		return h.parseContinueInterruptionParams()
 	default:
 		return nil
 	}
@@ -148,6 +150,15 @@ func (h *helper) parseUpdateFirmwareTaskParams() error {
 		err := fmt.Errorf("hostname is required for firmware update task")
 		log.Errorf("firmwares(%s): %v", h.reqId, err)
 		return err
+	}
+
+	return nil
+}
+
+func (h *helper) parseContinueInterruptionParams() error {
+	h.reqOpts.Hostname = h.c.Param("nodeName")
+	if h.reqOpts.Hostname == "" {
+		return fmt.Errorf("nodeName parameter is required")
 	}
 
 	return nil


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/318

<br/>

### What this PR does?

Fix the node name parsing issue for POST /firmwares/continueAnyway/:nodeName

