### PR TITLE
fix(ci): wrap rpm:build in sshagent so the submodule clone can authenticate

### DIFF
--- a/build/cube-cos-api-rpm.Jenkinsfile
+++ b/build/cube-cos-api-rpm.Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         BLDSRV         = 'bldsrv_prod'
 
         GITHUB_PAT     = 'Bigstack-CI-Bot-PAT'
+        GITHUB_SSH_KEY = 'github-SSH-KEY'
         SLACK_CHANNEL  = "#${PROJ_NAME}-ci"
     }
 
@@ -60,7 +61,10 @@ pipeline {
 
                 dir("${env.BLDPTH}") {
                     echo 'Creating the rpm package...'
-                    sh 'go-task rpm:build'
+                    // rpm:build clones the api/cube-cos-openapi submodule over SSH
+                    sshagent([GITHUB_SSH_KEY]) {
+                        sh 'go-task rpm:build'
+                    }
                 }
 
                 dir("${env.BLDPTH}") {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

<br/>

### Which issue(s) this PR fixes?

Fixes #614

<br/>

### What this PR does?

Makes the rpm pipeline able to clone the `api/cube-cos-openapi` submodule.

`rpm:prepareTarball` runs `git submodule update --init` against `git@github.com:bigstack-oss/cube-cos-openapi.git`, which needs an SSH credential inside the build container. `build/cube-cos-api-rpm.Jenkinsfile` had **neither** half of that:

1. no `GITHUB_SSH_KEY` in its `environment` block, and
2. no `sshagent` around the build step,

so the clone failed with `Permission denied (publickey)`. This PR adds both, matching `build/cube-cos-api-binary.Jenkinsfile`, which already declares `GITHUB_SSH_KEY = 'github-SSH-KEY'` and wraps its SSH git operations in `sshagent([GITHUB_SSH_KEY])`.

> Correction vs. the original description of this PR: it previously stated that the rpm pipeline "declares the credential but never loads it". That was wrong — the credential was never declared in this pipeline at all, so the first revision (which only added the `sshagent` wrap) would have failed with `MissingPropertyException: No such property: GITHUB_SSH_KEY`. Both lines are needed.

Note: `cos_api_rpm` tag jobs read the Jenkinsfile from the immutable tag commit, so this applies to tags created after it lands; pre-existing tags still need the environment-side workaround documented in the handbook known-issue (bigstack-handbook#123).

<br/>

### Test results (optional)

1). api docs untouched (CI-only change)

<br/>

2). `ssh-agent`/`ssh-add` verified present in the `cube-cos-api-rpm` image (fedora:35), so the `sshagent` step is usable. The failing clone was reproduced and root-caused on `cos_api_rpm/v3.1.0-dev-861b147` build #2; build #3 passed with the equivalent credential-side workaround, producing and uploading `cube-cos-api-v3.1.0-1.fc35.861b147.x86_64.rpm`.

<br/>

3). Pending: a tag build off this branch to exercise the Jenkinsfile change itself — the branch job (`continuous-integration/jenkins/branch`) does not run the rpm pipeline.
