### PR TITLE
feat(gpu): update node GPU card resource type API (886/895/896)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,7 @@ Initialized in `internal/runtime/dependency.go`: MongoDB (primary store), Influx
 ### PR checklist
 
 Per `.github/pull_request_template.md`: update API docs (`task generateApiDocs`) and verify the API works before submitting.
+
+### Commits
+
+Every commit must be DCO signed off, or the DCO CI check fails. Always commit with `git commit -s` (use `git commit --amend --signoff` when amending). The `Signed-off-by:` email must match the commit author's email.

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -388,14 +388,8 @@ func validateGpuCardUpdate(
 		distinctIds[reqProfile.Id] = struct{}{}
 	}
 
-	// The profile-count limit only applies to SR-IOV vGPU; MIG-backed vGPU has no such limit.
-	if req.ResourceType == gpu.ResourceTypeSriovVgpu &&
-		card.SriovVgpuProfileCountLimit != nil && len(distinctIds) > *card.SriovVgpuProfileCountLimit {
-		return fmt.Errorf("gpu %s: %d distinct profiles exceed profile count limit %d: %w",
-			card.Id, len(distinctIds), *card.SriovVgpuProfileCountLimit, gpu.ErrExceedProfileCountLimit)
-	}
-
 	totalVramReqMiB := 0
