### PR TITLE
Do descending order for firmware list by firmware version

### DIFF
--- a/internal/apis/v1/handlers/firmwares/paginate.go
+++ b/internal/apis/v1/handlers/firmwares/paginate.go
@@ -25,7 +25,7 @@ func (h *helper) paginateFirmwares(list []firmwares.Firmware) []firmwares.Firmwa
 
 func (h *helper) sortFirmwares(list *[]firmwares.Firmware) {
 	sort.Slice(*list, func(i, j int) bool {
-		return (*list)[i].UpdatedAt > (*list)[j].UpdatedAt
+		return (*list)[i].Version > (*list)[j].Version
 	})
 }
 


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-api/issues/545
<br/>

### What this PR does?

Do descending order for firmware list by firmware version

<br/>

### Test results (optional)

1). make sure the api works properly

<img width="1852" height="616" alt="Screenshot 2025-12-19 at 3 37 49 PM" src="https://github.com/user-attachments/assets/18f8cf2b-2c14-40c2-88ac-58361c9c592d" />
