### PR TITLE
fix(tunings): select the frontend storage network interface only

### DIFF
--- a/internal/cubecos/network.go
+++ b/internal/cubecos/network.go
@@ -3,6 +3,7 @@ package cubecos
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	conf "github.com/bigstack-oss/cube-cos-api/internal/config"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
@@ -77,7 +78,11 @@ func GetStorageIp(storageNet string) (string, error) {
 		return "", fmt.Errorf("storage network is empty")
 	}
 
-	netIfAddrStorageIp := fmt.Sprintf("%s%s", CubeNetIfAddrPrefix, storageNet)
+	// Splits the entire string by the comma
+	storageNets := strings.Split(storageNet, ",")
+	storageFrontendNet := storageNets[0]
+
+	netIfAddrStorageIp := fmt.Sprintf("%s%s", CubeNetIfAddrPrefix, storageFrontendNet)
 	return GetTuningValue(netIfAddrStorageIp)
 }
 


### PR DESCRIPTION
### What type of PR is this?

- fix

### Which issue(s) this PR fixes?

- When both frontend and backend storage network are provided to a node, `cube-cos-api` would fail to start.

### What this PR does?

- Parse the storage network tuning correctly if both frontend and backend storage network are provided

### Test results (optional)

1). make sure the api docs have been updated

<br/>

2). make sure the api works properly
