### PR TITLE
fix(licenses): include CMP licenses in license source sync (#597)

### DIFF
--- a/internal/cubecos/license.go
+++ b/internal/cubecos/license.go
@@ -36,20 +36,37 @@ func IsLicenseFile(file string) bool {
 }
 
 func SyncSourceLicense() {
-	b, err := exec.Command("hex_sdk", "-f", "json", "license_cluster_show").Output()
+	raws, err := listRawLicenses("def")
 	if err != nil {
-		log.Errorf("licenses: licenses: failed to list licenses(%v)", err)
 		return
+	}
+
+	cmpRaws, err := listRawLicenses("cmp")
+	if err != nil {
+		return
+	}
+
+	list := parseLicenses(append(raws, cmpRaws...))
+	licenses.SetList(list)
+}
+
+// hex_sdk license_cluster_show only reports the license of one product per
+// run ("def" for CubeCOS, "cmp" for CubeCMP), so the sync has to query each
+// product to see every installed license.
+func listRawLicenses(product string) ([]licenses.Raw, error) {
+	b, err := exec.Command("hex_sdk", "-f", "json", "license_cluster_show", product).Output()
+	if err != nil {
+		log.Errorf("licenses: failed to list %s licenses(%v)", product, err)
+		return nil, err
 	}
 
 	raws, err := parseRawLicenses(b)
 	if err != nil {
-		log.Errorf("licenses: licenses: failed to parse raw licenses(%v)", err)
-		return
+		log.Errorf("licenses: failed to parse %s raw licenses(%v)", product, err)
+		return nil, err
 	}
 
-	list := parseLicenses(raws)
-	licenses.SetList(list)
+	return raws, nil
 }
 
 func VerifyLicense(file string) (*licenses.Verification, error) {


### PR DESCRIPTION
### What type of PR is this?

Bug fix — the `listLicenses` endpoint never returns CMP licenses.

<br/>

### Which issue(s) this PR fixes?

Fixes #597

<br/>

### What this PR does?

`SyncSourceLicense()` builds the license store from
`hex_sdk -f json license_cluster_show`, invoked without the optional `[app]`
argument. The sdk then defaults to `def` and only ever reads the CubeCOS
license (`/etc/update/license.dat`), so an installed CMP license
(`/etc/update/license-cmp.dat`) never reaches the store — `GET /licenses`
(and `?products=CubeCMP`) can't return it.

Changes (one file, no API surface change):

- `internal/cubecos/license.go`: extract the show/parse steps into
  `listRawLicenses(product string)` and have `SyncSourceLicense()` query both
  products (`"def"` and `"cmp"`, the same strings `checkImportLicense()`
  already uses), merging the results before `parseLicenses`/`SetList`.
- Nodes without a CMP license are unaffected: their `cmp` rows carry no
  `issue.date` and are already dropped by the existing `IsUnlicense()` check.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

N/A — no endpoint/request/response change; existing `products` filter just
starts seeing CMP entries.

<br/>

2). make sure the api works properly

Built on the x86 build container (go 1.24.2) and deployed to a 1cc dev VM
(`cc1`) with one CubeCOS and one CubeCMP trial license installed
(`hex_sdk -v license_check cmp` → valid):

Before (2026-07-04T10:23:43Z):

- `GET .../licenses` → 1 item (CubeCOS only)
- `GET .../licenses?products=CubeCMP` → 0 items

After (2026-07-04T10:31:37Z):

- `GET .../licenses` → 2 items (CubeCOS + CubeCMP, both `valid`, `totalItemCount: 2`)
- `GET .../licenses?products=CubeCMP` → 1 item ✅

Service stayed healthy across the restart; no new errors in the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
