### PR TITLE
fix(firmwares): ensure consistent nodes order when listing updatable nodes

### DIFF
--- a/internal/apis/v1/handlers/firmwares/helper.go
+++ b/internal/apis/v1/handlers/firmwares/helper.go
@@ -3,6 +3,7 @@ package firmwares
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,7 +81,14 @@ func (h *helper) listUpdatableNodes() ([]node, error) {
 		})
 	}
 
+	h.sortNodesByName(&updatables)
 	return updatables, nil
+}
+
+func (h *helper) sortNodesByName(nodes *[]node) {
+	sort.SliceStable(*nodes, func(i, j int) bool {
+		return (*nodes)[i].Name < (*nodes)[j].Name
+	})
 }
 
 func (h *helper) updateFirmware() error {


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

Fix https://github.com/bigstack-oss/cube-cos-ui/issues/761

### What this PR does?

Ensure consistent nodes order when listing updatable nodes.

### Test results (optional)

1). make sure the api docs have been updated

<br/>

2). make sure the api works properly
