### PR TITLE
fix(integrations): report Cinder storage update times in the node's local offset

### DIFF
--- a/internal/cubecos/integration.go
+++ b/internal/cubecos/integration.go
@@ -116,6 +116,7 @@ func GetStorage(name string) (*storages.CinderDetails, error) {
 		return nil, err
 	}
 
+	convertStorageDetailsTimes(cinder)
 	return cinder, nil
 }
 
@@ -386,22 +387,37 @@ func identifyStorageModelDeleteErr(driver string, output []byte) error {
 
 func convertStorageTimes(list *[]storages.Cinder) {
 	for i, storage := range *list {
-		if storage.IsBuiltIn {
-			(*list)[i].UpdateTime = base.ActiveFirmwareUpdatedAt
-			continue
-		}
-
-		if storage.UpdateTime == "" {
-			(*list)[i].UpdateTime = time.NowRFC3339()
-			continue
-		}
-
-		updateTime, err := ostime.Parse(time.FormatRFC3339ZUTC, storage.UpdateTime)
-		if err != nil {
-			log.Warnf("integrations: failed to parse storage %s update time %s (%v)", storage.Name, storage.UpdateTime, err)
-			continue
-		}
-
-		(*list)[i].UpdateTime = time.LocalRFC3339(updateTime)
+		(*list)[i].UpdateTime = convertStorageTime(storage.Name, storage.IsBuiltIn, storage.UpdateTime)
 	}
+}
+
+// The details response emits the top-level update time and the one nested under
+// "storage"; both arrive as raw OpenStack UTC, so both go through the same
+// conversion the list path uses. Otherwise the two endpoints disagree about the
+// same storage's timestamp.
+func convertStorageDetailsTimes(details *storages.CinderDetails) {
+	if details == nil {
+		return
+	}
+
+	details.UpdateTime = convertStorageTime(details.Name, details.IsBuiltIn, details.UpdateTime)
+	details.Storage.UpdateTime = convertStorageTime(details.Name, details.IsBuiltIn, details.Storage.UpdateTime)
+}
+
+// A built-in storage and one hex_sdk reports no update time for are the same
+// case — no timestamp of its own — so both report the active firmware time.
+// That value is derived once at startup and already carries the node's offset;
+// request time would move on every GET and label itself UTC.
+func convertStorageTime(name string, isBuiltIn bool, updateTime string) string {
+	if isBuiltIn || updateTime == "" {
+		return base.ActiveFirmwareUpdatedAt
+	}
+
+	parsed, err := ostime.Parse(time.FormatRFC3339ZUTC, updateTime)
+	if err != nil {
+		log.Warnf("integrations: failed to parse storage %s update time %s (%v)", name, updateTime, err)
+		return updateTime
+	}
+
+	return time.LocalRFC3339(parsed)
 }

--- a/internal/cubecos/integration_test.go
+++ b/internal/cubecos/integration_test.go
@@ -1,0 +1,199 @@
+package cubecos
+
+import (
+	"testing"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	"github.com/stretchr/testify/require"
+)
+
+// hex_sdk emits OpenStack UTC — 15:02:37 in +08:00, 02:02:37 in -05:00.
+const sourceUpdateTime = "2026-07-24T07:02:37Z"
+
+// Stands in for the value runtime.initIdentity reads once at startup. It is
+// already in the node's local offset, so tests only need it to be recognisable.
+const firmwareUpdatedAt = "2026-07-01T09:00:00+08:00"
+
+// Pins the startup-derived firmware timestamp and restores it so the value does
+// not leak between tests.
+func stubActiveFirmwareUpdatedAt(t *testing.T, updatedAt string) {
+	t.Helper()
+
+	orig := base.ActiveFirmwareUpdatedAt
+	base.ActiveFirmwareUpdatedAt = updatedAt
+
+	t.Cleanup(func() { base.ActiveFirmwareUpdatedAt = orig })
+}
+
+func TestConvertStorageTimesReportsTheSourceTimeInTheNodeLocalOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60, want: "2026-07-24T15:02:37+08:00"},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60, want: "2026-07-24T02:02:37-05:00"},
+		{name: "at UTC", offsetSeconds: 0, want: "2026-07-24T07:02:37Z"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+			list := []storages.Cinder{{Name: "vsan", UpdateTime: sourceUpdateTime}}
+			convertStorageTimes(&list)
+
+			require.Equal(t, test.want, list[0].UpdateTime)
+		})
+	}
+}
+
+// A storage hex_sdk reports no update time for has no timestamp of its own, so
+// it reports the same stable placeholder a built-in storage does. Substituting
+// request time would move the value on every GET.
+func TestConvertStorageTimesReportsAStableTimeWhenTheSourceHasNone(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60},
+		{name: "at UTC", offsetSeconds: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+			first := []storages.Cinder{{Name: "vsan"}}
+			second := []storages.Cinder{{Name: "vsan"}}
+			convertStorageTimes(&first)
+			convertStorageTimes(&second)
+
+			require.Equal(t, firmwareUpdatedAt, first[0].UpdateTime)
+			require.Equal(t, first[0].UpdateTime, second[0].UpdateTime)
+		})
+	}
+}
+
+func TestConvertStorageTimesKeepsBuiltInStoragesOnTheFirmwareTime(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+	list := []storages.Cinder{{Name: "CubeStorage", IsBuiltIn: true, UpdateTime: sourceUpdateTime}}
+	convertStorageTimes(&list)
+
+	require.Equal(t, firmwareUpdatedAt, list[0].UpdateTime)
+}
+
+func TestConvertStorageTimesLeavesAnUnparseableSourceTimeAlone(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+	list := []storages.Cinder{{Name: "vsan", UpdateTime: "not a timestamp"}}
+	convertStorageTimes(&list)
+
+	require.Equal(t, "not a timestamp", list[0].UpdateTime)
+}
+
+// The details response emits the top-level update time and the one nested under
+// "storage". Both arrive raw UTC, so both need converting.
+func TestConvertStorageDetailsTimesConvertsBothUpdateTimeFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+		want          string
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60, want: "2026-07-24T15:02:37+08:00"},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60, want: "2026-07-24T02:02:37-05:00"},
+		{name: "at UTC", offsetSeconds: 0, want: "2026-07-24T07:02:37Z"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+			details := &storages.CinderDetails{
+				Name:       "vsan",
+				UpdateTime: sourceUpdateTime,
+				Storage:    storages.Storage{UpdateTime: sourceUpdateTime},
+			}
+			convertStorageDetailsTimes(details)
+
+			require.Equal(t, test.want, details.UpdateTime)
+			require.Equal(t, test.want, details.Storage.UpdateTime)
+		})
+	}
+}
+
+// The list and details endpoints report the same storage, so they must agree on
+// the instant and the offset.
+func TestConvertStorageDetailsTimesAgreesWithTheListPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		offsetSeconds int
+	}{
+		{name: "east of UTC", offsetSeconds: 8 * 60 * 60},
+		{name: "west of UTC", offsetSeconds: -5 * 60 * 60},
+		{name: "at UTC", offsetSeconds: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			useLocalZone(t, test.offsetSeconds)
+			stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+			list := []storages.Cinder{{Name: "vsan", UpdateTime: sourceUpdateTime}}
+			details := &storages.CinderDetails{
+				Name:       "vsan",
+				UpdateTime: sourceUpdateTime,
+				Storage:    storages.Storage{UpdateTime: sourceUpdateTime},
+			}
+
+			convertStorageTimes(&list)
+			convertStorageDetailsTimes(details)
+
+			require.Equal(t, list[0].UpdateTime, details.UpdateTime)
+			require.Equal(t, list[0].UpdateTime, details.Storage.UpdateTime)
+		})
+	}
+}
+
+// updateTime is required in GetIntegrationStorageResponse, so the details path
+// needs the same stable placeholder rather than an empty string.
+func TestConvertStorageDetailsTimesReportsAStableTimeWhenTheSourceHasNone(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+	details := &storages.CinderDetails{Name: "vsan"}
+	convertStorageDetailsTimes(details)
+
+	require.Equal(t, firmwareUpdatedAt, details.UpdateTime)
+	require.Equal(t, firmwareUpdatedAt, details.Storage.UpdateTime)
+}
+
+func TestConvertStorageDetailsTimesKeepsBuiltInStoragesOnTheFirmwareTime(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+	stubActiveFirmwareUpdatedAt(t, firmwareUpdatedAt)
+
+	details := &storages.CinderDetails{
+		Name:       "CubeStorage",
+		IsBuiltIn:  true,
+		UpdateTime: sourceUpdateTime,
+		Storage:    storages.Storage{UpdateTime: sourceUpdateTime},
+	}
+	convertStorageDetailsTimes(details)
+
+	require.Equal(t, firmwareUpdatedAt, details.UpdateTime)
+	require.Equal(t, firmwareUpdatedAt, details.Storage.UpdateTime)
+}
+
+func TestConvertStorageDetailsTimesToleratesANilStorage(t *testing.T) {
+	useLocalZone(t, 8*60*60)
+
+	require.NotPanics(t, func() { convertStorageDetailsTimes(nil) })
+}

