### PR TITLE
refactor: refine gpu cards response

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,7 +14,7 @@ vars:
   devE2ENode: "10.1.0.1"
   mongoVersion: "6.0.19"
   jenkinsBuildServerUser: "root"
-  jenkinsBuildServerIp: "10.32.200.11"
+  jenkinsBuildServerIp: "<REPLACE_WITH_YOUR_JENKINS_BUILD_SERVER_IP>"
   jenkinsBuildServerBinaryImage: "localhost:5000/cube-cos-api-jail"
   jenkinsBuildServerRpmImage: "localhost:5000/cube-cos-api-rpm"
 

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -141,10 +141,10 @@ func (h *helper) listLocalGpuCards() ([]gpu.GpuCard, error) {
 				Current:      hexGpu.Status,
 				IsProcessing: false,
 			},
-			AllocationSummary: hexGpu.Allocation,
-			ProfileCountLimit: hexGpu.ProfileCountLimit,
-			Profiles:          profileCollection,
-			AttachedInstances: attachedInstances,
+			AllocationSummary:          hexGpu.Allocation,
+			SriovVgpuProfileCountLimit: hexGpu.SriovVgpuProfileCountLimit,
+			Profiles:                   profileCollection,
+			AttachedInstances:          attachedInstances,
 		})
 	}
 

--- a/internal/definition/v1/gpu/gpu.go
+++ b/internal/definition/v1/gpu/gpu.go
@@ -20,14 +20,14 @@ const (
 )
 
 type GpuFromHex struct {
-	Id                string                `json:"id"`
-	Name              string                `json:"name"`
-	Type              ResourceType          `json:"type"`
-	SupportTypes      []SupportResourceType `json:"supportTypes"`
-	PciAddress        string                `json:"pciAddress"`
-	ProfileCountLimit *int                  `json:"profileCountLimit"`
-	Status            GpuStatus             `json:"status"`
-	Allocation        *AllocationSummary    `json:"allocation"`
+	Id                         string                `json:"id"`
+	Name                       string                `json:"name"`
+	Type                       ResourceType          `json:"type"`
+	SupportTypes               []SupportResourceType `json:"supportTypes"`
+	PciAddress                 string                `json:"pciAddress"`
+	SriovVgpuProfileCountLimit *int                  `json:"sriovVgpuProfileCountLimit"`
+	Status                     GpuStatus             `json:"status"`
+	Allocation                 *AllocationSummary    `json:"allocation"`
 }
 
 type VgpuProfileCollectionFromHex struct {
@@ -50,18 +50,18 @@ type PgpuAttachedInstanceFromHex struct {
 }
 
 type GpuCard struct {
-	Id                   string                `json:"id"`
-	Name                 string                `json:"name"`
-	PciAddress           string                `json:"pciAddress"`
-	ResourceType         ResourceType          `json:"resourceType"`
-	SupportResourceTypes []SupportResourceType `json:"supportResourceTypes"`
-	Vram                 VramInfo              `json:"vram"`
-	Gpu                  GpuInfo               `json:"gpu"`
-	AllocationSummary    *AllocationSummary    `json:"allocationSummary"`
-	ProfileCountLimit    *int                  `json:"profileCountLimit"`
-	Profiles             GpuProfileCollection  `json:"profiles"`
-	AttachedInstances    *[]AttachedInstance   `json:"attachedInstances"`
-	Status               GpuStatusInfo         `json:"status"`
+	Id                         string                `json:"id"`
+	Name                       string                `json:"name"`
+	PciAddress                 string                `json:"pciAddress"`
+	ResourceType               ResourceType          `json:"resourceType"`
+	SupportResourceTypes       []SupportResourceType `json:"supportResourceTypes"`
+	Vram                       VramInfo              `json:"vram"`
+	Gpu                        GpuInfo               `json:"gpu"`
+	AllocationSummary          *AllocationSummary    `json:"allocationSummary"`
+	SriovVgpuProfileCountLimit *int                  `json:"sriovVgpuProfileCountLimit"`
+	Profiles                   GpuProfileCollection  `json:"profiles"`
+	AttachedInstances          *[]AttachedInstance   `json:"attachedInstances"`
+	Status                     GpuStatusInfo         `json:"status"`
 }
 
 type VramInfo struct {


### PR DESCRIPTION
### What type of PR is this?

Refactor

### Which issue(s) this PR fixes?

N/A

### What this PR does?

refactor: refine gpu cards response

The `profileCountLimit` is only applied on sriov type gpu.
So I renamed it from `profileCountLimit` => `sriovVgpuProfileCountLimit`.

OpenAPI Changes: https://github.com/bigstack-oss/cube-cos-openapi/pull/104
SDK Changes: https://github.com/bigstack-oss/cubecos/pull/1038


### Test results (optional)

<img width="2464" height="1710" alt="image" src="https://github.com/user-attachments/assets/4c385214-7546-42e8-8812-fa8ab8e95eb9" />
