### PR TITLE
feat(health): surface fc_link in the cluster health module registry

### DIFF
--- a/internal/cubecos/module.go
+++ b/internal/cubecos/module.go
@@ -75,6 +75,7 @@ var (
 				{Name: "ceph_osd", IsRepairable: true},
 				{Name: "ceph_rgw", IsRepairable: true},
 				{Name: "rbd_target", IsRepairable: false},
+				{Name: "fc_link", IsRepairable: true},
 			},
 		},
 		{


### PR DESCRIPTION
### What type of PR is this?

/kind feature

<br/>

### Which issue(s) this PR fixes?

Refs bigstack-oss/cubecos#1056

<br/>

### What this PR does?

Surfaces the new `fc_link` health module in the cluster health module registry (`internal/cubecos/module.go`) as a repairable component, so the API exposes FC / multipath link health alongside the other Storage components. Pairs with the cubecos `cluster check` fc_link detector and the cos-ui "FC Link" label.

Also bumps the `api/cube-cos-openapi` submodule to add `fc_link` to both health `moduleType` enums (get + repair) — the API validates component names against the embedded spec and would 400 on `fc_link` without it. Submodule branch: `feat/fc-link-health` (commit ae2eb35) on cube-cos-openapi.

<br/>

### Test results (optional)

1). `yq -o=json` docs.json regeneration + `go build ./cmd` pass locally; `fc_link` present in both embedded enums.

2). `fc_link` now returned by the health module list and accepted by the health/repair endpoints.