--- a/internal/definition/v1/time/time.go
+++ b/internal/definition/v1/time/time.go
@@ -73,10 +73,6 @@ func RFC3339ZNano(t time.Time) string {
 	return t.Format(FormatRFC3339ZNano)
 }
 
-func NowRFC3339() string {
-	return time.Now().UTC().Format(time.RFC3339)
-}
-
 func LocalRFC3339(t time.Time) string {
 	return t.In(LocalFixedZone).Format(time.RFC3339)
 }


### PR DESCRIPTION
### What type of PR is this?

- Bug fix

<br/>

### Which issue(s) this PR fixes?

- Refs bigstack-oss/cubecos#1182
- Handbook write-up: [bigstack-handbook#180](https://github.com/bigstack-oss/bigstack-handbook/pull/180) — **merged 2026-08-01**. It already records this fix in the timestamp-contract Topic and the Cinder known-issue, with the known-issue deliberately left `status: open` until this PR ships. Closing that status is the follow-up once this merges.

<br/>

### What this PR does?

#### The bugs

**1. The two endpoints disagreed about the same object.** The storage **details** endpoint returned `updateTime` exactly as hex_sdk emitted it (OpenStack UTC). The **list** endpoint converted the same storage's timestamp to the node's local offset.

**2. The list path's fallback used *request* time.** When hex_sdk supplied no update time, the list path substituted `NowRFC3339()`. Two problems, the second being the substantive one:

- it emitted `Z` next to sibling fields carrying the node's local offset, and
- the value **moved on every `GET`** — nothing about the storage had changed.

#### Behaviour, before and after

| case | list — before | details — before | both — after |
|---|---|---|---|
| normal storage | local offset | raw UTC `Z` | local offset |
| no source timestamp | `NowRFC3339()` — UTC, moves every `GET` | empty string | active-firmware time |
| built-in storage | active-firmware time | raw UTC `Z` | active-firmware time |
| unparseable source | left as-is + warn | left as-is | left as-is + warn |

Note the details/no-source-timestamp cell: it returned an **empty string** for a field `GetIntegrationStorageResponse` declares required and non-empty. Now covered by the same placeholder.

#### Changes

```mermaid
flowchart TD
    list["list endpoint<br/>GetStorages"] --> conv["convertStorageTimes"]
    det["details endpoint<br/>GetStorage"] --> convd["convertStorageDetailsTimes<br/>top-level + nested storage"]

    conv --> shared["convertStorageTime<br/><b>single decision point</b>"]
    convd --> shared

    shared --> q1{"isBuiltIn?"}
    q1 -->|yes| fw["base.ActiveFirmwareUpdatedAt<br/>no timestamp of its own<br/>stable across GETs, node offset"]
    q1 -->|no| q2{"updateTime<br/>empty?"}
    q2 -->|yes| fw
    q2 -->|no| q3{"parses as<br/>RFC3339 UTC?"}
    q3 -->|yes| loc["time.LocalRFC3339<br/>node offset"]
    q3 -->|no| raw["pass through<br/>+ log.Warnf"]

    old["<b>was:</b> time.NowRFC3339<br/>request time, UTC Z<br/>moved on every GET"] -.->|replaced by| fw

    style old stroke-dasharray: 5 5
```

**Extract one conversion, call it from both paths.** `convertStorageTime(name, isBuiltIn, updateTime)` holds the whole decision. `convertStorageTimes` (list) and the new `convertStorageDetailsTimes` both delegate to it, so the two endpoints cannot drift apart again.

**The details response carries two update-time fields** — top-level and the one nested under `storage`. Both arrive as raw UTC, so both go through the conversion. `convertStorageDetailsTimes` is nil-tolerant.

**Fallback is now the active-firmware time,** not request time. It is derived once at startup and already carries the node's offset. A built-in storage and one with no source timestamp are the same case — no timestamp of its own — so both branches collapse into one.

**`NowRFC3339` deleted.** No remaining callers, and it emitted UTC in violation of the response-timestamp contract. Follows `ISO8601Z` out (#1166).

#### Compatibility

No schema change. `updateTime` stays required and non-empty on both responses. Only the value's timezone offset and its fallback source change.

Files: `internal/cubecos/integration.go`, `internal/cubecos/integration_test.go`, `internal/definition/v1/time/time.go`.

<br/>

### Test results (optional)

**1). make sure the api docs have been updated**

No API doc change needed — the OpenAPI schema is unchanged (`updateTime` remains a required, non-empty string on both the list and details responses).

<br/>

**2). make sure the api works properly**