+	totalProfileCount := 0
 	for _, reqProfile := range req.Profiles {
 		if reqProfile.Count <= 0 {
 			return fmt.Errorf("gpu %s: profile %d count %d must be positive: %w",
@@ -416,6 +410,16 @@ func validateGpuCardUpdate(
 		}
 
 		totalVramReqMiB += int(profile.VramMiB) * reqProfile.Count
+		totalProfileCount += reqProfile.Count
+	}
+
+	// The profile-count limit only applies to SR-IOV vGPU; MIG-backed vGPU has no such limit.
+	// It bounds the total number of vGPU instances (the sum of the requested per-profile
+	// counts), not the number of distinct profiles.
+	if req.ResourceType == gpu.ResourceTypeSriovVgpu &&
+		card.SriovVgpuProfileCountLimit != nil && totalProfileCount > *card.SriovVgpuProfileCountLimit {
+		return fmt.Errorf("gpu %s: total profile count %d exceeds profile count limit %d: %w",
+			card.Id, totalProfileCount, *card.SriovVgpuProfileCountLimit, gpu.ErrExceedProfileCountLimit)
 	}
 
 	// The VRAM limit only applies to MIG-backed vGPU; SR-IOV profiles are fixed

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -20,6 +20,8 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	log "go-micro.dev/v5/logger"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // Seams for unit tests: hex_sdk CLI, the NVML driver, and Openstack are
@@ -36,6 +38,11 @@ var (
 	createConsole               = createConsoleViaOpenstack
 	vgpuInstanceId              = vgpuInstanceIdViaReflect
 	isNvmlAvailable             = nvmlruntime.IsAvailable
+	getNodeGpuById              = cubecos.GetNodeGpuById
+	updateNodeGpuCardViaHex     = cubecos.UpdateNodeGpuCard
+	isGpuUpdating               = isGpuUpdatingViaMongo
+	upsertUpdatingGpuReq        = upsertUpdatingGpuReqViaMongo
+	deleteUpdatingGpuReq        = deleteUpdatingGpuReqViaMongo
 )
 
 type listAttachedInstancesOpts struct {
@@ -249,7 +256,7 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, serverNames map[string
 		PciAddress: hexGpu.PciAddress,
 		Status: gpu.GpuStatusInfo{
 			Current:      hexGpu.Status,
-			IsProcessing: false,
+			IsProcessing: isGpuUpdating(h, hexGpu.Id),
 		},
 		AllocationSummary:          hexGpu.Allocation,
 		SriovVgpuProfileCountLimit: hexGpu.SriovVgpuProfileCountLimit,
@@ -330,7 +337,95 @@ func bytesToMiB(bytes uint64) int {
 }
 
 func isVgpu(hexGpu gpu.GpuFromHex) bool {
-	return hexGpu.Type == gpu.ResourceTypeSriovVgpu || hexGpu.Type == gpu.ResourceTypeMigBackedVgpu
+	return isVgpuType(hexGpu.Type)
+}
+
+func isVgpuType(t gpu.ResourceType) bool {
+	return t == gpu.ResourceTypeSriovVgpu || t == gpu.ResourceTypeMigBackedVgpu
+}
+
+func isSupportedType(supportTypes []gpu.SupportResourceType, t gpu.ResourceType) bool {
+	for _, st := range supportTypes {
+		if string(st) == string(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateGpuCardUpdate checks a resource-type change against the card's real
+// capabilities. profilesMap (keyed by profile Id) and totalVramMiB (from NVML)
+// are only consulted for vGPU types with profiles. Returns a sentinel-wrapped
+// error the handler maps to a status.
+func validateGpuCardUpdate(
+	card gpu.GpuFromHex,
+	req gpu.UpdateGpuCardRequest,
+	profilesMap map[uint32]gpu.VgpuProfileFromHex,
+	totalVramMiB int,
+) error {
+	if !isSupportedType(card.SupportTypes, req.ResourceType) {
+		return fmt.Errorf("gpu card %s does not support '%s' resource type: %w", card.Id, req.ResourceType, gpu.ErrUnsupportedType)
+	}
+
+	if !isVgpuType(req.ResourceType) && len(req.Profiles) > 0 {
+		return fmt.Errorf("profiles are not allowed for resource type %s: %w", req.ResourceType, gpu.ErrProfilesNotAllowed)
+	}
+
+	if card.Status == gpu.GpuStatusInUse || (card.Allocation != nil && card.Allocation.Current > 0) {
+		return fmt.Errorf("gpu %s is in use: %w", card.Id, gpu.ErrGpuInUse)
+	}
+
+	if !isVgpuType(req.ResourceType) {
+		return nil
+	}
+
+	// Reject duplicate profile ids up front.
+	distinctIds := map[uint32]struct{}{}
+	for _, reqProfile := range req.Profiles {
+		if _, dup := distinctIds[reqProfile.Id]; dup {
+			return fmt.Errorf("gpu %s: duplicate vgpu profile %d: %w", card.Id, reqProfile.Id, gpu.ErrDuplicateProfile)
+		}
+		distinctIds[reqProfile.Id] = struct{}{}
+	}
+
+	// The profile-count limit only applies to SR-IOV vGPU; MIG-backed vGPU has no such limit.
+	if req.ResourceType == gpu.ResourceTypeSriovVgpu &&
+		card.SriovVgpuProfileCountLimit != nil && len(distinctIds) > *card.SriovVgpuProfileCountLimit {
+		return fmt.Errorf("gpu %s: %d distinct profiles exceed profile count limit %d: %w",
+			card.Id, len(distinctIds), *card.SriovVgpuProfileCountLimit, gpu.ErrExceedProfileCountLimit)
+	}
+
+	totalVramReqMiB := 0
+	for _, reqProfile := range req.Profiles {
+		if reqProfile.Count <= 0 {
+			return fmt.Errorf("gpu %s: profile %d count %d must be positive: %w",
+				card.Id, reqProfile.Id, reqProfile.Count, gpu.ErrInvalidProfileCount)
+		}
+
+		profile, ok := profilesMap[reqProfile.Id]
+		if !ok {
+			return fmt.Errorf("gpu %s: vgpu profile %d not found: %w", card.Id, reqProfile.Id, gpu.ErrProfileNotFound)
+		}
+
+		// The per-profile count limit only applies to MIG-backed vGPU; only its
+		// profiles carry a vm count limit.
+		if req.ResourceType == gpu.ResourceTypeMigBackedVgpu &&
+			profile.VmCountLimit != nil && reqProfile.Count > *profile.VmCountLimit {
+			return fmt.Errorf("gpu %s: profile %d count %d exceeds vm count limit %d: %w",
+				card.Id, reqProfile.Id, reqProfile.Count, *profile.VmCountLimit, gpu.ErrExceedProfileCountLimit)
+		}
+
+		totalVramReqMiB += int(profile.VramMiB) * reqProfile.Count
+	}
+
+	// The VRAM limit only applies to MIG-backed vGPU; SR-IOV profiles are fixed
+	// partitions constrained by the profile-count limit instead.
+	if req.ResourceType == gpu.ResourceTypeMigBackedVgpu && totalVramReqMiB > totalVramMiB {
+		return fmt.Errorf("gpu %s: requested vram %d MiB exceeds device total %d MiB: %w",
+			card.Id, totalVramReqMiB, totalVramMiB, gpu.ErrExceedVramLimit)
+	}
+
+	return nil
 }
 
 // listAttachedInstances returns the attached instances, flagging the card via
@@ -672,4 +767,130 @@ func createMigProfileRemainingMap(
 	}
 
 	return remainingMap
+}
+
+func (h *helper) updateNodeGpuCard() error {
+	if nodes.IsLocal(h.node) {
+		return h.updateLocalGpuCard()
+	}
+	return h.updateRemoteGpuCard()
+}
+
+func (h *helper) updateLocalGpuCard() error {
+	card, err := getNodeGpuById(h.node, h.gpuId)
+	if err != nil {
+		return err
+	}
+
+	// vGPU profile/VRAM limits need the GPU's available profiles (hex) and its
+	// total VRAM (NVML). Only gather them when profiles are actually supplied.
+	var profilesMap map[uint32]gpu.VgpuProfileFromHex
+	var totalVramMiB int
+	if isVgpuType(h.gpuCardReq.ResourceType) && len(h.gpuCardReq.Profiles) > 0 {
+		profilesMap, _, err = getNodeVgpuProfilesMap(card.Id)
+		if err != nil {
+			log.Errorf("gpu(%s): failed to get vgpu profiles for gpu %s: %v", h.reqId, h.gpuId, err)
+			return err
+		}
+
+		totalVramMiB, err = getGpuTotalVramMiB(card.Id)
+		if err != nil {
+			log.Errorf("gpu(%s): failed to get total vram for gpu %s: %v", h.reqId, h.gpuId, err)
+			return err
+		}
+	}
+
+	if err := validateGpuCardUpdate(card, h.gpuCardReq, profilesMap, totalVramMiB); err != nil {
+		return err
+	}
+
+	if err := upsertUpdatingGpuReq(h, h.gpuId); err != nil {
+		return err
+	}
+	defer func() {
+		if err := deleteUpdatingGpuReq(h, h.gpuId); err != nil {
+			log.Errorf("gpu(%s): failed to clear updating record for gpu %s: %v", h.reqId, h.gpuId, err)
+		}
+	}()
+
+	return updateNodeGpuCardViaHex(h.gpuId, h.gpuCardReq)
+}
+
+func (h *helper) updateRemoteGpuCard() error {
+	node, err := nodes.Get(h.node)
+	if err != nil {
+		log.Errorf("gpu(%s): failed to get node %s: %v", h.reqId, h.node, err)
+		return err
+	}
+
+	resp, err := h.http.R().
+		SetHeaders(nodes.GetSecretHeaders()).
+		SetBody(h.gpuCardReq).
+		Put(node.UpdateGpuCardUrl(h.gpuId))
+	if err != nil {
+		log.Errorf("gpu(%s): failed to update GPU card on remote node %s: %v", h.reqId, h.node, err)
+		return err
+	}
+
+	if resp.IsError() {
+		return fmt.Errorf("error response from node %s updating GPU card %s: %s", h.node, h.gpuId, string(resp.Body()))
+	}
+
+	return nil
+}
+
+func isGpuUpdatingViaMongo(h *helper, gpuId string) bool {
+	count, err := h.mongo.GetCount(
+		nodes.Db,
+		nodes.ReqGpuCollection,
+		bson.M{"hostname": h.node, "gpuId": gpuId},
+	)
+	if err != nil {
+		log.Errorf("gpu(%s): failed to get updating record for gpu %s: %v", h.reqId, gpuId, err)
+		return false
+	}
+
+	return count > 0
+}
+
+func upsertUpdatingGpuReqViaMongo(h *helper, gpuId string) error {
+	record := gpu.GpuReqRecord{
+		Hostname:     h.node,
+		GpuId:        gpuId,
+		ReqId:        h.reqId,
+		ResourceType: h.gpuCardReq.ResourceType,
+		Profiles:     h.gpuCardReq.Profiles,
+	}
+
+	return h.mongo.UpdateOne(
+		nodes.Db,
+		nodes.ReqGpuCollection,
+		bson.M{"hostname": h.node, "gpuId": gpuId, "reqId": h.reqId},
+		bson.M{"$set": record},
+		options.Update().SetUpsert(true),
+	)
+}
+
+func deleteUpdatingGpuReqViaMongo(h *helper, gpuId string) error {
+	return h.mongo.DeleteOne(
+		nodes.Db,
+		nodes.ReqGpuCollection,
+		bson.M{"hostname": h.node, "gpuId": gpuId, "reqId": h.reqId},
+	)
+}
+
+// getGpuTotalVramMiB reads the physical GPU's total VRAM via NVML. Used as the
+// budget for the vGPU VRAM-limit validation.
+func getGpuTotalVramMiB(uuid string) (int, error) {
+	device, ret := deviceGetHandleByUUID(uuid)
+	if ret != nvml.SUCCESS {
+		return 0, fmt.Errorf("nvml: failed to get device handle for gpu %s: %s", uuid, nvml.ErrorString(ret))
+	}
+
+	memoryInfo, ret := device.GetMemoryInfo()
+	if ret != nvml.SUCCESS {
+		return 0, fmt.Errorf("nvml: failed to get memory info for gpu %s: %s", uuid, nvml.ErrorString(ret))
+	}
+
+	return bytesToMiB(memoryInfo.Total), nil
 }

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -30,6 +30,16 @@ func restoreGpuSeams(t *testing.T) {
 	origCreateConsole := createConsole
 	origVgpuInstanceId := vgpuInstanceId
 	origIsNvmlAvailable := isNvmlAvailable
+	origGetNodeGpuById := getNodeGpuById
+	origUpdateNodeGpuCardViaHex := updateNodeGpuCardViaHex
+	origIsGpuUpdating := isGpuUpdating
+	origUpsertUpdatingGpuReq := upsertUpdatingGpuReq
+	origDeleteUpdatingGpuReq := deleteUpdatingGpuReq
+
+	// Defaults that avoid MongoDB in tests that build/list cards.
+	isGpuUpdating = func(h *helper, gpuId string) bool { return false }
+	upsertUpdatingGpuReq = func(h *helper, gpuId string) error { return nil }
+	deleteUpdatingGpuReq = func(h *helper, gpuId string) error { return nil }
 
 	t.Cleanup(func() {
 		getNodeGpusMap = origGetNodeGpusMap
@@ -43,6 +53,11 @@ func restoreGpuSeams(t *testing.T) {
 		createConsole = origCreateConsole
 		vgpuInstanceId = origVgpuInstanceId
 		isNvmlAvailable = origIsNvmlAvailable
+		getNodeGpuById = origGetNodeGpuById
+		updateNodeGpuCardViaHex = origUpdateNodeGpuCardViaHex
+		isGpuUpdating = origIsGpuUpdating
+		upsertUpdatingGpuReq = origUpsertUpdatingGpuReq
+		deleteUpdatingGpuReq = origDeleteUpdatingGpuReq
 	})
 }
 
@@ -988,6 +1003,153 @@ func TestIsVgpu(t *testing.T) {
 	require.True(t, isVgpu(gpu.GpuFromHex{Type: gpu.ResourceTypeMigBackedVgpu}))
 }
 
+func TestValidateGpuCardUpdate(t *testing.T) {
+	profileCountLimit := 2
+	vmCountLimit := 4
+
+	card := gpu.GpuFromHex{
+		Id:                         "GPU-1",
+		PciAddress:                 "0000:01:00.0",
+		SupportTypes:               []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeSriovVgpu},
+		Status:                     gpu.GpuStatusIdle,
+		SriovVgpuProfileCountLimit: &profileCountLimit,
+	}
+
+	// Only mig-backed profiles carry a vmCountLimit.
+	// Two profiles: id 57 = 2048 MiB each (vm limit 4), id 58 = 4096 MiB each (no vm limit).
+	profilesMap := map[uint32]gpu.VgpuProfileFromHex{
+		57: {Id: 57, VramMiB: 2048, VmCountLimit: &vmCountLimit},
+		58: {Id: 58, VramMiB: 4096},
+	}
+	totalVramMiB := 16384
+
+	t.Run("unsupported resource type -> 409 sentinel", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypeMigBackedVgpu}, nil, 0)
+		require.ErrorIs(t, err, gpu.ErrUnsupportedType)
+	})
+
+	t.Run("profiles on a non-vgpu type -> 400 sentinel", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypePgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}},
+		}, profilesMap, totalVramMiB)
+		require.ErrorIs(t, err, gpu.ErrProfilesNotAllowed)
+	})
+
+	t.Run("gpu in use by status -> 409 sentinel", func(t *testing.T) {
+		inUse := card
+		inUse.Status = gpu.GpuStatusInUse
+		err := validateGpuCardUpdate(inUse, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, 0)
+		require.ErrorIs(t, err, gpu.ErrGpuInUse)
+	})
+
+	t.Run("gpu in use by allocation -> 409 sentinel", func(t *testing.T) {
+		inUse := card
+		inUse.Allocation = &gpu.AllocationSummary{Current: 1, Total: 1}
+		err := validateGpuCardUpdate(inUse, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, 0)
+		require.ErrorIs(t, err, gpu.ErrGpuInUse)
+	})
+
+	t.Run("unknown profile id -> 400 sentinel", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 999, Count: 1}},
+		}, profilesMap, totalVramMiB)
+		require.ErrorIs(t, err, gpu.ErrProfileNotFound)
+	})
+
+	t.Run("distinct profile count over card limit -> 409 sentinel", func(t *testing.T) {
+		three := 1
+		limited := card
+		limited.SriovVgpuProfileCountLimit = &three // allow only 1 distinct profile
+		err := validateGpuCardUpdate(limited, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 58, Count: 1}},
+		}, profilesMap, totalVramMiB)
+		require.ErrorIs(t, err, gpu.ErrExceedProfileCountLimit)
+	})
+
+	// The profile-count limit is SR-IOV only; MIG-backed vGPU ignores it.
+	t.Run("mig-backed vgpu ignores the profile count limit", func(t *testing.T) {
+		one := 1
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+		migCard.SriovVgpuProfileCountLimit = &one // would trip for SR-IOV, but must be ignored here
+		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 58, Count: 1}}, // 2 distinct > limit 1
+		}, profilesMap, totalVramMiB)
+		require.NoError(t, err)
+	})
+
+	// The per-profile vmCountLimit is MIG-backed only.
+	t.Run("mig-backed per-profile count over vmCountLimit -> 409 sentinel", func(t *testing.T) {
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 5}}, // vmCountLimit is 4; 2048*5 = 10240 <= 16384 so vram is not what trips
+		}, profilesMap, totalVramMiB)
+		require.ErrorIs(t, err, gpu.ErrExceedProfileCountLimit)
+	})
+
+	t.Run("sriov vgpu ignores the per-profile vmCountLimit", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 5}}, // vmCountLimit is 4, but ignored for sriov
+		}, profilesMap, totalVramMiB)
+		require.NoError(t, err)
+	})
+
+	// The VRAM limit applies to MIG-backed vGPU only.
+	t.Run("mig-backed total requested vram over device total -> 409 sentinel", func(t *testing.T) {
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 58, Count: 5}}, // 4096*5 = 20480 > 16384
+		}, profilesMap, 16384)
+		require.ErrorIs(t, err, gpu.ErrExceedVramLimit)
+	})
+
+	// SR-IOV profiles are fixed partitions; their total VRAM is not checked against device memory.
+	t.Run("sriov vgpu ignores the vram limit", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 58, Count: 5}}, // 20480 > 16384, but ignored for sriov
+		}, profilesMap, 16384)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid pgpu update passes", func(t *testing.T) {
+		require.NoError(t, validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, 0))
+	})
+
+	// TODO: What?
+	t.Run("valid sriov vgpu update within all limits passes", func(t *testing.T) {
+		require.NoError(t, validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 2}, {Id: 58, Count: 1}}, // 2048*2+4096 = 8192
+		}, profilesMap, totalVramMiB))
+	})
+
+	t.Run("non-positive profile count -> 400 sentinel", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 0}},
+		}, profilesMap, totalVramMiB)
+		require.ErrorIs(t, err, gpu.ErrInvalidProfileCount)
+	})
+
+	t.Run("duplicate profile id -> 400 sentinel", func(t *testing.T) {
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 57, Count: 1}}, // same id twice
+		}, profilesMap, totalVramMiB)
+		require.ErrorIs(t, err, gpu.ErrDuplicateProfile)
+	})
+}
+
 func TestToProfileCollectionComputesMigRemaining(t *testing.T) {
 	migAlias := "1g.10gb"
 
@@ -1016,6 +1178,7 @@ func TestCreateMigProfileRemainingMap(t *testing.T) {
 		require.Empty(t, createMigProfileRemainingMap(nil, nil))
 	})
 
