### PR TITLE
fix(gpu): resolve MIG-backed vGPU profiles without a type translation

### DIFF
--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -22,20 +22,19 @@ import (
 // Seams for unit tests: hex_sdk CLI, nvidia-smi, and Openstack are
 // unavailable there.
 var (
-	getNodeGpusMap                 = cubecos.GetNodeGpusMap
-	getNodeVgpuProfilesMap         = cubecos.GetNodeVgpuProfilesMap
-	getNodePgpuAttachedInstance    = cubecos.GetNodePgpuAttachedInstance
-	getNvidiaSmiDevices            = cubecos.GetNvidiaSmiDevices
-	getNvidiaSmiVgpuInstances      = cubecos.GetNvidiaSmiVgpuInstances
-	getNvidiaSmiVgpuTypeProfileIds = cubecos.GetNvidiaSmiVgpuTypeGpuInstanceProfileIds
-	buildInstanceLinks             = buildInstanceLinksViaOpenstack
-	getOpenstackServerNames        = getOpenstackServerNamesViaHelper
-	createConsole                  = createConsoleViaOpenstack
-	getNodeGpuById                 = cubecos.GetNodeGpuById
-	updateNodeGpuCardViaHex        = cubecos.UpdateNodeGpuCard
-	isGpuUpdating                  = isGpuUpdatingViaMongo
-	upsertUpdatingGpuReq           = upsertUpdatingGpuReqViaMongo
-	deleteUpdatingGpuReq           = deleteUpdatingGpuReqViaMongo
+	getNodeGpusMap              = cubecos.GetNodeGpusMap
+	getNodeVgpuProfilesMap      = cubecos.GetNodeVgpuProfilesMap
+	getNodePgpuAttachedInstance = cubecos.GetNodePgpuAttachedInstance
+	getNvidiaSmiDevices         = cubecos.GetNvidiaSmiDevices
+	getNvidiaSmiVgpuInstances   = cubecos.GetNvidiaSmiVgpuInstances
+	buildInstanceLinks          = buildInstanceLinksViaOpenstack
+	getOpenstackServerNames     = getOpenstackServerNamesViaHelper
+	createConsole               = createConsoleViaOpenstack
+	getNodeGpuById              = cubecos.GetNodeGpuById
+	updateNodeGpuCardViaHex     = cubecos.UpdateNodeGpuCard
+	isGpuUpdating               = isGpuUpdatingViaMongo
+	upsertUpdatingGpuReq        = upsertUpdatingGpuReqViaMongo
+	deleteUpdatingGpuReq        = deleteUpdatingGpuReqViaMongo
 )
 
 // buildLocalGpuCardOpts carries data fetched once per listLocalGpuCards
@@ -69,11 +68,6 @@ type listAttachedInstancesOpts struct {
 	// VgpuInstances/VgpuInstancesAvailable: see buildLocalGpuCardOpts.
 	VgpuInstances          []cubecos.NvidiaSmiVgpuInstance
 	VgpuInstancesAvailable bool
-	// MigTypeProfileIds maps vGPU Type ID -> GPU Instance Profile ID for a
-	// MIG-backed GPU's supported types (nvidia-smi vgpu -q reports the former
-	// per instance; hex's MIG-backed profile ids are the latter). Unused for
-	// SR-IOV, whose hex profile ids are the vGPU Type ID directly.
-	MigTypeProfileIds map[uint32]uint32
 	// ServerNames maps Openstack server id to name, prefetched once per request
 	// so vGPU instance names do not cost a GetServer round trip each. A nil map
 	// means the prefetch failed outright, so a name missing for an attached
@@ -269,19 +263,6 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 		enr.degrade("gpu: Openstack server prefetch failed on node %s; gpu %s reported without instance names (degraded)", h.node, hexGpu.Id)
 	}
 
-	// MIG-backed hex profile ids are the GPU Instance Profile ID, which
-	// nvidia-smi only reports per vGPU *type* (vgpu -s -v), not per active
-	// instance (vgpu -q reports the vGPU Type ID instead): resolve the
-	// type -> profile-id mapping once here, only when actually needed.
-	migTypeProfileIds := map[uint32]uint32{}
-	if hexGpu.Type == gpu.ResourceTypeMigBackedVgpu && len(opts.VgpuInstances) > 0 {
-		var err error
-		migTypeProfileIds, err = getNvidiaSmiVgpuTypeProfileIds(hexGpu.PciAddress)
-		if err != nil {
-			enr.degrade("nvidiasmi: failed to get vgpu type profile ids for gpu %s: %v; mig-backed instance aliases may be missing (degraded)", hexGpu.Id, err)
-		}
-	}
-
 	attachedInstances, err := listAttachedInstances(listAttachedInstancesOpts{
 		IsDeviceVisible:          isDeviceVisible,
 		DeviceUUID:               hexGpu.Id,
@@ -293,7 +274,6 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 		HexProfilesMap:           hexProfilesMap,
 		VgpuInstances:            opts.VgpuInstances,
 		VgpuInstancesAvailable:   opts.VgpuInstancesAvailable,
-		MigTypeProfileIds:        migTypeProfileIds,
 		ServerNames:              opts.ServerNames,
 		Enrichment:               enr,
 	})
@@ -569,18 +549,13 @@ func listVgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedIn
 	}
 
 	for _, instance := range opts.VgpuInstances {
-		profileId := instance.VgpuTypeId
-
-		if opts.HexGpu.Type == gpu.ResourceTypeMigBackedVgpu {
-			giProfileId, ok := opts.MigTypeProfileIds[instance.VgpuTypeId]
-			if !ok {
-				enr.degrade("nvidiasmi: no GPU Instance Profile ID found for vgpu type %d on device %s; skipping instance %s (degraded)", instance.VgpuTypeId, deviceUUID, instance.VmUUID)
-				continue
-			}
-			profileId = giProfileId
-		}
-
-		hexProfile := hexProfilesMap[profileId]
+		// hex reports both vGPU flavours' profile ids as vGPU Type IDs, which is
+		// exactly what `nvidia-smi vgpu -q` gives per active instance - so the
+		// lookup is direct for MIG-backed cards too. It used to need a
+		// type -> GPU Instance Profile ID translation, because
+		// gpu_vgpu_profile_list keyed migBacked entries by partition shape; that
+		// list is per vGPU type as of cubecos #905.
+		hexProfile := hexProfilesMap[instance.VgpuTypeId]
 		profileAlias := hexProfile.Alias
 
 		// The server name is enrichment resolved from the prefetched map. A missing

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -19,7 +19,6 @@ func restoreGpuSeams(t *testing.T) {
 	origGetNodePgpuAttachedInstance := getNodePgpuAttachedInstance
 	origGetNvidiaSmiDevices := getNvidiaSmiDevices
 	origGetNvidiaSmiVgpuInstances := getNvidiaSmiVgpuInstances
-	origGetNvidiaSmiVgpuTypeProfileIds := getNvidiaSmiVgpuTypeProfileIds
 	origBuildInstanceLinks := buildInstanceLinks
 	origGetOpenstackServerNames := getOpenstackServerNames
 	origCreateConsole := createConsole
@@ -40,7 +39,6 @@ func restoreGpuSeams(t *testing.T) {
 		getNodePgpuAttachedInstance = origGetNodePgpuAttachedInstance
 		getNvidiaSmiDevices = origGetNvidiaSmiDevices
 		getNvidiaSmiVgpuInstances = origGetNvidiaSmiVgpuInstances
-		getNvidiaSmiVgpuTypeProfileIds = origGetNvidiaSmiVgpuTypeProfileIds
 		buildInstanceLinks = origBuildInstanceLinks
 		getOpenstackServerNames = origGetOpenstackServerNames
 		createConsole = origCreateConsole
@@ -640,7 +638,8 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 			return gpu.InstanceLinks{}
 		}
 
-		giProfileId := uint32(47)
+		// hex keys migBacked profiles by vGPU Type ID (cubecos #905), the same id
+		// `vgpu -q` reports per instance - so no translation step is involved.
 		vgpuTypeId := uint32(0x619)
 
 		enr := &enrichment{}
@@ -648,12 +647,11 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 			IsDeviceVisible: true,
 			DeviceUUID:      "GPU-44444444-4444-4444-4444-444444444444",
 			HexGpu:          gpu.GpuFromHex{Type: gpu.ResourceTypeMigBackedVgpu},
-			HexProfilesMap:  map[uint32]gpu.VgpuProfileFromHex{giProfileId: {Alias: &alias}},
+			HexProfilesMap:  map[uint32]gpu.VgpuProfileFromHex{vgpuTypeId: {Alias: &alias}},
 			VgpuInstances: []cubecos.NvidiaSmiVgpuInstance{
 				{VmUUID: "vm-9", VgpuTypeId: vgpuTypeId},
 			},
 			VgpuInstancesAvailable: true,
-			MigTypeProfileIds:      map[uint32]uint32{vgpuTypeId: giProfileId},
 			ServerNames:            map[string]string{},
 			Enrichment:             enr,
 		})
