### PR TITLE
Chore/build with docker due to nvml

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,7 +37,10 @@ tasks:
       - GOWORK=off go test -v ./...
   buildLocalBinary:
     cmds:
-      - GOWORK=off GOOS=linux GOARCH=amd64 go build -o bin/{{.apiService}} cmd/main.go
+      - cmd: docker compose run --rm cube-cos-api-builder
+        platforms: [darwin, windows]
+      - cmd: GOWORK=off GOOS=linux GOARCH=amd64 go build -o bin/{{.apiService}} cmd/main.go
+        platforms: [linux]
   runLocalDevApi:
     cmds:
       - GOWORK=off go run cmd/main.go -conf configs/{{.apiService}}.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  cube-cos-api-builder:
+    build:
+      context: ./build
+      dockerfile: cube-cos-api-rpm.Dockerfile
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - go-module-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+    command: >
+      sh -c "GOWORK=off GOOS=linux GOARCH=amd64 go build -o bin/cube-cos-api cmd/main.go"
+
+volumes:
+  go-module-cache:
+  go-build-cache:


### PR DESCRIPTION
### What type of PR is this?

Chore

### Which issue(s) this PR fixes?

None

### What this PR does?

Build GO binary in a Docker container because it fails to build on MacOS after NVML dependency is added to the project.

### Notes

Build process stays the same (run `task build` or `task buildLocalBinary`).

### Test results (optional)

None