### PR TITLE
fix(events): make keyword search match user intent

### DIFF
--- a/internal/apis/v1/handlers/events/keyword.go
+++ b/internal/apis/v1/handlers/events/keyword.go
@@ -1,67 +1,96 @@
 package events
 
 import (
+	"strings"
+	"unicode"
+
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/events"
-	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/search"
-	"github.com/blevesearch/bleve/v2"
-	log "go-micro.dev/v5/logger"
 )
 
-const (
-	maxSearchResults = 10000
-)
-
+// filteredByKeyword: word-prefix match per keyword term over visible fields
+// + metadata values ("CLU" matches "cluster", never "hacluster"); keeps time order
 func (h *helper) filteredByKeyword(nonFilterEvents []events.Event) []events.Event {
 	if !h.isKeywordRequired() {
 		return nonFilterEvents
 	}
 
-	h.setEventSearchIndex(&nonFilterEvents)
-	result, err := h.searchEvents(nonFilterEvents)
-	if err != nil {
-		log.Errorf("events: failed to search events(%v)", err)
+	terms := strings.FieldsFunc(strings.ToLower(h.keyword), isNonToken)
+	if len(terms) == 0 {
 		return nonFilterEvents
 	}
 
-	eventMap := genEventMap(nonFilterEvents)
+	// an event-id prefix ("CLU", "RUG00003") is the primary search token of
+	// this table: when the keyword names ids, return only those
+	if byId := filteredByIdPrefix(nonFilterEvents, strings.ToLower(h.keyword)); len(byId) > 0 {
+		return byId
+	}
+
 	filtered := []events.Event{}
-	for _, hit := range result.Hits {
-		filtered = append(filtered, eventMap[hit.ID])
+	for _, event := range nonFilterEvents {
+		if matchAllTerms(event, terms) {
+			filtered = append(filtered, event)
+		}
 	}
 
 	return filtered
 }
 
-func (h *helper) setEventSearchIndex(nonFilterEvents *[]events.Event) {
-	for i := range *nonFilterEvents {
-		(*nonFilterEvents)[i].SetSearchIndex()
-	}
-}
-
-func (h *helper) searchEvents(nonFilterEvents []events.Event) (*bleve.SearchResult, error) {
-	searcher, err := search.New()
-	if err != nil {
-		log.Errorf("events: failed to create search index(%v)", err)
-		return nil, err
-	}
-
+func filteredByIdPrefix(nonFilterEvents []events.Event, keyword string) []events.Event {
+	filtered := []events.Event{}
 	for _, event := range nonFilterEvents {
-		err := searcher.Index(event.SearchIndex, event.GenSearchableObject())
-		if err != nil {
-			continue
+		if strings.HasPrefix(strings.ToLower(event.Id), keyword) {
+			filtered = append(filtered, event)
 		}
 	}
 
-	defer searcher.Close()
-	keyword := search.NormalizeKeyword(h.keyword)
-	return searcher.Search(search.WildcardQuery(keyword))
+	return filtered
 }
 
-func genEventMap(nonFilterEvents []events.Event) map[string]events.Event {
-	eventMap := map[string]events.Event{}
-	for _, event := range nonFilterEvents {
-		eventMap[event.SearchIndex] = event
+func isNonToken(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+}
+
+func matchAllTerms(event events.Event, terms []string) bool {
+	tokens := eventTokens(event)
+	for _, term := range terms {
+		if !anyTokenHasPrefix(tokens, term) {
+			return false
+		}
 	}
 
-	return eventMap
+	return true
+}
+
+func eventTokens(event events.Event) []string {
+	fields := []string{
+		event.Id,
+		event.Description,
+		event.Host,
+		event.Category,
+		event.Service,
+		event.Severity,
+		event.Message,
+	}
+	for _, value := range event.Metadata {
+		if s, ok := value.(string); ok {
+			fields = append(fields, s)
+		}
+	}
+
+	tokens := []string{}
+	for _, field := range fields {
+		tokens = append(tokens, strings.FieldsFunc(strings.ToLower(field), isNonToken)...)
+	}
+
+	return tokens
+}
+
+func anyTokenHasPrefix(tokens []string, term string) bool {
+	for _, token := range tokens {
+		if strings.HasPrefix(token, term) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/definition/v1/events/event.go
+++ b/internal/definition/v1/events/event.go
@@ -1,11 +1,8 @@
 package events
 
 import (
-	"maps"
 	"strings"
 
-	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/search"
-	"github.com/google/uuid"
 )
 
 const (
@@ -37,7 +34,6 @@ var (
 )
 
 type Event struct {
-	SearchIndex string         `json:"-"`
 	Type        string         `json:"type"`
 	Severity    string         `json:"severity"`
 	Id          string         `json:"id"`
@@ -134,29 +130,6 @@ func GetSeverityFullNames(severities []string) []string {
 
 func (e *Event) GetSeverityFullName() string {
 	return GetSeverityFullName(e.Severity)
-}
-
-func (e *Event) SetSearchIndex() {
-	e.SearchIndex = uuid.New().String()
-}
-
-// note:
-// in the current search lib(bleve), the algo is not able to detect the string if it include uppercase
-// we've tried a few different init settings, but the result is not as expected as always
-// currenlty, the only way we found is to convert all the string to lower case and inject to searcher
-func (e *Event) GenSearchableObject() Event {
-	return Event{
-		SearchIndex: e.SearchIndex,
-		Type:        search.NormalizeKeyword(e.Type),
-		Id:          search.NormalizeKeyword(e.Id),
-		Severity:    search.NormalizeKeyword(e.Severity),
-		Description: search.NormalizeKeyword(e.Description),
-		Host:        search.NormalizeKeyword(e.Host),
-		Category:    search.NormalizeKeyword(e.Category),
-		Service:     search.NormalizeKeyword(e.Service),
-		Metadata:    maps.Clone(e.Metadata),
-		Time:        e.Time,
-	}
 }
 
 func (e *Event) SetCategory(metaObj map[string]any) {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

<br/>

### Which issue(s) this PR fixes?

Fixes #610

<br/>

### What this PR does?

Keyword search on /events read as completely broken (sky lab report). Three stacked defects:

1. **Relevance order** — results returned in bleve hit order; page 1 mixed today with days-old events. Now keeps influx time-desc order.
2. **Substring-anywhere matching** — the old bleve wildcard ran over space-stripped concatenations of every field *including metadata*, so `CLU` matched `haCLUster` and `category=cluster` metadata: 3839 of 8841 events "matched" ≈ no filter. Replaced with **word-prefix matching** over visible fields + metadata string values (`CLU` matches `CLU00010I` and "cluster", never "hacluster"); multi-term keywords AND together.
3. **Id-first semantics** — when the keyword prefix-matches event ids (`CLU`, `RUG00003`), only those are returned; free text (`evacuation failures`, `sky141`) falls back to word-prefix matching.

Events-only bleve plumbing removed; the shared search package stays for the other handlers.

<br/>

### Test results (optional)

1). api docs unchanged (no surface change)

2). `go build` + `go vet` clean. Verified live on sky (hot-deployed to all 3 nodes): `keyword=CLU` → 2977 all-CLU newest-first (was 3839 mixed SRV/BSP/CLU jumbled); `RUG` → RUG-only; `"evacuation failures"` → 7×RUG00003W; box typing + URL params both fire correctly.