### PR TITLE
fix(fixpacks): stop reading a fixpack from rewriting it (#1188)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -40,6 +40,10 @@ tasks:
   test:
     cmds:
       - CGO_ENABLED=1 GOWORK=off go test -v ./...
+  testFixpackMount:
+    desc: Regression tests for the fixpack mount path; needs root and a loop device, so it runs in a privileged container
+    cmds:
+      - ./scripts/test-fixpack-mount.sh
   buildLocalBinary:
     deps:
       - generateApiDocs

--- a/internal/cubecos/fixpacks.go
+++ b/internal/cubecos/fixpacks.go
@@ -717,13 +717,8 @@ func parseFixpackInfo(file string) ([]byte, error) {
 	}
 
 	defer unmountTmpDir(tmpDir)
-	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
-	defer cancel()
-
-	out, err := exec.CommandContext(ctx, "mount", file, tmpDir).CombinedOutput()
+	err = mountFixpackReadOnly(file, tmpDir)
 	if err != nil {
-		err := fmt.Errorf("failed to mount fixpack %s(%v %s)", file, err, string(out))
-		log.Errorf("fixpack: %v", err)
 		return nil, err
 	}
 
@@ -736,6 +731,41 @@ func parseFixpackInfo(file string) ([]byte, error) {
 	}
 
 	return bytes, nil
+}
+
+// mountFixpackReadOnly mounts a fixpack image without writing to it. A plain
+// read-write mount mutates the image's superblock (mount count, last write time),
+// which changes the file's md5 on every read. noload skips journal replay, so it
+// reads pre-recovery metadata -- correct for fixpack.info, which is fixed at
+// build time, but a degraded read. Try a proper ro mount first and fall back
+// only when the journal is dirty, which a read-only loop device cannot replay.
+func mountFixpackReadOnly(file string, tmpDir string) error {
+	var lastErr error
+	for _, opts := range []string{
+		"ro,nosuid,nodev,noexec",
+		"ro,noload,nosuid,nodev,noexec",
+	} {
+		out, err := runFixpackMount(file, tmpDir, opts)
+		if err == nil {
+			return nil
+		}
+
+		// An earlier option set failing is expected -- a dirty ext4 rejects a
+		// plain ro mount -- so only the exhausted loop is an error.
+		lastErr = fmt.Errorf("failed to mount fixpack %s with -o %s(%v %s)", file, opts, err, string(out))
+		log.Warnf("fixpack: %v", lastErr)
+	}
+
+	log.Errorf("fixpack: %v", lastErr)
+
+	return lastErr
+}
+
+func runFixpackMount(file string, tmpDir string, opts string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
+	defer cancel()
+
+	return exec.CommandContext(ctx, "mount", "-o", opts, file, tmpDir).CombinedOutput()
 }
 
 func unmountTmpDir(tmpDir string) {

--- a/internal/cubecos/fixpacks_mount_test.go
+++ b/internal/cubecos/fixpacks_mount_test.go
@@ -1,0 +1,189 @@
+//go:build linux && privileged
+
+// Regression tests for parseFixpackInfo, which mounts a fixpack image to read
+// fixpack.info out of it.
+//
+// A plain `mount <file> <dir>` is a read-write mount. On a writable filesystem
+// image it rewrites the superblock (mount count, last write time), so reading
+// the metadata used to change the artifact's md5 on every single call. See
+// mountFixpackReadOnly.
+//
+// These tests need root and a free loop device, so they sit behind the
+// `privileged` build tag and never run in `task test`. Run them with:
+//
+//	task testFixpackMount
+package cubecos
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testFixpackInfo = "FIXPACK_ID=\"3.2.0\"\n" +
+	"FIXPACK_NAME=\"regression-fixture\"\n" +
+	"ROLLBACK=\"yes\"\n" +
+	"REBOOT_REQUIRED=\"control compute\"\n"
+
+// ext4 and ext4Dirty are the shapes a real fixpack takes: hex's makehotfix and
+// makefixpack both build the image with `CreateFsImage ext4`, and
+// hex_fixpack_install mounts it with an explicit `-t ext4`. ext4Dirty is the one
+// that a plain `-o ro` refuses outright, because a read-only loop device cannot
+// replay a journal -- an interrupted mount by the old read-write code is enough
+// to leave a real fixpack in that state. squashfs and ext2 are defensive cover
+// in case the build ever changes format; nothing ships them today.
+var fixpackImageKinds = []string{"squashfs", "ext2", "ext4", "ext4Dirty"}
+
+func run(t *testing.T, name string, args ...string) {
+	t.Helper()
+
+	out, err := exec.Command(name, args...).CombinedOutput()
+	require.NoErrorf(t, err, "%s %v failed: %s", name, args, string(out))
+}
+
+func requireTools(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		_, err := exec.LookPath(name)
+		if err != nil {
+			t.Skipf("%s is not installed; run this suite via `task testFixpackMount`", name)
+		}
+	}
+}
+
+// Builds an artifact shaped like a real fixpack: a filesystem image with
+// fixpack.info at its root. Returns the image path.
+func buildFixpackImage(t *testing.T, kind string) string {
+	t.Helper()
+	requireTools(t, "mount", "umount")
+
+	dir := t.TempDir()
+	img := filepath.Join(dir, "fixture.fixpack")
+
+	if kind == "squashfs" {
+		requireTools(t, "mksquashfs")
+
+		src := filepath.Join(dir, "src")
+		require.NoError(t, os.MkdirAll(src, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "fixpack.info"), []byte(testFixpackInfo), 0644))
+		run(t, "mksquashfs", src, img, "-quiet", "-no-progress")
+
+		return img
+	}
+
+	mkfs := "mkfs.ext4"
+	if kind == "ext2" {
+		mkfs = "mkfs.ext2"
+	}
+	requireTools(t, mkfs)
+
+	run(t, "dd", "if=/dev/zero", "of="+img, "bs=1M", "count=16", "status=none")
+	run(t, mkfs, "-q", "-F", img)
+
+	mnt := filepath.Join(dir, "mnt")
+	require.NoError(t, os.MkdirAll(mnt, 0755))
+	run(t, "mount", img, mnt)
+	require.NoError(t, os.WriteFile(filepath.Join(mnt, "fixpack.info"), []byte(testFixpackInfo), 0644))
+	run(t, "umount", mnt)
+	run(t, "sync")
+
+	if kind == "ext4Dirty" {
+		requireTools(t, "debugfs")
+
+		// Mark the journal as needing recovery, the state an interrupted mount
+		// leaves behind. A read-only mount cannot replay it.
+		run(t, "debugfs", "-w", "-R", "ssv state 0", img)
+		run(t, "debugfs", "-w", "-R", "feature needs_recovery", img)
+	}
+
+	return img
+}
+
+func md5OfFile(t *testing.T, path string) string {
+	t.Helper()
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	h := md5.New()
+	_, err = io.Copy(h, f)
+	require.NoError(t, err)
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// The bug: reading the metadata rewrote the artifact. Mounting must leave the
+// file byte-for-byte identical, whatever the image format.
+func TestParseFixpackInfoLeavesTheImageUntouched(t *testing.T) {
+	for _, kind := range fixpackImageKinds {
+		t.Run(kind, func(t *testing.T) {
+			img := buildFixpackImage(t, kind)
+			before := md5OfFile(t, img)
+
+			info, err := parseFixpackInfo(img)
+
+			require.NoError(t, err)
+			require.Contains(t, string(info), `FIXPACK_ID="3.2.0"`)
+			require.Equal(t, before, md5OfFile(t, img), "mounting the fixpack rewrote the artifact")
+		})
+	}
+}
+
+// The reported symptom, stated directly: the md5 changed on every read. The
+// list endpoints call this once per .fixpack in /var/fixpack, so a single
+// request used to churn every artifact on the node.
+func TestParseFixpackInfoKeepsTheSameMd5AcrossRepeatedReads(t *testing.T) {
+	img := buildFixpackImage(t, "ext4")
+	want := md5OfFile(t, img)
+
+	for range 5 {
+		_, err := parseFixpackInfo(img)
+
+		require.NoError(t, err)
+		require.Equal(t, want, md5OfFile(t, img))
+	}
+}
+
+// Pins the noload fallback. Without it, `-o ro` fails on this image with
+// "cannot mount /dev/loop0 read-only" and the fixpack becomes unreadable --
+// which the old read-write code could itself cause by being interrupted.
+func TestParseFixpackInfoStillReadsAnExt4ImageWithADirtyJournal(t *testing.T) {
+	img := buildFixpackImage(t, "ext4Dirty")
+
+	info, err := parseFixpackInfo(img)
+
+	require.NoError(t, err)
+	require.Contains(t, string(info), `FIXPACK_ID="3.2.0"`)
+}
+
+// The parsing on top of the mount still works, so the read-only options did not
+// cost us access to any part of the image.
+func TestGetFixpackInfoParsesAReadOnlyMountedImage(t *testing.T) {
+	img := buildFixpackImage(t, "ext4")
+
+	raw, err := GetFixpackInfo(img)
+
+	require.NoError(t, err)
+	require.Equal(t, "3.2.0", raw.Id)
+	require.Equal(t, "regression-fixture", raw.Name)
+	require.True(t, raw.Rollbackable)
+	require.Contains(t, raw.RebootRequired, "control")
+}
+
+// A non-image file must fail, not hang and not leave a mount behind.
+func TestParseFixpackInfoRejectsAFileThatIsNotAFilesystemImage(t *testing.T) {
+	img := filepath.Join(t.TempDir(), "garbage.fixpack")
+	require.NoError(t, os.WriteFile(img, []byte("not a filesystem"), 0644))
+
+	_, err := parseFixpackInfo(img)
+
+	require.ErrorContains(t, err, "failed to mount fixpack")
+}

--- a/scripts/test-fixpack-mount.sh
+++ b/scripts/test-fixpack-mount.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Runs the fixpack mount regression suite (internal/cubecos/fixpacks_mount_test.go).
+#
+# Those tests mount real filesystem images, so they need root and a free loop
+# device. They are behind the `privileged` build tag so `task test` never picks
+# them up. This script supplies the environment they need: natively when already
+# root on Linux, otherwise inside a privileged container.
+#
+# Usage: task testFixpackMount   (or ./scripts/test-fixpack-mount.sh)
+
+set -euo pipefail
+
+readonly repoRoot="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly goImage="golang:1.26-alpine"
+readonly pkg="./internal/cubecos/"
+readonly tags="privileged"
+
+# e2fsprogs-extra carries debugfs, used to build the dirty-journal fixture.
+readonly fsTools="e2fsprogs e2fsprogs-extra squashfs-tools util-linux"
+
+runNatively() {
+    echo "==> running natively as root on linux"
+    cd "$repoRoot"
+    CGO_ENABLED=1 GOWORK=off go test -tags="$tags" -count=1 -v "$pkg"
+}
+
+runInContainer() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "error: docker is required to run these tests off a Linux root shell" >&2
+        exit 1
+    fi
+
+    echo "==> running in a privileged $goImage container"
+    docker run --rm -i --privileged \
+        -v "$repoRoot:/src" \
+        -v cube-cos-api-gomodcache:/go/pkg/mod \
+        -w /src \
+        -e GOWORK=off \
+        -e CGO_ENABLED=1 \
+        -e GOFLAGS=-buildvcs=false \
+        "$goImage" \
+        sh -c "apk add --no-cache --quiet $fsTools gcc musl-dev >/dev/null && \
+               go test -tags=$tags -count=1 -v $pkg"
+}
+
+if [[ "$(uname -s)" == "Linux" && "$(id -u)" -eq 0 ]]; then
+    runNatively
+else
+    runInContainer
+fi


