### PR TITLE
feat(grafana): add device GPU utilization/vram deep-link endpoints (#824)

### DIFF
--- a/internal/apis/v1/handlers/grafana/handlers.go
+++ b/internal/apis/v1/handlers/grafana/handlers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/bodies"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/grafana"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/gin-gonic/gin"
 )
 
@@ -53,6 +54,18 @@ var (
 			Method:  http.MethodGet,
 			Path:    "/grafana/storages",
 			Func:    forwardStoragesLink,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/devices/:hostname/gpuUtilization",
+			Func:    forwardDeviceGpuUtilizationLink,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodGet,
+			Path:    "/grafana/devices/:hostname/gpuVram",
+			Func:    forwardDeviceGpuVramLink,
 		},
 	}
 )
@@ -130,6 +143,35 @@ func forwardStoragesLink(c *gin.Context) {
 		grafana.Dashboard{
 			Link:    genStoragesLink(),
 			Enabled: true,
+		},
+	)
+}
+
+// Returns the device dashboard deep-link for a physical node's GPU utilization
+// history (panel 50), filtered by var-GPU_HOST, whose value must equal the
+// gpu.host `host` tag (verified equal to Node.Hostname). Enabled is gated on
+// node existence (cluster-wide); GetNodeGpusMap is NOT used here because it is
+// local-only and would report the wrong node for remote ones.
+func forwardDeviceGpuUtilizationLink(c *gin.Context) {
+	bodies.SetOk(
+		c,
+		"fetch device gpu utilization link successfully",
+		grafana.Dashboard{
+			Link:    genGpuUtilizationHistoryLink(c),
+			Enabled: nodes.IsExist(c.Param("hostname")),
+		},
+	)
+}
+
+// Returns the device dashboard deep-link for a physical node's GPU VRAM usage
+// history (panel 51). Same var-GPU_HOST / enabled semantics as the utilization link.
+func forwardDeviceGpuVramLink(c *gin.Context) {
+	bodies.SetOk(
+		c,
+		"fetch device gpu vram link successfully",
+		grafana.Dashboard{
+			Link:    genGpuVramHistoryLink(c),
+			Enabled: nodes.IsExist(c.Param("hostname")),
 		},
 	)
 }

--- a/internal/apis/v1/handlers/grafana/links.go
+++ b/internal/apis/v1/handlers/grafana/links.go
@@ -57,3 +57,22 @@ func genStoragesLink() string {
 		base.DataCenterVip,
 	)
 }
+
+// panel 50 = GPU Utilization on the device dashboard (UID i-device).
+// Filtered by the hidden $GPU_HOST variable (gpu.host's `host` tag), NOT $HOST.
+func genGpuUtilizationHistoryLink(c *gin.Context) string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/i-device/device?orgId=1&var-GPU_HOST=%s&from=now-3h&to=now&viewPanel=50",
+		base.DataCenterVip,
+		c.Param("hostname"),
+	)
+}
+
+// panel 51 = GPU VRAM Usage on the device dashboard (UID i-device).
+func genGpuVramHistoryLink(c *gin.Context) string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/i-device/device?orgId=1&var-GPU_HOST=%s&from=now-3h&to=now&viewPanel=51",
+		base.DataCenterVip,
+		c.Param("hostname"),
+	)
+}


### PR DESCRIPTION
### What type of PR is this?

Feature — new backend API endpoints (Grafana deep-links to the Device dashboard GPU panels).

<br/>

### Which issue(s) this PR fixes?

Backend track of #824 and #825 (cross-track User Stories; backend portion only — not closing the stories).

<br/>

### What this PR does?

The GPU host panels live in the **Device** dashboard (UID `i-device`), so this adds two device-scoped Grafana deep-link endpoints:

```
GET /api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuUtilization   (panel 50, #824)
GET /api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuVram          (panel 51, #825)
```

Each returns the existing `grafana.Dashboard`:

```json
{ "link": "https://<vip>/grafana/d/i-device/device?orgId=1&var-GPU_HOST=<host>&from=now-3h&to=now&viewPanel=50", "enabled": true }
```

Changes (additive, zero breaking change):
- `handlers/grafana/links.go`: `genGpuUtilizationHistoryLink` / `genGpuVramHistoryLink` (reuse existing link-gen style + `base.DataCenterVip`).
- `handlers/grafana/handlers.go`: two forward handlers + two routes, each returning the existing `grafana.Dashboard{link, enabled}`.
- Bumps the `cube-cos-openapi` submodule for the matching docs (companion PR bigstack-oss/cube-cos-openapi#103).

Design notes:
- Endpoints scoped under `devices/{hostname}` to match the "one endpoint : one dashboard" Grafana hierarchy (GPU panels are in the Device dashboard).
- Filter variable is **`var-GPU_HOST`** (hidden `$GPU_HOST`), not `var-HOST` (which resolves to `ipmi_sensor.hostname` → blank panels).
- `enabled = nodes.IsExist(hostname)` (cluster-wide); `GetNodeGpusMap` avoided (local-only, reports the wrong node for remote hostnames).
- Auth-free, like the other grafana link endpoints.
- Contract (see #824/#825): panel ids 50/51 and `var-GPU_HOST` must stay stable.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

✅ Two endpoints added to the OpenAPI spec via companion PR bigstack-oss/cube-cos-openapi#103; submodule pointer bumped in this PR. (Merge openapi first, then re-bump to the merged commit.)

<br/>

2). make sure the api works properly

Built on the x86 build container (go 1.24.2) and deployed to test node `sky150`; smoke:
- `.../grafana/devices/sky150/gpuUtilization` → `{ "link": "...viewPanel=50", "enabled": true }`
- `.../grafana/devices/sky150/gpuVram` → `{ "link": "...viewPanel=51", "enabled": true }`
- non-existent hostname → `enabled: false`
- hostname consistency confirmed: `gpu.host.host` = `Node.Hostname` = `sky150`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
