### PR TITLE
fix(runtime): log successful fast requests at Debug to stop poll flooding

### DIFF
--- a/internal/runtime/router.go
+++ b/internal/runtime/router.go
@@ -325,6 +325,18 @@ func traceTime(c *gin.Context) {
 		return
 	}
 
+	// Successful, fast requests (e.g. dashboard polling /notifications, /events)
+	// log at Debug to avoid flooding; errors and slow requests stay at Info.
+	if c.Writer.Status() < 400 && elapsed < time.Second {
+		log.Debugf(
+			"req(%s): %s (%s)",
+			reqId,
+			genReqMsg(c),
+			elapsed,
+		)
+		return
+	}
+
 	log.Infof(
 		"req(%s): %s (%s)",
 		reqId,


### PR DESCRIPTION
### What type of PR is this?

/kind bug

<br/>

### Which issue(s) this PR fixes?

Refs bigstack-oss/cubecos#1029 — the **cube-cos-api** half of the cross-repo
log-flooding cleanup (cubecos + hex#119 + this). Keep #1029 open until all land.

<br/>

### What this PR does?

`traceTime` logged every request at Info; only `GET /live` was throttled. The
dashboard's `/notifications` and `/events/abstract` polling flooded Info
(~76/min). This logs 2xx requests under 1s at **Debug**, and keeps errors and
slow (>=1s) requests at Info.

<br/>

### Test results (optional)

1). No API doc change — router-level logging only, no endpoint/schema change.

2). 2xx requests under 1s drop to Debug; error and slow requests still log at Info.
