### PR TITLE
build(ci): bump build containers to go 1.26.5

### DIFF
--- a/build/cube-cos-api-jail.Dockerfile
+++ b/build/cube-cos-api-jail.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bookworm
+FROM golang:1.26.5-bookworm
 
 ENV USER=jenkins UID=1000 GID=1000
 

--- a/build/cube-cos-api-rpm.Dockerfile
+++ b/build/cube-cos-api-rpm.Dockerfile
@@ -5,9 +5,9 @@ ENV GOLANG_VERSION=1.24.2
 ENV GOTOOLCHAIN=local
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN rm -rf /usr/local/go
-RUN wget -q --no-check-certificate https://go.dev/dl/go1.24.2.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.24.2.linux-amd64.tar.gz
-RUN rm go1.24.2.linux-amd64.tar.gz
+RUN wget -q --no-check-certificate https://go.dev/dl/go1.26.5.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.26.5.linux-amd64.tar.gz
+RUN rm go1.26.5.linux-amd64.tar.gz
 
 RUN dnf install -y go-task rpmdevtools gh
 RUN dnf install -y make automake gcc gcc-c++ kernel-devel


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup

<br/>

### Which issue(s) this PR fixes?

Unblocks #592 (dependabot go_modules group raises `go.mod` to `go >= 1.26.0`; the build images pin go 1.24.2 with `GOTOOLCHAIN=local`, so `task check` fails at vet).

<br/>

### What this PR does?

Bumps `build/cube-cos-api-jail.Dockerfile` (`golang:1.24.2-bookworm` → `golang:1.26.5-bookworm`) and `build/cube-cos-api-rpm.Dockerfile` (go tarball 1.24.2 → 1.26.5). The `localhost:5000/cube-cos-api-jail` / `-rpm` images on the Jenkins docker host must be rebuilt+pushed after this merges for the change to take effect.

<br/>

### Test results (optional)

1). api docs untouched

2). the real test is #592's branch build going green once the registry image is rebuilt