### PR TITLE
fix(taskfile): stop deploy tasks from overwriting remote cube-cos-api.yaml

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -65,13 +65,11 @@ tasks:
       - task: buildLocalBinary
       - task: initRemoteCosDevEnv
       - task: moveLocalBinaryToRemoteCos
-      - task: moveLocalConfigToRemoteCos
       - task: activateSystemdService
   deployRemoteE2EApi:
     cmds:
       - task: buildLocalBinary
       - task: moveLocalBinaryToRemoteE2E
-      - task: moveLocalConfigToRemoteE2E
       - task: restartRemoteE2ESystemdService
   deployRemoteDevMongo:
     cmds:


### PR DESCRIPTION
### What type of PR is this?

fix — `Taskfile.yaml` only, no product code.

<br/>

### Which issue(s) this PR fixes?

None.

<br/>

### What this PR does?

Removes the config-copy step from both deploy chains:

- `deployRemoteDevApi` no longer runs `moveLocalConfigToRemoteCos`
- `deployRemoteE2EApi` no longer runs `moveLocalConfigToRemoteE2E`

Both tasks `scp` `configs/cube-cos-api.yaml.template` over
`/etc/cube/api/cube-cos-api.yaml` on the target node, which wipes the MongoDB
password already provisioned there — every deploy broke the DB connection until
the password was re-filled by hand.

Both tasks are kept and can still be triggered manually
(`task moveLocalConfigToRemoteCos` / `task moveLocalConfigToRemoteE2E`).

<br/>

### Test results (optional)

1). api docs — N/A, no API surface changed.

2). Deployed to a remote dev COS and E2E node: binary updates, service
restarts, `cube-cos-api.yaml` keeps its MongoDB password, API reconnects
with no manual repair.