@@ -663,27 +661,29 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 		require.Equal(t, &alias, (*instances)[0].ProfileAlias)
 	})
 
-	// A MIG-backed vGPU type absent from the type->profile-id map (e.g. the
-	// static vgpu -s -v lookup failed or returned an incomplete set) is
-	// skipped rather than reported with a wrong or zero-value profile id.
-	t.Run("mig-backed instance with unresolvable type is skipped", func(t *testing.T) {
+	// A vGPU type absent from hex's profile list is reported without an alias and
+	// does not degrade the card - the same as the SR-IOV path has always behaved.
+	// Both flavours share one lookup now, so there is no MIG-only signal to keep:
+	// the id mismatch that used to produce one (hex reporting GPU Instance Profile
+	// IDs while vgpu -q reports vGPU Type IDs) no longer exists.
+	t.Run("vgpu type missing from hex profiles reports without an alias", func(t *testing.T) {
 		enr := &enrichment{}
 		instances := listVgpuAttachedInstances(listAttachedInstancesOpts{
 			IsDeviceVisible: true,
 			DeviceUUID:      "GPU-44444444-4444-4444-4444-444444444444",
 			HexGpu:          gpu.GpuFromHex{Type: gpu.ResourceTypeMigBackedVgpu},
+			HexProfilesMap:  map[uint32]gpu.VgpuProfileFromHex{},
 			VgpuInstances: []cubecos.NvidiaSmiVgpuInstance{
 				{VmUUID: "vm-9", VgpuTypeId: 0x619},
 			},
 			VgpuInstancesAvailable: true,
-			MigTypeProfileIds:      map[uint32]uint32{},
 			ServerNames:            map[string]string{},
 			Enrichment:             enr,
 		})
 
-		require.True(t, enr.degraded)
-		require.NotNil(t, instances)
-		require.Empty(t, *instances)
+		require.False(t, enr.degraded)
+		require.Len(t, *instances, 1)
+		require.Nil(t, (*instances)[0].ProfileAlias)
 	})
 }
 

--- a/internal/cubecos/gpu_nvidiasmi.go
+++ b/internal/cubecos/gpu_nvidiasmi.go
@@ -10,12 +10,6 @@ import (
 	log "go-micro.dev/v5/logger"
 )
 
-// nvidiaSmiVgpuTypeProfileIdWindow bounds how many lines past a "vGPU Type ID"
-// line are scanned for its "GPU Instance Profile ID". Mirrors the `grep -A 20`
-// window `gpu_vgpu_profile_list` (core/sdk_sh/modules/sdk_gpu.sh, cubecos repo)
-// already uses successfully against this exact nvidia-smi output.
-const nvidiaSmiVgpuTypeProfileIdWindow = 20
-
 // NvidiaSmiDevice is one GPU's device-level stats as reported by `nvidia-smi
 // -q`. MemoryUsedMiB is Reserved+Used: newer drivers split a fixed ECC/driver
 // reservation out of Used that the previous NVML v1 GetMemoryInfo() call
@@ -30,10 +24,9 @@ type NvidiaSmiDevice struct {
 }
 
 // NvidiaSmiVgpuInstance is one active vGPU instance as reported by `nvidia-smi
-// vgpu -q`. VgpuTypeId is the vGPU Type ID (not a GPU Instance Profile ID);
-// hex's SR-IOV profile ids are the vGPU Type ID directly, while MIG-backed
-// profile ids are the GPU Instance Profile ID, which needs a separate lookup
-// via GetNvidiaSmiVgpuTypeGpuInstanceProfileIds.
+// vgpu -q`. VgpuTypeId is the vGPU Type ID, which is what hex reports as the
+// profile id for both vGPU flavours, so it maps straight onto a hex profile
+// with no further lookup.
 type NvidiaSmiVgpuInstance struct {
 	VmUUID                string
 	VgpuTypeId            uint32
@@ -72,21 +65,6 @@ func GetNvidiaSmiVgpuInstances() (map[string][]NvidiaSmiVgpuInstance, error) {
 	}
 
 	return parseNvidiaSmiVgpuInstances(output), nil
-}
-
-// GetNvidiaSmiVgpuTypeGpuInstanceProfileIds runs `nvidia-smi vgpu -s -v -i
-// <pciAddress>` and returns the GPU Instance Profile ID for each MIG-backed
-// vGPU type the device supports, keyed by vGPU Type ID. SR-IOV vGPU types
-// have no GPU Instance Profile ID and are absent from the returned map --
-// hex's SR-IOV profile ids are the vGPU Type ID directly, so callers only
-// need this lookup to resolve MIG-backed profile ids.
-func GetNvidiaSmiVgpuTypeGpuInstanceProfileIds(pciAddress string) (map[uint32]uint32, error) {
-	output, err := runNvidiaSmi("vgpu", "-s", "-v", "-i", pciAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return parseNvidiaSmiVgpuTypeProfileIds(output), nil
 }
 
 func runNvidiaSmi(args ...string) (string, error) {
@@ -268,45 +246,6 @@ func parseNvidiaSmiVgpuInstanceBlock(lines []string) []NvidiaSmiVgpuInstance {
 	return result
 }
 
-// parseNvidiaSmiVgpuTypeProfileIds ports gpu_vgpu_profile_list's own parsing
-// strategy (core/sdk_sh/modules/sdk_gpu.sh, cubecos repo) for `nvidia-smi
-// vgpu -s -v` output to Go: find each "vGPU Type ID" line, then scan a
-// bounded window of following lines for "GPU Instance Profile ID" rather than
-// relying on strict block boundaries. That shell code is proven working
-// against this exact command in production, so the same tolerant strategy is
-// reused here instead of a stricter structural parse this package cannot
-// verify against real hardware output.
-func parseNvidiaSmiVgpuTypeProfileIds(output string) map[uint32]uint32 {
-	profileIds := map[uint32]uint32{}
-	lines := strings.Split(output, "\n")
-
-	for i, line := range lines {
-		key, value, ok := splitNvidiaSmiKeyValue(line)
-		if !ok || key != "vGPU Type ID" {
-			continue
-		}
-
-		vgpuTypeId, err := parseNvidiaSmiHexId(value)
-		if err != nil {
-			continue
-		}
-
-		windowEnd := min(i+nvidiaSmiVgpuTypeProfileIdWindow, len(lines))
-		for _, windowLine := range lines[i:windowEnd] {
-			wKey, wValue, wOk := splitNvidiaSmiKeyValue(windowLine)
-			if !wOk || wKey != "GPU Instance Profile ID" {
-				continue
-			}
-			if profileId, err := parseLeadingUint32Field(wValue); err == nil {
-				profileIds[vgpuTypeId] = profileId
-			}
-			break
-		}
-	}
-
-	return profileIds
-}
-
 // splitTopLevelBlocks splits text into blocks, each starting at a zero-indent
 // line beginning with headerPrefix and running until the next such line (or
 // EOF). Text before the first matching line is discarded.
@@ -373,18 +312,6 @@ func parseLeadingUint32Field(value string) (uint32, error) {
 	}
 
 	n, err := strconv.ParseUint(fields[0], 10, 32)
-	if err != nil {
-		return 0, err
-	}
-
-	return uint32(n), nil
-}
-
-// parseNvidiaSmiHexId parses a "0x5ef"-style hex id into a decimal uint32,
-// matching gpu_vgpu_profile_list's own `strtonum` conversion of the same
-// field in sdk_gpu.sh.
-func parseNvidiaSmiHexId(value string) (uint32, error) {
-	n, err := strconv.ParseUint(strings.TrimPrefix(value, "0x"), 16, 32)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/cubecos/gpu_nvidiasmi_test.go
+++ b/internal/cubecos/gpu_nvidiasmi_test.go
@@ -1,7 +1,6 @@
 package cubecos
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -174,65 +173,6 @@ func TestParseNvidiaSmiVgpuInstancesNoActiveVgpus(t *testing.T) {
 	require.Empty(t, instancesByPci)
 }
 
-// nvidiaSmiVgpuTypeBlock builds one synthetic "vGPU Type ID" block padded to
-// nvidiaSmiVgpuTypeProfileIdWindow lines so a test can prove the window
-// mechanism stays inside its own block and does not read a neighboring
-// type's fields. The filler field names are not real nvidia-smi output --
-// this repo has no captured `vgpu -s -v` sample to draw them from (see the
-// test doc comment below) -- only the two real fields this parser reads
-// (vGPU Type ID, GPU Instance Profile ID) are meaningful.
-func nvidiaSmiVgpuTypeBlock(hexId string, giProfileId string) string {
-	block := "    vGPU Type ID                          : " + hexId + "\n"
-	block += "        Name                              : NVIDIA RTX Pro 6000 Blackwell DC-Q\n"
-	for i := range nvidiaSmiVgpuTypeProfileIdWindow - 3 {
-		block += "        Filler Field " + strconv.Itoa(i) + "                     : n/a\n"
-	}
-	if giProfileId != "" {
-		block += "        GPU Instance Profile ID           : " + giProfileId + "\n"
-	}
-	return block
-}
-
-// parseNvidiaSmiVgpuTypeProfileIds ports gpu_vgpu_profile_list's own
-// windowed-grep strategy for `nvidia-smi vgpu -s -v` output; this test is
-// synthetic (this repo has no captured `vgpu -s -v` sample -- MIG-backed
-// vGPU creation does not work on any node available to it yet, see cubecos's
-// feat/905-mig-vgpu-infra-wip findings), so it only proves the windowing
-// mechanism matches the shell script's own `grep -A 20` semantics -- each
-// type's real field is placed exactly nvidiaSmiVgpuTypeProfileIdWindow-1
-// lines below its "vGPU Type ID" line (the edge of the window) so a
-// too-narrow or off-by-one window would fail this test, and each MIG type
-// carries a distinct profile id so a window overshooting into the next
-// block's field would also be caught as a wrong value, not just a missing one.
-func TestParseNvidiaSmiVgpuTypeProfileIds(t *testing.T) {
-	fixture := "Supported vGPU types on pGPU 0 :\n" +
-		nvidiaSmiVgpuTypeBlock("0x5ef", "") + // SR-IOV: no GI profile id
-		nvidiaSmiVgpuTypeBlock("0x619", "47") +
-		nvidiaSmiVgpuTypeBlock("0x61a", "48")
-
-	profileIds := parseNvidiaSmiVgpuTypeProfileIds(fixture)
-
-	require.Len(t, profileIds, 2)
-	require.Equal(t, map[uint32]uint32{
-		0x619: 47,
-		0x61a: 48,
-	}, profileIds)
-}
-
-// A GI profile id placed one line past the window must not be picked up by
-// the wrong (earlier) type, confirming the window is bounded, not unlimited.
-func TestParseNvidiaSmiVgpuTypeProfileIdsWindowIsBounded(t *testing.T) {
-	block := "    vGPU Type ID                          : 0x619\n"
-	for i := range nvidiaSmiVgpuTypeProfileIdWindow {
-		block += "        Filler Field " + strconv.Itoa(i) + "                     : n/a\n"
-	}
-	block += "        GPU Instance Profile ID           : 47\n"
-
-	profileIds := parseNvidiaSmiVgpuTypeProfileIds(block)
-
-	require.Empty(t, profileIds)
-}
-
 func TestParseLeadingIntField(t *testing.T) {
 	n, err := parseLeadingIntField("97887 MiB")
 	require.NoError(t, err)
@@ -246,15 +186,6 @@ func TestParseLeadingIntField(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = parseLeadingIntField("")
-	require.Error(t, err)
-}
-
-func TestParseNvidiaSmiHexId(t *testing.T) {
-	n, err := parseNvidiaSmiHexId("0x5ef")
-	require.NoError(t, err)
-	require.Equal(t, uint32(1519), n)
-
-	_, err = parseNvidiaSmiHexId("not-hex")
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
### What type of PR is this?

/kind bug

<br/>

### Which issue(s) this PR fixes?

Part of bigstack-oss/cubecos#905. Pairs with bigstack-oss/cubecos#1223.

<br/>

### What this PR does?

Removes the MIG-only "vGPU Type ID → GPU Instance Profile ID" reverse lookup.

`nvidia-smi vgpu -q` reports a **vGPU Type ID** per active instance. For
SR-IOV cards that is already what hex records as the profile id, so the lookup
into `hexProfilesMap` was direct. For MIG-backed cards hex used to record the
**GPU Instance Profile ID** instead, so this package ran a second
`nvidia-smi vgpu -s -v` per card to translate one into the other.

As of cubecos#905, `gpu_vgpu_profile_list` reports migBacked profiles per vGPU
type, keyed by vGPU Type ID — the same as the sriov list has always been. The
translation is no longer a translation, so it goes away along with
`GetNvidiaSmiVgpuTypeGpuInstanceProfileIds`, `parseNvidiaSmiVgpuTypeProfileIds`,
`parseNvidiaSmiHexId`, the `nvidiaSmiVgpuTypeProfileIdWindow` constant, the
`MigTypeProfileIds` option field, and the per-card degrade path that fired when
a type had no profile id.

Net effect: one fewer `nvidia-smi` subprocess per MIG-backed card per request,
one fewer parser to keep in sync with nvidia-smi's output format, and
`listVgpuAttachedInstances` treats both vGPU flavours identically.

**Merge ordering.** No longer a question: cubecos#1223 (the hex half of #905)
merged into cubecos `develop` on 2026-08-07 as `ebf47c36`. `gpu_vgpu_profile_list`
there already reports migBacked profiles per vGPU type, keyed by vGPU Type ID —
confirmed against cn13 on 2026-08-10:

```json
{"id":1546,"name":"DC-1-2Q","vramMiB":2048,"vmCountLimit":48,"count":0,"alias":null}
{"id":1549,"name":"DC-1-3Q","vramMiB":3072,"vmCountLimit":32,"count":0,"alias":null}
```

That makes `develop`'s API the mismatched half rather than this branch: its MIG
branch translates a vGPU Type ID into a GPU Instance Profile ID and looks that up
in hex's profile map, where those ids no longer exist, so a MIG-backed card's
`attachedInstances` resolve no `profileAlias`. This PR is what puts the two sides
back in agreement, and nothing has to be sequenced behind it.

`cube-cos-openapi` needs no change — no fields are added or removed, only how
`profileAlias` is resolved internally.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

No API surface change, so `api/cube-cos-openapi/docs.yaml` is untouched — this
PR only changes how an existing response field is resolved internally. The
`docs.json` derived artifact was still regenerated as part of the build below
(it is gitignored and the local copy was stale), so the Swagger UI served by the
tested binary matches the committed spec.

<br/>

2). make sure the api works properly

Built x86 in the repo's own jail image (`golang:1.26.5-bookworm`, matching
`build/cube-cos-api-jail.Dockerfile`; the container's own Go was too old for
`go.mod`) and deployed to cn13, the NYCU GPU node — the only node available
that can carve MIG-backed vGPUs at all. Binary identity was confirmed by the
symbols that should have **disappeared**
(`GetNvidiaSmiVgpuTypeGpuInstanceProfileIds`, `parseNvidiaSmiVgpuTypeProfileIds`,
`"no GPU Instance Profile ID found for vgpu type"`) rather than by new strings,
and by checking `GetNvidiaSmiVgpuInstances` was still present. The
previously-deployed binary was verified to still contain the removed symbol, so
the comparison was against a genuinely older build.

With the paired cubecos change carving GPU 0 as `migBackedVgpu` (8 x `DC-1-3Q`,
one 1g.24gb+gfx partition) and a VM booted against the resulting Nova
PCI-passthrough alias:

    GET /api/v1/datacenters/RegionOne/nodes/cn13/gpuCards
    (Bearer token; the API listens on 10.231.0.13:8082, not loopback)

    "resourceType": "migBackedVgpu",
    "status": { "current": "inUse" },
    "migProfileCount": 43,
    "attachedInstances": [{
      "id": "c0822453-59b6-4ae1-8c2f-f7831153c700",
      "name": "mig-1549-vm",
      "profileAlias": "nvidia_rtx_pro_6000_blackwell_dc_1_3q_1549",
      "memoryUsage": { "totalMiB": 3072 }
    }]

- `attachedInstances[0].id` equals the id returned by
  `openstack server create` — the PCI-address string match holds.
- `profileAlias` **resolved**. This is the load-bearing assertion: if the
  removed lookup were still needed, this array would have been silently empty
  rather than erroring.
- `totalMiB` 3072 is `DC-1-3Q`'s framebuffer, and `migProfileCount` 43 is the
  per-type list coming through unchanged.
- Cross-checked against the host: `nvidia-smi vgpu -q -i 0` reported
  `vGPU Type : 1549` for the same VM UUID — the same id hex records, which is
  what makes the translation unnecessary.

`go build ./...`, `go vet`, and `go test -count=1` on
`internal/cubecos/...` and `internal/apis/v1/handlers/nodes/...` all pass
(2026-08-06). Unit tests for the removed parser were deleted with it; no other
test referenced the removed symbols, and a repo-wide grep for all five removed
identifiers returns nothing. `strconv` and `strings` are still used elsewhere in
`gpu_nvidiasmi.go`, so no import became unused.

Re-verified 2026-08-10 in the same x86 jail image, both on this branch alone and
on a local merge with #626 (which touches the same file): `go vet ./internal/...`
exits 0 and `go test -count=1 ./internal/apis/v1/handlers/nodes/...
./internal/cubecos/...` passes on both trees. The merge is clean — #626 changes
the gate that decides *when* profiles are fetched, this PR changes how a fetched
profile is *looked up*, and #626's new tests drive `getNodeVgpuProfilesMap`,
which this PR leaves in the seam list.

Not covered: the SR-IOV path was not re-verified in this pass, as it never went
through the removed lookup — its lookup was already direct and this diff does
not touch it.

Known blind spot, inherited rather than introduced: a vGPU type absent from
hex's profile list is now reported without an alias and without degrading, which
is deliberate (it matches how the SR-IOV path has always behaved). What that
leaves uncovered is a *silently* empty profile map. `gpu_vgpu_profile_list`
redirects nvidia-smi's stderr to `/dev/null` and never checks its exit status
(cubecos `sdk_gpu.sh:580`); its only non-zero return is a missing config.json
(`:553`). Measured on cn13 2026-08-10:

```
$ nvidia-smi vgpu -s -v -i <nonexistent GPU>   exit = 6
$ hex_sdk gpu_vgpu_profile_list <same>         exit = 0
                                      stdout = {"sriov":[],"migBacked":[]}
```

So a failed probe reaches the API as a successful empty fetch, and every
attached instance on that card resolves no alias while the card still reports
`degraded: false`. `develop` behaves the same way today — its MIG branch would
be handed the same empty map — so this is not a regression from this PR, but the
fix belongs in `gpu_vgpu_profile_list`, not here.