### PR DESCRIPTION
### What type of PR is this?

Bug fix (data integrity) + test coverage.

<br/>

### Which issue(s) this PR fixes?

Fixes bigstack-oss/cubecos#1188 — *[Bug]: Running fixpack from the Web UI changes the fixpack file's MD5*.

| Path | Reads fixpack metadata? | `md5sum -c v3.1.0-002.fixpack.md5` |
|---|---|---|
| SCP into `/var/fixpack` | No | passes |
| Web UI upload → list / inspect | Yes (`GetFixpackInfo`) | **fails** |

Every inspection mounted the image read-write, and the kernel rewrote its superblock.

<details>
<summary><b>Handbook PRs</b> (also in the issue's DoD)</summary>

<br/>

| PR | Status | Content | Why separate |
|---|---|---|---|
| [bigstack-handbook#179](https://github.com/bigstack-oss/bigstack-handbook/pull/179) | **merged 2026-08-01** | P1 known-issue: symptom, root cause, operator workaround, mount-option ordering | Left `status: open` on purpose until this PR ships |
| [bigstack-handbook#199](https://github.com/bigstack-oss/bigstack-handbook/pull/199) | open | Topic: why `ro` alone does not bound an uploaded filesystem image (the `nosuid,nodev,noexec` rationale) | The known-issue closes when this ships; the hardening rationale should outlive it |

</details>

<br/>

### What this PR does?

**The whole fix, in one line** (`internal/cubecos/fixpacks.go`):

```diff
-exec.CommandContext(ctx, "mount", file, tmpDir)
+exec.CommandContext(ctx, "mount", "-o", "ro,nosuid,nodev,noexec", file, tmpDir)
```

Everything else is scaffolding around it:

| Change | Why |
|---|---|
| `mount -o ro,…` | A plain `mount` is read-write. The kernel bumps `s_mnt_count` / `s_state` / `s_wtime` on every cycle, so *reading* a fixpack rewrote it |
| `noload` fallback | A dirty ext4 journal cannot be mounted read-only at all — and the old code is exactly what leaves images dirty |
| `nosuid,nodev,noexec` | Free hardening on a mount of unvalidated uploaded bytes. Not part of the md5 fix |
| `fixpacks_mount_test.go` + `task testFixpackMount` | Regression suite behind the `privileged` build tag — needs root and a loop device |

#### Blast radius of the bug

One API request churned *every* fixpack on the node:

```mermaid
flowchart LR
    A["GET /v1/fixpacks<br/>(list endpoints)"] --> D
    B[GetFixpackRawByVersion] --> D
    C[GetFixpackPathByVersion] --> D
    D[GetFixpackInfo] -->|"once per .fixpack<br/>in /var/fixpack"| E[parseFixpackInfo]
    E --> F["mount file dir<br/>(read-write)"]
    F --> G["superblock rewritten<br/>md5 changes"]
```

Measured on a 16 MiB ext4 image: **11 bytes differ per read**, all inside the superblock. `checkFixpackDuplication` already worked around this by copying the whole file and mounting the copy.

#### Why two mount attempts, in this order

```mermaid
flowchart TD
    A["mount -o ro,nosuid,nodev,noexec"] -->|OK| Z[read fixpack.info]
    A -->|"refused (dirty journal)"| B["mount -o ro,noload,nosuid,nodev,noexec"]
    B -->|OK| Z
    B -->|refused| E[return last error]
```

`ro` gives two layers: the VFS refuses writes, and util-linux also marks the **loop device** read-only (`losetup -l` shows `RO=1`), so the kernel cannot touch the backing file regardless of image format.

That same read-only loop device cannot replay a journal, so a dirty ext4 refuses the strict options. `noload` skips the replay — it reads **pre-recovery metadata**, safe for `fixpack.info` (fixed at build time, never rewritten) but a degraded read. Hence *behind* the strict mount, not beside it.

| options | squashfs | ext2 | ext4 clean | ext4 dirty |
|---|---|---|---|---|
| `ro,nosuid,nodev,noexec` | OK | OK | OK | refused |
| `ro,noload,nosuid,nodev,noexec` | refused | refused | OK | OK |

<details>
<summary>squashfs and ext2 are defensive cover, not reachable states</summary>

<br/>

Observed behaviour, recorded in case the build format ever changes:

- hex's `makehotfix` and `makefixpack` both build with `CreateFsImage ext4`
- `hex_fixpack_install` mounts with an explicit `-t ext4`, so a non-ext4 fixpack could not install

</details>

<details>
<summary>Why <code>nosuid,nodev,noexec</code> ride along</summary>

<br/>

`ro` bounds only whether the kernel writes *to* the image. A read-only mount still honours setuid bits, lets a process open a device node and reach the device behind it, and executes binaries.

The mount is genuinely of unvalidated bytes — no integrity check precedes it:

```mermaid
flowchart LR
    A[upload handler] --> B["saveUploadFile()"]
    B --> C["checkFixpackDuplication()<br/><b>mounts here</b>"]
    C --> D["syncFixpackMd5()<br/>(first integrity check)"]
```

Defence in depth against an already-authenticated caller, not a remote hole. Full rationale in [bigstack-handbook#199](https://github.com/bigstack-oss/bigstack-handbook/pull/199).

</details>

<details>
<summary>How the tests avoid drifting from the code</summary>

<br/>

- Behind the `privileged` build tag, so `task test` never picks them up (verified: excluded from an untagged build)
- `task testFixpackMount` supplies a privileged container and builds real squashfs / ext2 / ext4 / dirty-ext4 images with `mkfs`
- Asserts the mount leaves them byte-for-byte identical
- Calls the real `parseFixpackInfo` instead of re-implementing the option list

</details>

<br/>

### Test results (optional)

**1). make sure the api docs have been updated**

No API surface change — internal to the fixpack read path. `task generateApiDocs` produces no diff against the committed `api/docs.json`.

**2). make sure the api works properly**

`task testFixpackMount` — 5 new tests pass (the first fans out over all 4 image formats), plus the 4 pre-existing tests in the package.

| test | pins |
|---|---|
| `TestParseFixpackInfoLeavesTheImageUntouched` | md5 identical before/after, all 4 formats |
| `TestParseFixpackInfoKeepsTheSameMd5AcrossRepeatedReads` | 5 consecutive reads — the reported symptom |
| `TestParseFixpackInfoStillReadsAnExt4ImageWithADirtyJournal` | the `noload` fallback |
| `TestGetFixpackInfoParsesAReadOnlyMountedImage` | parsing on top of the mount |
| `TestParseFixpackInfoRejectsAFileThatIsNotAFilesystemImage` | bad input fails instead of hanging |

Also clean: `CGO_ENABLED=1 GOWORK=off go vet ./...`, `CGO_ENABLED=1 GOWORK=off go test ./...`, `gofmt`.

> [!WARNING]
> **Not verified against real hardware.** The tests use synthetic `mkfs` images; no endpoint has been exercised on a CubeCOS node with a vendor-built `.fixpack`. Worth one manual `GET /v1/fixpacks` on a dev node before merge — confirm listed versions still resolve and `md5sum` on `/var/fixpack` files stays stable across repeated calls.

<br/>

### Follow-up not included here

| # | Item | Decision |
|---|---|---|
| 1 | **The `checkFixpackDuplication` copy is now redundant.** `internal/apis/v1/handlers/fixpacks/verify.go:89` copies the entire fixpack to `*.copy` before mounting — a workaround for this bug, costing a full multi-hundred-MB copy per upload | Left alone: removing it changes behaviour, and I have not proven the copy had no second purpose |
| 2 | **Firmware checked — not affected.** A firmware `.pkg` is the same kind of artifact (hex's `makeppu` also uses `CreateFsImage ext4`), so it would churn identically if anything mounted it read-write | Nothing does — see below |
| 3 | **The new suite does not run in CI.** `ci.yml` runs `go vet ./...` and `go test ./...`, neither carrying `-tags privileged`, so the suite only runs on a manual `task testFixpackMount` | That leaves it one "simplify the option list" refactor away from being decorative. Adding a job is feasible — `ubuntu-latest` runners have passwordless sudo and loop devices, and `scripts/test-fixpack-mount.sh` already has a native-root path. Say the word and I'll fold it into this PR |

On (2), why firmware is immune today:

- The fixpack mount above is the **only** `mount` invocation in the repo
- Firmware metadata comes from the filename (`ConvertPkgNameToFirmware` splits on `_`) plus `/var/appliance-db/update.history`, never from inside the image
- The only byte-level reads are `md5.GenByFile` and the upload-time copy, both read-only

The immunity is **structural, not deliberate**: the day something needs a field from inside a `.pkg`, the same bug is one plain `mount` away.
