### PR TITLE
fix: nvml fatal error on gpu not supported server

### DIFF
--- a/internal/runtime/nvml.go
+++ b/internal/runtime/nvml.go
@@ -12,8 +12,18 @@ func initNvml() error {
 	ret := nvml.Init()
 	if ret != nvml.SUCCESS {
 		errorString := nvml.ErrorString(ret)
+
+		if ret == nvml.ERROR_DRIVER_NOT_LOADED {
+			log.Warnf("Failed to initialize NVML: %v", errorString)
+			log.Warnf("NVIDIA driver is not loaded. Continuing without NVML support, GPU features will be unavailable.")
+
+			return nil
+		}
+
 		log.Fatalf("Failed to initialize NVML: %v", errorString)
+
 		return errors.New(errorString)
 	}
+
 	return nil
 }


### PR DESCRIPTION
### What type of PR is this?

fix

### Which issue(s) this PR fixes?

N/A

### What this PR does?

fix: NVML fatal error on gpu not supported server

<img width="993" height="382" alt="截圖 2026-06-15 晚上9 02 51" src="https://github.com/user-attachments/assets/9baac7b0-a3c6-4d88-8313-1ab556e80f26" />

### Test results (optional)

1). make sure the api docs have been updated

On 45.10 server:

<img width="1512" height="675" alt="截圖 2026-06-16 下午4 52 26" src="https://github.com/user-attachments/assets/776f72c3-c622-489c-b89e-fc825fa99fb5" />

Show warning instead of fatal error.
