### PR TITLE
fix(time): emit local timezone for every mislabeled timestamp, drop ISO8601Z (#1166)

### DIFF
--- a/internal/apis/v1/handlers/nodes/ipmi.go
+++ b/internal/apis/v1/handlers/nodes/ipmi.go
@@ -26,12 +26,23 @@ func (h *helper) verifyNodeIpmi() (*ipmi.FRU, error) {
 		return nil, fmt.Errorf("unable to connect with IPMI, please check your IPMI settings")
 	}
 
-	dateTime, err := time.Parse(bstime.FormatBmc, fru.ManufacturingDate)
+	manufacturingDate, err := convertBmcTime(fru.ManufacturingDate)
 	if err == nil {
-		fru.ManufacturingDate = bstime.ISO8601Z(dateTime)
+		fru.ManufacturingDate = manufacturingDate
 	}
 
 	return fru, nil
+}
+
+// FormatBmc carries no zone token, so the BMC wall clock must be parsed as the
+// node's local time — otherwise it is read as UTC and mislabeled.
+func convertBmcTime(rawTime string) (string, error) {
+	t, err := time.ParseInLocation(bstime.FormatBmc, rawTime, bstime.LocalFixedZone)
+	if err != nil {
+		return "", err
+	}
+
+	return bstime.RFC3339Z(t), nil
 }
 
 func (h *helper) checkBoardSerialConsistency(fru *ipmi.FRU) error {

--- a/internal/apis/v1/handlers/nodes/ipmi_test.go
+++ b/internal/apis/v1/handlers/nodes/ipmi_test.go
@@ -1,0 +1,59 @@
+package nodes
+
+import (
+	"testing"
+	ostime "time"
+
+	bstime "github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the process-wide local zone the way runtime.initSystemTime would, and
+// restores it so the offset does not leak between tests.
+func useLocalZone(t *testing.T, offsetSeconds int) {
+	t.Helper()
+
+	origSeconds := bstime.LocalZoneSeconds
+	origZone := bstime.LocalFixedZone
+
+	bstime.LocalZoneSeconds = offsetSeconds
+	bstime.LocalFixedZone = ostime.FixedZone("", offsetSeconds)
+
+	t.Cleanup(func() {
+		bstime.LocalZoneSeconds = origSeconds
+		bstime.LocalFixedZone = origZone
+	})
+}
+
+// The BMC reports a bare wall clock with no zone. It is the node's local time,
+// so the emitted value must carry the node's offset and keep the same digits.
+func TestConvertBmcTimeKeepsTheWallClockAndAddsTheLocalOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60, want: "2025-07-24T15:02:37+08:00"},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60, want: "2025-07-24T15:02:37-05:00"},
+		{name: "at UTC", offsetSeconds: 0, want: "2025-07-24T15:02:37Z"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+
+			got, err := convertBmcTime("Thu Jul 24 15:02:37 2025")
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestConvertBmcTimeRejectsAnUnparseableWallClock(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+
+	_, err := convertBmcTime("Unspecified")
+
+	require.Error(t, err)
+}

--- a/internal/apis/v1/handlers/supportfiles/createdat_test.go
+++ b/internal/apis/v1/handlers/supportfiles/createdat_test.go
@@ -1,0 +1,104 @@
+package supportfiles
+
+import (
+	nethttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	ostime "time"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/support"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the process-wide local zone the way runtime.initSystemTime would, and
+// restores it so the offset does not leak between tests.
+func useLocalZone(t *testing.T, offsetSeconds int) {
+	t.Helper()
+
+	origSeconds := time.LocalZoneSeconds
+	origZone := time.LocalFixedZone
+
+	time.LocalZoneSeconds = offsetSeconds
+	time.LocalFixedZone = ostime.FixedZone("", offsetSeconds)
+
+	t.Cleanup(func() {
+		time.LocalZoneSeconds = origSeconds
+		time.LocalFixedZone = origZone
+	})
+}
+
+// Asserts the value is RFC3339 carrying the node's offset — not a wall clock
+// mislabeled with a fixed "+00:00" — and stamped at roughly now.
+func requireStampedInLocalZone(t *testing.T, createdAt string, offsetSeconds int) {
+	t.Helper()
+
+	parsed, err := ostime.Parse(time.FormatRFC3339, createdAt)
+	require.NoError(t, err, "createdAt must be RFC3339")
+
+	_, offset := parsed.Zone()
+	require.Equal(t, offsetSeconds, offset)
+	require.WithinDuration(t, ostime.Now(), parsed, ostime.Minute)
+}
+
+func newTestContext(t *testing.T, body string) *gin.Context {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(nethttp.MethodPost, "/supportFiles", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	return c
+}
+
+func TestParseHostsStampsCreatedAtWithTheNodeLocalOffset(t *testing.T) {
+	offsets := map[string]int{
+		"east of UTC": 8 * 60 * 60,
+		"west of UTC": -5 * 60 * 60,
+		"at UTC":      0,
+	}
+
+	for name, offsetSeconds := range offsets {
+		t.Run(name, func(t *testing.T) {
+			useLocalZone(t, offsetSeconds)
+
+			h := &helper{c: newTestContext(t, `{"hosts":["node-1"],"description":"probe"}`)}
+
+			require.NoError(t, h.parseHosts())
+			require.Equal(t, []string{"node-1"}, h.fileReq.Hosts)
+			requireStampedInLocalZone(t, h.fileReq.CreatedAt, offsetSeconds)
+		})
+	}
+}
+
+// A createdAt supplied by the delegating control node is authoritative — every
+// node in the set must file under one group, so it is not re-stamped locally.
+func TestSetSupportFileReqKeepsACallerSuppliedCreatedAt(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+
+	const delegated = "2025-07-24T15:02:37+08:00"
+	h := &helper{fileReq: support.FileRequest{CreatedAt: delegated}}
+
+	h.setSupportFileReq()
+
+	require.Equal(t, delegated, h.fileReq.CreatedAt)
+	require.Equal(t, delegated, h.file.Status.CreatedAt)
+	require.Contains(t, h.file.Group, delegated)
+}
+
+func TestSetSupportFileReqStampsAMissingCreatedAtWithTheNodeLocalOffset(t *testing.T) {
+	useLocalZone(t, -5*60*60)
+
+	h := &helper{fileReq: support.FileRequest{Description: "probe"}}
+
+	h.setSupportFileReq()
+
+	requireStampedInLocalZone(t, h.fileReq.CreatedAt, -5*60*60)
+	require.Equal(t, h.fileReq.CreatedAt, h.file.Status.CreatedAt)
+	require.Equal(t, status.Creating, h.file.Status.Current)
+}

--- a/internal/apis/v1/handlers/supportfiles/delegate.go
+++ b/internal/apis/v1/handlers/supportfiles/delegate.go
@@ -54,7 +54,7 @@ func (h *helper) delegateSupportFileReq() {
 
 func (h *helper) setSupportFileReq() {
 	if h.fileReq.CreatedAt == "" {
-		h.fileReq.CreatedAt = time.ISO8601Z(ostime.Now())
+		h.fileReq.CreatedAt = time.LocalRFC3339(ostime.Now())
 	}
 
 	h.file = support.File{

--- a/internal/apis/v1/handlers/supportfiles/parse.go
+++ b/internal/apis/v1/handlers/supportfiles/parse.go
@@ -137,7 +137,7 @@ func (h *helper) parseHosts() error {
 		return err
 	}
 
-	h.fileReq.CreatedAt = time.ISO8601Z(ostime.Now())
+	h.fileReq.CreatedAt = time.LocalRFC3339(ostime.Now())
 	return nil
 }
 

--- a/internal/apis/v1/handlers/triggers/resp.go
+++ b/internal/apis/v1/handlers/triggers/resp.go
@@ -10,6 +10,9 @@ import (
 	"github.com/shirou/gopsutil/v4/host"
 )
 
+// Test seam.
+var bootTime = host.BootTime
+
 var (
 	builtInMap = map[string]triggerResp{
 		"admin-notify": {
@@ -119,14 +122,14 @@ func (t *triggerResp) SetOk() {
 		IsProcessing: false,
 	}
 
-	bootDuration, err := host.BootTime()
+	bootDuration, err := bootTime()
 	if err != nil {
-		t.Status.UpdatedAt = time.TimeISO8601Z(ostime.Now())
+		t.Status.UpdatedAt = time.LocalRFC3339(ostime.Now())
 		return
 	}
 
-	bootTime := ostime.Unix(int64(bootDuration), 0)
-	t.Status.UpdatedAt = time.TimeISO8601Z(bootTime)
+	bootedAt := ostime.Unix(int64(bootDuration), 0)
+	t.Status.UpdatedAt = time.LocalRFC3339(bootedAt)
 }
 
 func (t *triggerResp) HasEmails() bool {

--- a/internal/apis/v1/handlers/triggers/resp_test.go
+++ b/internal/apis/v1/handlers/triggers/resp_test.go
@@ -1,0 +1,81 @@
+package triggers
+
+import (
+	"errors"
+	"testing"
+	ostime "time"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
+	"github.com/stretchr/testify/require"
+)
+
+// 2025-07-24T07:02:37Z — 15:02:37 in +08:00, 02:02:37 in -05:00.
+const testBootEpoch = uint64(1753340557)
+
+// Pins the process-wide local zone the way runtime.initSystemTime would, and
+// restores it so the offset does not leak between tests.
+func useLocalZone(t *testing.T, offsetSeconds int) {
+	t.Helper()
+
+	origSeconds := time.LocalZoneSeconds
+	origZone := time.LocalFixedZone
+
+	time.LocalZoneSeconds = offsetSeconds
+	time.LocalFixedZone = ostime.FixedZone("", offsetSeconds)
+
+	t.Cleanup(func() {
+		time.LocalZoneSeconds = origSeconds
+		time.LocalFixedZone = origZone
+	})
+}
+
+// Restores the bootTime seam so stubs do not leak between tests.
+func stubBootTime(t *testing.T, fn func() (uint64, error)) {
+	t.Helper()
+
+	orig := bootTime
+	bootTime = fn
+
+	t.Cleanup(func() { bootTime = orig })
+}
+
+func TestSetOkStampsUpdatedAtWithTheNodeLocalOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60, want: "2025-07-24T15:02:37+08:00"},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60, want: "2025-07-24T02:02:37-05:00"},
+		{name: "at UTC", offsetSeconds: 0, want: "2025-07-24T07:02:37Z"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubBootTime(t, func() (uint64, error) { return testBootEpoch, nil })
+
+			resp := &triggerResp{}
+			resp.SetOk()
+
+			require.Equal(t, status.Ok, resp.Status.Current)
+			require.Equal(t, test.want, resp.Status.UpdatedAt)
+		})
+	}
+}
+
+func TestSetOkFallsBackToNowInTheNodeLocalOffset(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubBootTime(t, func() (uint64, error) { return 0, errors.New("boot time unavailable") })
+
+	resp := &triggerResp{}
+	resp.SetOk()
+
+	parsed, err := ostime.Parse(time.FormatRFC3339, resp.Status.UpdatedAt)
+	require.NoError(t, err)
+
+	_, offset := parsed.Zone()
+	require.Equal(t, 8*60*60, offset)
+	require.WithinDuration(t, ostime.Now(), parsed, ostime.Minute)
+}

--- a/internal/cubecos/datacenter.go
+++ b/internal/cubecos/datacenter.go
@@ -138,19 +138,22 @@ func GetFixpackVersion() (string, error) {
 	return version, nil
 }
 
+// Test seam.
+var getLastInstalledFixpack = GetDataCenterLastInstalledFixpack
+
 func GetFixpackUpdatedAt() (string, error) {
-	fixpack, err := GetDataCenterLastInstalledFixpack()
+	fixpack, err := getLastInstalledFixpack()
 	if err != nil {
 		return "", err
 	}
 
 	updatedAt := fixpack[0]
-	t, err := ostime.Parse(time.FormatFixpack, updatedAt)
+	t, err := ostime.ParseInLocation(time.FormatFixpack, updatedAt, time.LocalFixedZone)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse fixpack updatedAt(%s %v)", updatedAt, err)
 	}
 
-	return time.LocalRFC3339(t), nil
+	return time.RFC3339Z(t), nil
 }
 
 func GetDataCenterLastInstalledFixpack() ([]string, error) {

--- a/internal/cubecos/datacenter_test.go
+++ b/internal/cubecos/datacenter_test.go
@@ -1,0 +1,104 @@
+package cubecos
+
+import (
+	"errors"
+	"testing"
+	ostime "time"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the process-wide local zone the way runtime.initSystemTime would, and
+// restores it so the offset does not leak between tests.
+func useLocalZone(t *testing.T, offsetSeconds int) {
+	t.Helper()
+
+	origSeconds := time.LocalZoneSeconds
+	origZone := time.LocalFixedZone
+
+	time.LocalZoneSeconds = offsetSeconds
+	time.LocalFixedZone = ostime.FixedZone("", offsetSeconds)
+
+	t.Cleanup(func() {
+		time.LocalZoneSeconds = origSeconds
+		time.LocalFixedZone = origZone
+	})
+}
+
+// Restores the fixpack-history seam so stubs do not leak between tests.
+func stubLastInstalledFixpack(t *testing.T, fn func() ([]string, error)) {
+	t.Helper()
+
+	orig := getLastInstalledFixpack
+	getLastInstalledFixpack = fn
+
+	t.Cleanup(func() { getLastInstalledFixpack = orig })
+}
+
+// hex_config fixpack_get_history emits a bare wall clock with no zone. It is
+// the node's local time, so the emitted value keeps those digits and gains the
+// node's offset — it must not be re-shifted as if it had been UTC.
+func TestGetFixpackUpdatedAtKeepsTheWallClockAndAddsTheLocalOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60, want: "2025-07-24T15:02:37+08:00"},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60, want: "2025-07-24T15:02:37-05:00"},
+		{name: "at UTC", offsetSeconds: 0, want: "2025-07-24T15:02:37Z"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubLastInstalledFixpack(t, func() ([]string, error) {
+				return []string{"24 Jul 2025 15:02:37", "3.2.0", "fixpack-name", "", "", "", ""}, nil
+			})
+
+			got, err := GetFixpackUpdatedAt()
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+// The fixpack list endpoint formats the same hex_config value via
+// convertRawTime. Both endpoints report the same fixpack, so they must agree.
+func TestGetFixpackUpdatedAtAgreesWithTheFixpackListPath(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+
+	const rawUpdatedAt = "24 Jul 2025 15:02:37"
+	stubLastInstalledFixpack(t, func() ([]string, error) {
+		return []string{rawUpdatedAt, "3.2.0", "fixpack-name", "", "", "", ""}, nil
+	})
+
+	got, err := GetFixpackUpdatedAt()
+
+	require.NoError(t, err)
+	require.Equal(t, convertRawTime(time.FormatFixpack, rawUpdatedAt), got)
+}
+
+func TestGetFixpackUpdatedAtRejectsAnUnparseableWallClock(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubLastInstalledFixpack(t, func() ([]string, error) {
+		return []string{"not a timestamp", "3.2.0", "fixpack-name", "", "", "", ""}, nil
+	})
+
+	_, err := GetFixpackUpdatedAt()
+
+	require.ErrorContains(t, err, "failed to parse fixpack updatedAt")
+}
+
+func TestGetFixpackUpdatedAtPropagatesTheHistoryLookupError(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubLastInstalledFixpack(t, func() ([]string, error) {
+		return nil, errors.New("hex_config unavailable")
+	})
+
+	_, err := GetFixpackUpdatedAt()
+
+	require.ErrorContains(t, err, "hex_config unavailable")
+}

--- a/internal/definition/v1/time/time.go
+++ b/internal/definition/v1/time/time.go
@@ -8,8 +8,6 @@ import (
 
 const (
 	FormatBmc          = "Mon Jan 2 15:04:05 2006"
-	FormatISO8601      = "2006-01-02T15:04:05"
-	FormatISO8601Z     = "2006-01-02T15:04:05+00:00"
 	FormatRFC3339      = time.RFC3339
 	FormatRFC3339Z     = "2006-01-02T15:04:05Z07:00"
 	FormatRFC3339ZUTC  = "2006-01-02T15:04:05Z"
@@ -18,6 +16,9 @@ const (
 	FormatFirmwarePkg  = "20060102-1504"
 	FormatFixpack      = "02 Jan 2006 15:04:05"
 )
+
+// Test seam.
+var bootTime = host.BootTime
 
 var (
 	Day = 24 * time.Hour
@@ -85,20 +86,12 @@ func LocalRFC3339AddDuration(t time.Time, duration time.Duration) string {
 	return adjusted.In(LocalFixedZone).Format(time.RFC3339)
 }
 
-func ISO8601Z(t time.Time) string {
-	return t.Format(FormatISO8601Z)
-}
-
 func Boot() string {
-	bootDuration, err := host.BootTime()
+	bootDuration, err := bootTime()
 	if err != nil {
-		return ISO8601Z(time.Now())
+		return LocalRFC3339(time.Now())
 	}
 
-	bootTime := time.Unix(int64(bootDuration), 0)
-	return ISO8601Z(bootTime)
-}
-
-func TimeISO8601Z(t time.Time) string {
-	return t.Format(FormatISO8601Z)
+	bootedAt := time.Unix(int64(bootDuration), 0)
+	return LocalRFC3339(bootedAt)
 }

--- a/internal/definition/v1/time/time_test.go
+++ b/internal/definition/v1/time/time_test.go
@@ -1,0 +1,72 @@
+package time
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// 2025-07-24T07:02:37Z — 15:02:37 in +08:00, 02:02:37 in -05:00.
+const testBootEpoch = uint64(1753340557)
+
+// Pins the process-wide local zone the way runtime.initSystemTime would, and
+// restores it so the offset does not leak between tests.
+func useLocalZone(t *testing.T, offsetSeconds int) {
+	t.Helper()
+
+	origSeconds := LocalZoneSeconds
+	origZone := LocalFixedZone
+
+	LocalZoneSeconds = offsetSeconds
+	LocalFixedZone = time.FixedZone("", offsetSeconds)
+
+	t.Cleanup(func() {
+		LocalZoneSeconds = origSeconds
+		LocalFixedZone = origZone
+	})
+}
+
+// Restores the bootTime seam so stubs do not leak between tests.
+func stubBootTime(t *testing.T, fn func() (uint64, error)) {
+	t.Helper()
+
+	orig := bootTime
+	bootTime = fn
+
+	t.Cleanup(func() { bootTime = orig })
+}
+
+func TestBootReportsTheBootInstantInTheNodeLocalOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60, want: "2025-07-24T15:02:37+08:00"},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60, want: "2025-07-24T02:02:37-05:00"},
+		{name: "at UTC", offsetSeconds: 0, want: "2025-07-24T07:02:37Z"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubBootTime(t, func() (uint64, error) { return testBootEpoch, nil })
+
+			require.Equal(t, test.want, Boot())
+		})
+	}
+}
+
+func TestBootFallsBackToNowInTheNodeLocalOffset(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubBootTime(t, func() (uint64, error) { return 0, errors.New("boot time unavailable") })
+
+	parsed, err := time.Parse(FormatRFC3339, Boot())
+	require.NoError(t, err)
+
+	_, offset := parsed.Zone()
+	require.Equal(t, 8*60*60, offset)
+	require.WithinDuration(t, time.Now(), parsed, time.Minute)
+}

--- a/internal/definition/v1/triggers/api.go
+++ b/internal/definition/v1/triggers/api.go
@@ -6,7 +6,6 @@ const (
 	Collection       = "triggers"
 	ReqCollection    = "requests"
 	ResponsePolicyV2 = "/etc/policies/alert_resp/alert_resp2_0.yml"
-	ISO8601Z         = "2006-01-02T15:04:05+00:00"
 )
 
 var (


### PR DESCRIPTION
### What type of PR is this?

`bug` — timezone correctness fix

<br/>

### Which issue(s) this PR fixes?

Fixes bigstack-oss/cubecos#1166

Handbook write-up: bigstack-oss/bigstack-handbook#154 — `kb/cubecos/architecture/api-response-timestamp-timezone.md`, the timestamp timezone contract plus an audit of every timestamp path.

<br/>

### What this PR does?

Every timestamp cube-cos-api returns must carry the node's local UTC offset — the node's timezone **is** the datacenter's timezone. Five response fields did not. All are fixed here, and the helper that caused most of them is removed so the mistake cannot recur.

**The two root causes**

1. **Double shift.** A zone-less CLI layout (`FormatFixpack`, `FormatBmc`) parsed with `time.Parse` is read as UTC; `LocalRFC3339` then applies `.In(LocalFixedZone)` on top, moving the clock by the node offset *and* labeling it local. Wrong digits, wrong instant.
2. **Fake zone label.** `FormatISO8601Z = "2006-01-02T15:04:05+00:00"`. In a Go layout `+00:00` is a literal, not a zone token, so `ISO8601Z` emitted local wall-clock digits asserted to be UTC — off by the whole node offset for any client that parses it.

**Fields fixed**

| Field | Was | Now |
|---|---|---|
| `GET /datacenters/:DataCenter` → `fixpack.updatedAt` | double shift | `ParseInLocation` + `RFC3339Z` |
| Support file `createdAt` (2 call sites) | fake `+00:00` | `LocalRFC3339` |
| FRU `manufacturingDate` | both causes at once | `convertBmcTime` → `ParseInLocation` + `RFC3339Z` |
| Trigger `status.updatedAt` (both branches) | fake `+00:00` | `LocalRFC3339` |
| Tunings `UpdatedAt` (via `time.Boot()`) | fake `+00:00` | `LocalRFC3339` |

**Cleanup**

With `Boot()` converted, nothing reached the broken helpers, so they are gone: `FormatISO8601Z`, `ISO8601Z`, `TimeISO8601Z`, a second unreferenced copy of the same literal in the triggers package, and the unused `FormatISO8601`. No format constant left in the package silently mislabels a zone.

**Checked, no change needed**

- `GetActiveFirmwaretUpdatedAt` (`time.Unix` + `LocalRFC3339`), the firmware list and fixpack list (`convertRawTime`), and the license dates (inlined `LocalRFC3339`) already emit correct local time.

**Out of scope — found by widening the audit afterwards**

The audit behind this PR followed `ISO8601Z` and the zone-less CLI layouts. Grepping *every* emit helper in the `time` package for callers found two more things, both deliberately left out of this PR:

- **bigstack-oss/cubecos#1182** — the Cinder storage paths. `GET /integrations/storages/:name` never converts the timezone at all (returns raw OpenStack UTC), while the list endpoint returns the same storage in local offset; and the list's empty-value fallback fills in `NowRFC3339()`, which both emits `Z` and fabricates request time so the value changes on every `GET`. Left out because the fix changes behaviour, not just a format — a drive-by zone swap here would hide the fabrication while making the path look audited.
- **bigstack-oss/cubecos#1183** — `LocalFixedZone` is a `FixedZone` snapshot taken at startup, so it goes stale across a DST transition until the process restarts, and `NowLocal()` reaches the offset through Go's DST-aware runtime zone instead. No current deployment is affected (no CST/+08:00 region observes DST); filed as the blocker to clear before any deployment in a DST region. Left out because it is a design decision touching every timestamp path.

So this PR closes #1166's two bug classes and removes the helper behind them. It does not make every timestamp in the codebase contract-clean — #1182 is the remaining live gap.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

No API doc change — response field types and paths are unchanged. Only the timezone offset inside existing `updatedAt` / `createdAt` / `manufacturingDate` strings differs.

<br/>

2). make sure the api works properly

Tests added for every fixed path — previously these packages had none. Each is tabled over **+08:00, -05:00 and UTC**, driven through stubbed seams rather than `hex_config`, IPMI, or a live request.

Both bug classes are **invisible at offset 0** — every UTC case passes even with the fix reverted — so single-zone tests would not have caught either. Each test was confirmed to fail before the fix was restored:

| Case | Expected | Actual with bug |
|---|---|---|
| fixpack @ +08:00 | `2025-07-24T15:02:37+08:00` | `2025-07-24T23:02:37+08:00` |
| fixpack @ −05:00 | `2025-07-24T15:02:37-05:00` | `2025-07-24T10:02:37-05:00` |
| support file / trigger / boot offset | `28800` | `0` |

- `go vet ./...` clean
- `go test -count=1 ./...` passes across all 9 packages
- Squashed to a single commit, rebased onto the current `develop` tip, and vet/test re-run on that tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)