`go test ./...` and `go vet ./...` — pass.

New suite in `internal/cubecos/integration_test.go`. Each conversion test runs across three node offsets (`+08:00`, `-05:00`, UTC) so a hardcoded offset cannot pass:

| test | pins |
|---|---|
| `TestConvertStorageTimesReportsTheSourceTimeInTheNodeLocalOffset` | list-path conversion, 3 offsets |
| `TestConvertStorageTimesReportsAStableTimeWhenTheSourceHasNone` | two consecutive calls return the same value — the reported defect |
| `TestConvertStorageTimesKeepsBuiltInStoragesOnTheFirmwareTime` | built-in overrides its source timestamp |
| `TestConvertStorageTimesLeavesAnUnparseableSourceTimeAlone` | bad input passes through instead of becoming empty |
| `TestConvertStorageDetailsTimesConvertsBothUpdateTimeFields` | top-level **and** nested `storage.updateTime`, 3 offsets |
| `TestConvertStorageDetailsTimes…` (matches list / stable fallback / built-in / nil) | the two endpoints agree byte-for-byte; required field never empty; nil does not panic |

**Not verified:** no run against a live cluster. Worth one `GET /v1/integrations/storages` plus `GET /v1/integrations/storages/{name}` on a dev node before merge, confirming both `updateTime` values match and carry the node's offset.