+	// TODO: but this should not happen. We should log warning.
 	t.Run("remaining count does not go below zero", func(t *testing.T) {
 		migProfiles := &[]gpu.VgpuProfileFromHex{
 			{Id: 5, Count: 1, Alias: &alias},
@@ -1030,6 +1193,7 @@ func TestCreateMigProfileRemainingMap(t *testing.T) {
 		require.Equal(t, map[uint32]int{5: 0}, remainingMap)
 	})
 
+	// TODO: This should not happen. We should log warning.
 	t.Run("instances with unknown alias are ignored", func(t *testing.T) {
 		unknownAlias := "unknown"
 		migProfiles := &[]gpu.VgpuProfileFromHex{
@@ -1043,4 +1207,157 @@ func TestCreateMigProfileRemainingMap(t *testing.T) {
 
 		require.Equal(t, map[uint32]int{5: 2}, remainingMap)
 	})
+}
+
+func TestUpdateLocalGpuCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	card := gpu.GpuFromHex{
+		Id:           "GPU-1",
+		PciAddress:   "0000:01:00.0",
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeSriovVgpu},
+		Status:       gpu.GpuStatusIdle,
+	}
+
+	t.Run("valid pgpu update calls hex and clears the record", func(t *testing.T) {
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return card, nil }
+
+		var hexCalled, upserted, deleted bool
+		upsertUpdatingGpuReq = func(h *helper, gpuId string) error { upserted = true; return nil }
+		deleteUpdatingGpuReq = func(h *helper, gpuId string) error { deleted = true; return nil }
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error {
+			hexCalled = true
+			require.Equal(t, "GPU-1", gpuId)
+			require.Equal(t, gpu.ResourceTypePgpu, req.ResourceType)
+			return nil
+		}
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypePgpu,
+		}}
+
+		require.NoError(t, h.updateLocalGpuCard())
+		require.True(t, upserted)
+		require.True(t, hexCalled)
+		require.True(t, deleted)
+	})
+
+	t.Run("valid sriov vgpu update gathers profiles + vram then calls hex", func(t *testing.T) {
+		vmLimit := 4
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return card, nil }
+		getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+			require.Equal(t, card.Id, gpuId)
+			return map[uint32]gpu.VgpuProfileFromHex{
+				57: {Id: 57, VramMiB: 2048, VmCountLimit: &vmLimit},
+			}, gpu.VgpuProfileCollectionFromHex{}, nil
+		}
+		deviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+			require.Equal(t, "GPU-1", uuid)
+			return &nvmlmock.Device{
+				GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
+					return nvml.Memory{Total: 16384 * bytesPerMiB}, nvml.SUCCESS
+				},
+			}, nvml.SUCCESS
+		}
+
+		var hexCalled bool
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error { hexCalled = true; return nil }
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 2}}, // 2048*2 = 4096 <= 16384
+		}}
+
+		require.NoError(t, h.updateLocalGpuCard())
+		require.True(t, hexCalled)
+	})
+
+	t.Run("hex failure still clears the record", func(t *testing.T) {
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return card, nil }
+
+		var deleted bool
+		deleteUpdatingGpuReq = func(h *helper, gpuId string) error { deleted = true; return nil }
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error {
+			return errors.New("hex_config failed")
+		}
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}}
+
+		require.Error(t, h.updateLocalGpuCard())
+		require.True(t, deleted)
+	})
+
+	t.Run("validation failure skips hex and record", func(t *testing.T) {
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return card, nil }
+
+		upsertUpdatingGpuReq = func(h *helper, gpuId string) error { t.Fatal("must not upsert"); return nil }
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error { t.Fatal("must not call hex"); return nil }
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypeMigBackedVgpu}}
+
+		err := h.updateLocalGpuCard()
+		require.ErrorIs(t, err, gpu.ErrUnsupportedType)
+	})
+
+	t.Run("gpu not found is surfaced", func(t *testing.T) {
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) {
+			return gpu.GpuFromHex{}, gpu.ErrGpuNotFound
+		}
+
+		h := &helper{node: "node-1", gpuId: "missing", gpuCardReq: gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}}
+
+		require.ErrorIs(t, h.updateLocalGpuCard(), gpu.ErrGpuNotFound)
+	})
+
+	t.Run("node-side profile-list failure surfaces as a non-4xx infra error, not a bad request", func(t *testing.T) {
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return card, nil }
+		getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+			return nil, gpu.VgpuProfileCollectionFromHex{}, errors.New("hex_sdk profile list failed")
+		}
+		deviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+			return &nvmlmock.Device{
+				GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
+					return nvml.Memory{Total: 16384 * bytesPerMiB}, nvml.SUCCESS
+				},
+			}, nvml.SUCCESS
+		}
+
+		hexCalled := false
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error { hexCalled = true; return nil }
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeSriovVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}},
+		}}
+
+		err := h.updateLocalGpuCard()
+
+		require.Error(t, err)
+		require.NotErrorIs(t, err, gpu.ErrGpuNotFound)
+		require.NotErrorIs(t, err, gpu.ErrUnsupportedType)
+		require.NotErrorIs(t, err, gpu.ErrProfilesNotAllowed)
+		require.NotErrorIs(t, err, gpu.ErrProfileNotFound)
+		require.NotErrorIs(t, err, gpu.ErrInvalidProfileCount)
+		require.NotErrorIs(t, err, gpu.ErrExceedProfileCountLimit)
+		require.NotErrorIs(t, err, gpu.ErrExceedVramLimit)
+		require.NotErrorIs(t, err, gpu.ErrGpuInUse)
+		require.False(t, hexCalled)
+	})
+}
+
+func TestBuildLocalGpuCardReportsIsProcessing(t *testing.T) {
+	restoreGpuSeams(t)
+
+	isGpuUpdating = func(h *helper, gpuId string) bool { return gpuId == "GPU-proc" }
+	deviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) { return nil, nvml.ERROR_NOT_FOUND }
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(gpu.GpuFromHex{
+		Id:         "GPU-proc",
+		PciAddress: "0000:01:00.0",
+		Type:       gpu.ResourceTypePgpu,
+		Status:     gpu.GpuStatusIdle,
+	}, nil)
+
+	require.NoError(t, err)
+	require.True(t, card.Status.IsProcessing)
 }

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -1004,7 +1004,7 @@ func TestIsVgpu(t *testing.T) {
 }
 
 func TestValidateGpuCardUpdate(t *testing.T) {
-	profileCountLimit := 2
+	profileCountLimit := 10
 	vmCountLimit := 4
 
 	card := gpu.GpuFromHex{
@@ -1058,13 +1058,16 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		require.ErrorIs(t, err, gpu.ErrProfileNotFound)
 	})
 
