### PR TITLE
Upgrade the Golang to 1.24.2 for fixing the security issue from standard libs

### DIFF
--- a/build/cube-cos-api-rpm.Dockerfile
+++ b/build/cube-cos-api-rpm.Dockerfile
@@ -1,13 +1,13 @@
 FROM fedora:35
 
 RUN dnf install -y ca-certificates wget
-ENV GOLANG_VERSION=1.24.0
+ENV GOLANG_VERSION=1.24.2
 ENV GOTOOLCHAIN=local
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN rm -rf /usr/local/go
-RUN wget -q --no-check-certificate https://go.dev/dl/go1.24.0.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.24.0.linux-amd64.tar.gz
-RUN rm go1.24.0.linux-amd64.tar.gz
+RUN wget -q --no-check-certificate https://go.dev/dl/go1.24.2.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.24.2.linux-amd64.tar.gz
+RUN rm go1.24.2.linux-amd64.tar.gz
 
 RUN dnf install -y go-task rpmdevtools gh
 

--- a/docs/developing/README.md
+++ b/docs/developing/README.md
@@ -12,7 +12,7 @@ Genearlly, there're two ways for CubeCOS API developing which help you to have a
 
 ## ▎Get The Environment Ready
 
-- Go >= 1.24.0
+- Go >= 1.24.2
 
 - Taskfile
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bigstack-oss/cube-cos-api
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0
@@ -19,7 +19,6 @@ require (
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/json-iterator/go v1.1.12
-	github.com/kr/pty v1.1.1
 	github.com/micro/plugins/v5/server/http v1.0.2
 	github.com/micro/plugins/v5/wrapper/breaker/hystrix v1.0.2
 	github.com/micro/plugins/v5/wrapper/ratelimiter/uber v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -232,7 +232,6 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
-github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
### What type of PR is this?

Chore
Fix

<br/>

### Which issue(s) this PR fixes?

None

<br/>

### What this PR does?

Upgrade the Golang to 1.24.2 for fixing the security issue from standard libs
