### PR TITLE
fix(ci): create the GitHub release with the gh CLI, not the missing plugin

### DIFF
--- a/build/cube-cos-api-binary.Jenkinsfile
+++ b/build/cube-cos-api-binary.Jenkinsfile
@@ -107,14 +107,11 @@ pipeline {
                         }
 
                         def commitish = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-                        createGitHubRelease(
-                            credentialId: GITHUB_PAT,
-                            repository: REPO_NAME,
-                            tag: version,
-                            commitish: commitish,
-                            bodyText: "Release ${version}",
-                            name: version
-                        )
+                        withCredentials([string(credentialsId: env.GITHUB_PAT, variable: 'PAT')]) {
+                            sh 'echo $PAT | gh auth login --with-token && ' +
+                                "gh release create ${version} --repo ${env.REPO_NAME} " +
+                                "--target ${commitish} --title '${version}' --notes 'Release ${version}'"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### What type of PR is this?

/kind bug (CI pipeline)

<br/>

### Which issue(s) this PR fixes?

None filed — chronic CI failure, diagnosed from the Jenkins console (develop builds 461–468).

<br/>

### What this PR does?

Replaces the `createGitHubRelease` plugin step in the binary pipeline's release stage with `gh release create`, wired through the same `GITHUB_PAT` string credential the rpm pipeline already uses for `gh release upload`.

Every `develop` build since at least Jul 1 fails in the release stage with `NoSuchMethodError: createGitHubRelease` — the github-release Jenkins plugin providing that step is not installed on our Jenkins, and no build in retained history has passed. `check`/`build`/`test` are green throughout; only this step dies.

Consequences of the breakage: the tag push happens *before* the plugin call, so version tags accumulate with no Release object; the rpm job has no release to attach its asset to; and the cubecos RC image build downloads exactly that release asset — the develop RPM distribution channel has been dead the whole time.

Rather than installing the plugin, this drops the dependency: the sibling rpm pipeline already uses the `gh` CLI, and both agent images install `gh` in their Dockerfiles. The secret is passed via the `withCredentials` env var inside a single-quoted `sh` string (no Groovy interpolation of the secret) — safer than the rpm file's `'echo ' + PAT` concatenation, which can be aligned in a follow-up.

Leftover tags from failed builds (e.g. `v3.1.0-dev-d6b0606`) have no Release; the next green develop build creates a fresh tag+release pair, so no backfill is needed.

<br/>

### Test results (optional)

Jenkinsfile-only change — no API code, docs untouched. The release stage runs only post-merge on `develop`, so the definitive validation is the first develop build after this lands; syntax follows the working pattern in `cube-cos-api-rpm.Jenkinsfile`.