-	t.Run("distinct profile count over card limit -> 409 sentinel", func(t *testing.T) {
-		three := 1
+	// The limit bounds the total number of vGPU instances (sum of the requested
+	// per-profile counts), not the number of distinct profiles: a single profile
+	// whose count exceeds the limit trips it.
+	t.Run("total profile count over card limit -> 409 sentinel", func(t *testing.T) {
+		two := 2
 		limited := card
-		limited.SriovVgpuProfileCountLimit = &three // allow only 1 distinct profile
+		limited.SriovVgpuProfileCountLimit = &two // allow only 2 vgpu instances total
 		err := validateGpuCardUpdate(limited, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
-			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 58, Count: 1}},
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 3}}, // sum 3 > limit 2
 		}, profilesMap, totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrExceedProfileCountLimit)
 	})
@@ -1077,7 +1080,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		migCard.SriovVgpuProfileCountLimit = &one // would trip for SR-IOV, but must be ignored here
 		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeMigBackedVgpu,
-			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 58, Count: 1}}, // 2 distinct > limit 1
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 58, Count: 1}}, // total count 2 > limit 1
 		}, profilesMap, totalVramMiB)
 		require.NoError(t, err)
 	})

--- a/internal/apis/v1/handlers/nodes/handlers.go
+++ b/internal/apis/v1/handlers/nodes/handlers.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/bodies"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/gpu"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
 	_ "github.com/bigstack-oss/cube-cos-api/internal/operators/v1/nodes"
@@ -70,6 +72,12 @@ var (
 			Method:  http.MethodGet,
 			Path:    "/nodes/:nodeName/gpuCards",
 			Func:    listNodeGpuCards,
+		},
+		{
+			Version: apis.V1,
+			Method:  http.MethodPut,
+			Path:    "/nodes/:nodeName/gpuCards/:gpuId",
+			Func:    updateNodeGpuCard,
 		},
 		{
 			Version: apis.V1,
@@ -318,6 +326,38 @@ func getGpuInstanceConsole(c *gin.Context) {
 	bodies.SetOk(c, "gpu instance console link retrieved successfully", console)
 }
 
+func updateNodeGpuCard(c *gin.Context) {
+	h, err := initHelper(c, "updateNodeGpuCard")
+	if err != nil {
+		log.Errorf("gpu(%s): failed to init helper(%v)", h.reqId, err)
+		bodies.SetBadRequest(c, err, nil)
+		return
+	}
+
+	if !nodes.IsExist(h.node) {
+		bodies.SetNotFound(c, fmt.Errorf("node %s not found", h.node))
+		return
+	}
+
+	err = h.updateNodeGpuCard()
+	switch {
+	case err == nil:
+		bodies.SetOk(c, "node GPU card updated successfully", nil)
+	case errors.Is(err, gpu.ErrGpuNotFound):
+		bodies.SetNotFound(c, err)
+	case errors.Is(err, gpu.ErrProfilesNotAllowed), errors.Is(err, gpu.ErrProfileNotFound), errors.Is(err, gpu.ErrInvalidProfileCount), errors.Is(err, gpu.ErrDuplicateProfile):
+		bodies.SetBadRequest(c, err, nil)
+	case errors.Is(err, gpu.ErrUnsupportedType),
+		errors.Is(err, gpu.ErrGpuInUse),
+		errors.Is(err, gpu.ErrExceedProfileCountLimit),
+		errors.Is(err, gpu.ErrExceedVramLimit):
+		bodies.SetConflict(c, err)
+	default:
+		log.Errorf("gpu(%s): failed to update GPU card %s for node %s: %v", h.reqId, h.gpuId, h.node, err)
+		bodies.SetInternalServerError(c, err)
+	}
+}
+
 func ipmiOperateNode(c *gin.Context) {
 	h, err := initHelper(c, "ipmiOperateNode")
 	if err != nil {
@@ -340,7 +380,7 @@ func ipmiOperateNode(c *gin.Context) {
 
 	bodies.SetAccepted(
 		c,
-		"the requets of ipmi operation is accepted and under processing",
+		"the request of ipmi operation is accepted and under processing",
 	)
 }
 

--- a/internal/apis/v1/handlers/nodes/helper.go
+++ b/internal/apis/v1/handlers/nodes/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/apis/v1/queries"
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/gpu"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/pages"
 	"github.com/gin-gonic/gin"
@@ -39,6 +40,8 @@ type helper struct {
 	deviceReqOpts   nodes.DeviceReqOpts
 	osdReqOpts      nodes.OsdReqOpts
 	osdReqOptses    []nodes.OsdReqOpts
+	gpuId           string
+	gpuCardReq      gpu.UpdateGpuCardRequest
 
 	page  *pages.Page
 	watch bool

--- a/internal/apis/v1/handlers/nodes/parse.go
+++ b/internal/apis/v1/handlers/nodes/parse.go
@@ -31,6 +31,8 @@ func (h *helper) parseParamsByHandler() error {
 		return h.parseListGPUCardsOptions()
 	case "getGpuInstanceConsole":
 		return h.parseGetGpuInstanceConsoleOptions()
+	case "updateNodeGpuCard":
+		return h.parseUpdateGPUCardOptions()
 	case "addNodeDevice":
 		return h.parseCreateDeviceOptions()
 	case "updateNodeDevice":
@@ -378,6 +380,24 @@ func (h *helper) parseGetGpuInstanceConsoleOptions() error {
 	h.instanceId = h.c.Param("instanceId")
 	if h.instanceId == "" {
 		return fmt.Errorf("instanceId should be provided")
+	}
+
+	return nil
+}
+
+func (h *helper) parseUpdateGPUCardOptions() error {
+	h.node = h.c.Param("nodeName")
+	if h.node == "" {
+		return fmt.Errorf("nodeName should be provided")
+	}
+
+	h.gpuId = h.c.Param("gpuId")
+	if h.gpuId == "" {
+		return fmt.Errorf("gpuId should be provided")
+	}
+
+	if err := h.c.ShouldBindJSON(&h.gpuCardReq); err != nil {
+		return fmt.Errorf("failed to parse update GPU card request(%v)", err)
 	}
 
 	return nil

--- a/internal/cubecos/nodes.go
+++ b/internal/cubecos/nodes.go
@@ -396,6 +396,52 @@ func GetNodeGpusMap(nodeName string) (map[string]gpu.GpuFromHex, error) {
 	return gpuMap, nil
 }
 
+// GetNodeGpuById returns the hex GPU whose Id matches gpuId, or gpu.ErrGpuNotFound.
+// Reuses GetNodeGpusMap (keyed by PCI address) and matches on the NVML UUID Id.
+func GetNodeGpuById(nodeName, gpuId string) (gpu.GpuFromHex, error) {
+	gpusMap, err := GetNodeGpusMap(nodeName)
+	if err != nil {
+		return gpu.GpuFromHex{}, err
+	}
+
+	for _, g := range gpusMap {
+		if g.Id == gpuId {
+			return g, nil
+		}
+	}
+
+	return gpu.GpuFromHex{}, fmt.Errorf("gpu %s not found on node %s: %w", gpuId, nodeName, gpu.ErrGpuNotFound)
+}
+
+// UpdateNodeGpuCard sets a GPU's resource type via hex_config. Profiles, when
+// present, are passed as a single JSON-string positional argument.
+func UpdateNodeGpuCard(gpuId string, req gpu.UpdateGpuCardRequest) error {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
+	defer cancel()
+
+	args := []string{"gpu_resource_set", gpuId, string(req.ResourceType)}
+	if len(req.Profiles) > 0 {
+		profilesJson, err := json.Marshal(req.Profiles)
+		if err != nil {
+			return fmt.Errorf("failed to marshal gpu profiles: %w", err)
+		}
+		args = append(args, string(profilesJson))
+	}
+
+	out, err := exec.CommandContext(ctx, "hex_config", args...).CombinedOutput()
+	if err != nil {
+		log.Errorf("nodes: failed to set gpu %s resource via hex_config: %v, output: %s", gpuId, err, string(out))
+		return err
+	}
+
+	if !IsHexSuccessful(err) {
+		log.Errorf("nodes: output error when setting gpu %s resource via hex_config: %s", gpuId, string(out))
+		return fmt.Errorf("hex_config gpu_resource_set failed: %s", string(out))
+	}
+
+	return nil
+}
+
 func listNodeGpus(nodeName string) ([]gpu.GpuFromHex, error) {
 	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
 	defer cancel()

--- a/internal/definition/v1/gpu/gpu.go
+++ b/internal/definition/v1/gpu/gpu.go
@@ -1,5 +1,7 @@
 package gpu
 
+import "errors"
+
 type ResourceType string
 type SupportResourceType string
 type GpuStatus string
@@ -127,4 +129,38 @@ type InstanceConsole struct {
 type GpuStatusInfo struct {
 	Current      GpuStatus `json:"current"`
 	IsProcessing bool      `json:"isProcessing"`
+}
+
+// Sentinel errors for the update-GPU-card flow. Wrap with %w so the HTTP
+// handler can map them to status codes via errors.Is.
+var (
+	ErrGpuNotFound             = errors.New("gpu not found")
+	ErrUnsupportedType         = errors.New("resource type not supported by gpu")
+	ErrProfilesNotAllowed      = errors.New("profiles not allowed for this resource type")
+	ErrProfileNotFound         = errors.New("vgpu profile not found")
+	ErrExceedProfileCountLimit = errors.New("exceed gpu profile count limit")
+	ErrExceedVramLimit         = errors.New("exceed vram limit MiB")
+	ErrGpuInUse                = errors.New("gpu is in use")
+	ErrInvalidProfileCount     = errors.New("invalid vgpu profile count")
+	ErrDuplicateProfile        = errors.New("duplicate vgpu profile")
+)
+
+type UpdateGpuCardProfile struct {
+	Id    uint32 `json:"id" bson:"id"`
+	Count int    `json:"count" bson:"count"`
+}
+
+type UpdateGpuCardRequest struct {
+	ResourceType ResourceType           `json:"resourceType" binding:"required"`
+	Profiles     []UpdateGpuCardProfile `json:"profiles"`
+}
+
+// GpuReqRecord marks a GPU as being reconfigured. Its presence in
+// ReqGpuCollection makes the list endpoint report Status.IsProcessing = true.
+type GpuReqRecord struct {
+	Hostname     string                 `json:"hostname" bson:"hostname"`
+	GpuId        string                 `json:"gpuId" bson:"gpuId"`
+	ReqId        string                 `json:"reqId" bson:"reqId"`
+	ResourceType ResourceType           `json:"resourceType" bson:"resourceType"`
+	Profiles     []UpdateGpuCardProfile `json:"profiles" bson:"profiles"`
 }

--- a/internal/definition/v1/gpu/gpu_test.go
+++ b/internal/definition/v1/gpu/gpu_test.go
@@ -1,0 +1,34 @@
+package gpu
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateGpuCardRequestUnmarshal(t *testing.T) {
+	body := `{"resourceType":"sriovVgpu","profiles":[{"id":57,"count":2}]}`
+
+	var req UpdateGpuCardRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &req))
+
+	require.Equal(t, ResourceTypeSriovVgpu, req.ResourceType)
+	require.Len(t, req.Profiles, 1)
+	require.Equal(t, UpdateGpuCardProfile{Id: 57, Count: 2}, req.Profiles[0])
+}
+
+func TestGpuUpdateSentinelsAreDistinct(t *testing.T) {
+	for _, e := range []error{
+		ErrGpuNotFound, ErrUnsupportedType, ErrProfilesNotAllowed,
+		ErrProfileNotFound, ErrExceedProfileCountLimit, ErrExceedVramLimit, ErrGpuInUse,
+	} {
+		require.Error(t, e)
+	}
+
+	wrapped := fmt.Errorf("gpu abc is in use: %w", ErrGpuInUse)
+	require.True(t, errors.Is(wrapped, ErrGpuInUse))
+	require.False(t, errors.Is(wrapped, ErrGpuNotFound))
+}

--- a/internal/definition/v1/nodes/node.go
+++ b/internal/definition/v1/nodes/node.go
@@ -26,6 +26,7 @@ const (
 
 	ReqDeviceCollection = "deviceRequests"
 	ReqOsdCollection    = "osdRequests"
+	ReqGpuCollection    = "gpuRequests"
 )
 
 var (

--- a/internal/definition/v1/nodes/url.go
+++ b/internal/definition/v1/nodes/url.go
@@ -184,6 +184,14 @@ func (n *Node) ListGpuCardsUrl() string {
 	return u.String()
 }
 
+func (n *Node) UpdateGpuCardUrl(gpuId string) string {
+	u := url.URL{}
+	u.Scheme = n.Protocol
+	u.Host = n.Address
+	u.Path = fmt.Sprintf("/api/v1/datacenters/%s/nodes/%s/gpuCards/%s", base.DataCenterName, n.Hostname, gpuId)
+	return u.String()
+}
+
 func (n *Node) GetDeviceUrl(device string) string {
 	u := url.URL{}
 	u.Scheme = n.Protocol

--- a/internal/definition/v1/nodes/url_test.go
+++ b/internal/definition/v1/nodes/url_test.go
@@ -1,0 +1,19 @@
+package nodes
+
+import (
+	"testing"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateGpuCardUrl(t *testing.T) {
+	base.DataCenterName = "dc1"
+
+	n := &Node{Protocol: "https", Address: "10.0.0.5:8443", Hostname: "compute-1"}
+
+	require.Equal(t,
+		"https://10.0.0.5:8443/api/v1/datacenters/dc1/nodes/compute-1/gpuCards/GPU-abc",
+		n.UpdateGpuCardUrl("GPU-abc"),
+	)
+}


### PR DESCRIPTION
## Summary

Adds `PUT /nodes/:nodeName/gpuCards/:gpuId` to change a GPU card's **resource type** (`pgpu` / `sriovVgpu` / `migBackedVgpu`) via `hex_config gpu_resource_set`, with server-side validation and an "updating" status surfaced on the GPU-list endpoint.

Tickets: **886 / 895 / 896**.

## What it does

- **Endpoint:** `PUT /nodes/:nodeName/gpuCards/:gpuId`, body `{ resourceType, profiles?: [{ id: uint32, count }] }`. Synchronous — blocks on `hex_config` and returns `200`.
- **Local/remote split:** control nodes proxy the `PUT` to the target compute node (mirrors the existing `listGpuCards` path).
- **`profiles`** are passed to `hex_config` as a single JSON-string argument; the GPU's available profiles are looked up by **GPU id** via `hex_sdk gpu_vgpu_profile_list <gpuId>`.

## Validation (`validateGpuCardUpdate`)

Inputs: the card as hex reports it, the request, the card's available-profile map, and the device's total VRAM from NVML. The profile map and VRAM are only fetched when the request actually carries profiles for a vGPU type — switching a card to `pgpu` touches neither `hex_sdk gpu_vgpu_profile_list` nor NVML.

Checks run in this order:

1. **Resource type is supported by the card** — `req.resourceType` must appear in the card's `supportTypes`. → `409`
2. **Profiles only on vGPU types** — supplying `profiles` for `pgpu` (or any non-vGPU type) is rejected. → `400`
3. **Card is idle** — hex status is not `inUse` and `allocation.current == 0`. → `409`
4. Non-vGPU requests stop here; everything below is vGPU-only.
5. **No duplicate profile ids** in the request. → `400`
6. **SR-IOV only — profile-count limit:** the *total* number of requested vGPU instances (`Σ` of each profile's `count`) must not exceed the card's `sriovVgpuProfileCountLimit` (when hex reports one). → `409`
7. **Per profile:** `count` must be positive (`400`) and the id must exist in the card's available profiles (`400`). **MIG-backed only:** `count` must not exceed that profile's `vmCountLimit` when hex reports one (`409`).
8. **MIG-backed only — VRAM budget:** `Σ (profile.vramMiB × count)` must not exceed the device's total VRAM as reported by NVML. → `409`

### Why SR-IOV and MIG-backed differ

The two vGPU modes are deliberately asymmetric, because the hardware constrains them differently:

- **SR-IOV** exposes a fixed set of virtual functions. The only bound is *how many vGPU instances in total* the request asks for — `Σ` of the per-profile `count` values vs. `sriovVgpuProfileCountLimit` — since the VFs carve the card up ahead of time. Neither the VRAM total nor a per-profile `vmCountLimit` is checked: SR-IOV profiles do not carry one.
- **MIG-backed** slices the card into GPU instances drawn from a shared memory budget. It is bounded by *total VRAM* (`Σ vramMiB × count` vs. device total) and by each profile's own `vmCountLimit`. The card-level `sriovVgpuProfileCountLimit` does not apply and is **not** checked.

So `vmCountLimit` (step 7) and the VRAM budget (step 8) are MIG-backed-only; `sriovVgpuProfileCountLimit` (step 6) is SR-IOV-only.

Profile ids are resolved against a single map merged from the `sriov` and `migBacked` lists returned by `hex_sdk gpu_vgpu_profile_list`; ids do not collide across the two.

### Status mapping

- **`409`** — unsupported resource type · GPU in use · SR-IOV profile-count limit · MIG-backed per-profile `vmCountLimit` · MIG-backed VRAM budget
- **`400`** — unknown profile id · duplicate profile id · non-positive `count` · profiles supplied for a non-vGPU type · malformed body
- **`404`** — node / GPU not found
- **`500`** — `hex_config` / NVML / node-side (`gpu_vgpu_profile_list`) failure

## Updating status

An "updating" record is written to the `gpuRequests` MongoDB collection and cleared within the same request (via `defer`); `listLocalGpuCards` reflects it as `Status.IsProcessing`.

## Tests

`CGO_ENABLED=1 GOWORK=off go test ./internal/apis/v1/handlers/nodes/ ./internal/cubecos/ ./internal/definition/...` — green; `task vet` clean; `task generateApiDocs` regenerated.

## ⚠️ Submodule dependency

https://github.com/bigstack-oss/cube-cos-openapi/pull/105

Closes https://github.com/bigstack-oss/cubecos/issues/886 https://github.com/bigstack-oss/cubecos/issues/895 https://github.com/bigstack-oss/cubecos/issues/896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
