### PR TITLE
fix(gpu): report vgpu profiles for cards that support them (#1224)

### DIFF
--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -239,7 +239,24 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 	hexProfilesMap := map[uint32]gpu.VgpuProfileFromHex{}
 	hexProfileCollection := gpu.VgpuProfileCollectionFromHex{}
 
-	if isVgpu(hexGpu) {
+	// Profiles are capability data, not state: hex builds them from nvidia-smi
+	// and never reads the configured type, and a client needs them to switch a
+	// pgpu/unset card into vGPU mode. Gating on the current type alone made that
+	// a dead end - no profiles reported, so nothing to request.
+	//
+	// The current type still counts on its own, as a second chance rather than a
+	// safeguard: supportTypes and the profile list both come from
+	// `nvidia-smi vgpu -s -v`, but from two hex calls made at different moments
+	// (gpu_device_list when the card list was built, gpu_vgpu_profile_list here).
+	// A probe that failed for the first can succeed for the second, so a card
+	// that is demonstrably running vGPU still gets asked.
+	//
+	// It buys no degraded flag. gpu_vgpu_profile_list sends nvidia-smi's stderr
+	// to /dev/null and never checks its exit status, so a failed probe returns
+	// {"sriov":[],"migBacked":[]} with exit 0 and the fetch below sees no error.
+	// Empty profile lists therefore never mean "degraded" - they mean either "no
+	// vGPU types" or "the probe failed", and the two are indistinguishable here.
+	if supportsVgpu(hexGpu) || isVgpu(hexGpu) {
 		var profErr error
 		// Must be the GPU UUID, not the PCI address: gpu_vgpu_profile_list looks
 		// the card up in /etc/cube/cos/gpu/config.json by its `.id` field, which
@@ -359,6 +376,15 @@ func (h *helper) listRemoteGpuCards() ([]gpu.GpuCard, error) {
 
 func isVgpu(hexGpu gpu.GpuFromHex) bool {
 	return isVgpuType(hexGpu.Type)
+}
+
+// supportsVgpu reports whether the card can be put into a vGPU mode, whatever
+// mode it is in now. Use it for capability data (the profile list); use isVgpu
+// for runtime data that only exists while the card actually runs vGPU (attached
+// instances, Openstack server-name resolution).
+func supportsVgpu(hexGpu gpu.GpuFromHex) bool {
+	return isSupportedType(hexGpu.SupportTypes, gpu.ResourceTypeSriovVgpu) ||
+		isSupportedType(hexGpu.SupportTypes, gpu.ResourceTypeMigBackedVgpu)
 }
 
 func isVgpuType(t gpu.ResourceType) bool {

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -222,6 +222,161 @@ func TestListLocalGpuCardsDegradesOnNvidiaSmiFaults(t *testing.T) {
 	})
 }
 
+// A card's vGPU profiles are capability data, not state: they say what the card
+// could be partitioned into, which is exactly what a client needs to switch a
+// pgpu card into vGPU mode. hex agrees - gpu_vgpu_profile_list builds them from
+// `nvidia-smi vgpu -s -v` and never reads the card's configured type - and so
+// does the API contract (docs.yaml's gpu-002 example is a pgpu card reporting
+// sriovVgpu profiles). Gating the fetch on the card's *current* type instead
+// makes the switch impossible: no profiles reported, so nothing to request.
+func TestBuildLocalGpuCardReportsProfilesForVgpuCapablePgpuCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	hexGpu := gpu.GpuFromHex{
+		Id:           "GPU-88888888-8888-8888-8888-888888888888",
+		Name:         "NVIDIA RTX Pro 6000 Blackwell",
+		Type:         gpu.ResourceTypePgpu,
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeSriovVgpu},
+		PciAddress:   "0000:06:00.0",
+		Status:       gpu.GpuStatusIdle,
+		Allocation:   &gpu.AllocationSummary{Current: 0, Total: 1},
+	}
+
+	// Mirrors what hex reports for an SR-IOV-capable card that is not currently
+	// partitioned: the profile comes from nvidia-smi (id, name, vram), while
+	// count/alias come from config.json, which holds no entry for this card yet.
+	// The name is the bare type suffix - sdk_gpu.sh takes `awk '{print $NF}'` of
+	// nvidia-smi's Name line, so "NVIDIA RTX Pro 6000 Blackwell DC-2B" arrives as
+	// "DC-2B". SR-IOV profiles carry no vmCountLimit: their nvidia-smi block has
+	// no `Max Instances` line, and sdk_gpu.sh defaults the field to null.
+	getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+		require.Equal(t, hexGpu.Id, gpuId)
+
+		profile := gpu.VgpuProfileFromHex{
+			Id:           1518,
+			Name:         "DC-2B",
+			VramMiB:      2048,
+			Count:        0,
+			Alias:        nil,
+			VmCountLimit: nil,
+		}
+
+		return map[uint32]gpu.VgpuProfileFromHex{profile.Id: profile},
+			gpu.VgpuProfileCollectionFromHex{Sriov: &[]gpu.VgpuProfileFromHex{profile}},
+			nil
+	}
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
+		ServerNames: map[string]string{},
+		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
+			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 98304},
+		},
+		NvidiaSmiAvailable:     true,
+		VgpuInstancesAvailable: true,
+	})
+
+	require.NoError(t, err)
+	require.False(t, card.Degraded)
+	require.Equal(t, []gpu.VgpuProfile{{
+		Id:         1518,
+		Name:       "DC-2B",
+		VramMiB:    2048,
+		Count:      0,
+		Remaining:  nil,
+		AliasName:  nil,
+		CountLimit: nil,
+	}}, card.Profiles.SriovVgpu)
+	require.Empty(t, card.Profiles.MigBackedVgpu)
+}
+
+// MIG capability counts the same as SR-IOV: an unset card that can only be
+// partitioned MIG-backed still reports the profiles needed to configure it.
+func TestBuildLocalGpuCardReportsProfilesForMigCapableUnsetCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	hexGpu := gpu.GpuFromHex{
+		Id:           "GPU-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Name:         "NVIDIA A100",
+		Type:         gpu.ResourceTypeUnset,
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypeMigBackedVgpu},
+		PciAddress:   "0000:08:00.0",
+		Status:       gpu.GpuStatusUnassigned,
+	}
+
+	// Post-#905 shape: a MIG-backed entry is a vGPU *type*, not a GPU Instance
+	// Profile, so its id is the vGPU type id and its name carries the slice count
+	// ("DC-1-3Q") that MIG_PROFILE_NAME_REGEX keys off. vmCountLimit is the
+	// `Max Instances` line of the same nvidia-smi block; SR-IOV types have none.
+	vmCountLimit := 32
+	getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+		profile := gpu.VgpuProfileFromHex{
+			Id:           1549,
+			Name:         "DC-1-3Q",
+			VramMiB:      3072,
+			Count:        0,
+			Alias:        nil,
+			VmCountLimit: &vmCountLimit,
+		}
+
+		return map[uint32]gpu.VgpuProfileFromHex{profile.Id: profile},
+			gpu.VgpuProfileCollectionFromHex{MigBacked: &[]gpu.VgpuProfileFromHex{profile}},
+			nil
+	}
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
+		ServerNames: map[string]string{},
+		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
+			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 81920},
+		},
+		NvidiaSmiAvailable:     true,
+		VgpuInstancesAvailable: true,
+	})
+
+	require.NoError(t, err)
+	require.False(t, card.Degraded)
+	require.Len(t, card.Profiles.MigBackedVgpu, 1)
+	require.Equal(t, uint32(1549), card.Profiles.MigBackedVgpu[0].Id)
+	require.Equal(t, &vmCountLimit, card.Profiles.MigBackedVgpu[0].CountLimit)
+	require.Empty(t, card.Profiles.SriovVgpu)
+}
+
+// The other side of the gate: a card that supports only pgpu has no vGPU
+// profiles to report, so hex is never asked for them. gpu_vgpu_profile_list is a
+// subprocess spawn per card, and the list path deliberately keeps those off the
+// per-card path (see buildLocalGpuCardOpts).
+func TestBuildLocalGpuCardSkipsProfileFetchForPgpuOnlyCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	hexGpu := gpu.GpuFromHex{
+		Id:           "GPU-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+		Name:         "NVIDIA T4",
+		Type:         gpu.ResourceTypePgpu,
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypePgpu},
+		PciAddress:   "0000:09:00.0",
+		Status:       gpu.GpuStatusIdle,
+		Allocation:   &gpu.AllocationSummary{Current: 0, Total: 1},
+	}
+
+	getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+		t.Errorf("gpu_vgpu_profile_list must not be spawned for a pgpu-only card (gpu %s)", gpuId)
+		return nil, gpu.VgpuProfileCollectionFromHex{}, nil
+	}
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
+		ServerNames: map[string]string{},
+		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
+			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 16384},
+		},
+		NvidiaSmiAvailable:     true,
+		VgpuInstancesAvailable: true,
+	})
+
+	require.NoError(t, err)
+	require.False(t, card.Degraded)
+	require.Empty(t, card.Profiles.SriovVgpu)
+	require.Empty(t, card.Profiles.MigBackedVgpu)
+}
+
 func TestBuildLocalGpuCardVgpuProfiles(t *testing.T) {
 	restoreGpuSeams(t)
 


### PR DESCRIPTION
### What type of PR is this?

Bug fix.

<br/>

### Which issue(s) this PR fixes?

Fixes bigstack-oss/cubecos#1224

<br/>

### What this PR does?

#### QA perspective

A GPU card now reports the vGPU profiles it supports whatever mode it currently sits in. Before this change, a card only reported profiles once it was already running vGPU — which blocked the Edit GPU Resource flow, since a user needs the profile list to pick profiles and counts before the switch.

Repos involved:

| Repo | Role |
|---|---|
| `cube-cos-api` | **Root cause, fixed here.** Dropped the profile data before it reached the response |
| `cube-cos-ui` | **Affected, no change needed.** Its Edit GPU Resource modal renders the SR-IOV and MIG-backed profile tables from this field |
| `cubecos` | **Not at fault.** `hex_sdk` returned the profiles correctly all along |
| `cube-cos-openapi` | **Contract, unchanged.** Already documents the fixed behavior |

What to check after this lands:

- [ ] Every card whose `supportResourceTypes` include `sriovVgpu` reports a non-empty `profiles.sriovVgpu`, whatever its `resourceType`.
- [ ] Every card whose `supportResourceTypes` include `migBackedVgpu` reports a non-empty `profiles.migBackedVgpu`, whatever its `resourceType`.
- [ ] Every card whose `supportResourceTypes` are `["pgpu"]` alone reports both profile lists empty.
- [ ] Profile lists match `hex_sdk gpu_vgpu_profile_list <gpu-id>` on that node, entry for entry.
- [ ] Edit GPU Resource on a pGPU or unset card that supports vGPU lists selectable profiles, and the switch completes end to end.

Empty profile lists do **not** raise `degraded`. `hex_sdk gpu_vgpu_profile_list` returns `{"sriov":[],"migBacked":[]}` with exit 0 when its `nvidia-smi` probe fails, so the API cannot tell "this card has no vGPU types" from "the probe failed". A card that reports empty lists against non-`pgpu` supported types is a hex-side probe question — run `hex_sdk gpu_vgpu_profile_list <gpu-id>` on that node and compare.

#### Developer perspective

`buildLocalGpuCard` gated the `hex_sdk gpu_vgpu_profile_list` call on `isVgpu(hexGpu)` — the card's current resource type — so a card at `pgpu` or `unset` never reached the fetch and `toProfileCollection` received an empty collection.

Three sources agree the current type is the wrong key:

| Source | What it says |
|---|---|
| `cubecos` `sdk_gpu.sh` → `gpu_vgpu_profile_list` | Builds both lists from `nvidia-smi vgpu -s -v` (post-#905; `mig -lgip` is gone). Never reads the configured type — `config.json` only supplies `count` and `alias` |
| `cubecos` `sdk_gpu.sh` → `gpu_device_list` | Derives `supportTypes` from the same probe, so profiles and `supportTypes` agree by construction |
| `cube-cos-openapi` `docs.yaml` | The `gpu-002` example is a `resourceType: pgpu` card carrying two `profiles.sriovVgpu` entries |

`updateLocalGpuCard` already keyed the same fetch off the **requested** type. The list path was the odd one out.

The fetch now runs when the card supports a vGPU type, **or** when it currently runs one:

```go
if supportsVgpu(hexGpu) || isVgpu(hexGpu) {
```

`supportsVgpu` alone fixes the bug. The `|| isVgpu` arm is kept as a **second chance, not a safeguard** — an earlier draft of this description claimed it forces `degraded: true` on a failed probe. It does not, and @SekiXu measured why on cn13:

```
$ nvidia-smi vgpu -s -v -i <nonexistent GPU>   exit = 6
$ hex_sdk gpu_vgpu_profile_list <same>         exit = 0
                                      stdout = {"sriov":[],"migBacked":[]}
```

`gpu_vgpu_profile_list` puts `2>/dev/null` on `nvidia-smi` and never checks its exit status; its only non-zero return is a missing `config.json`. `getNodeVgpuProfileCollection` errors only on a non-zero exit, so `enrichment.degrade` never fires on a probe failure.

What the arm does buy: `supportTypes` and the profile list come from the same `nvidia-smi vgpu -s -v` probe, but from **two hex calls made at different moments** — `gpu_device_list` when the card list was built, `gpu_vgpu_profile_list` on this call. A probe that failed for the first can succeed for the second, so a card that is demonstrably running vGPU still gets asked. Three cases:

| supportTypes has vGPU | current type is vGPU | Situation | `isVgpu` only (the bug) | `supportsVgpu` \|\| `isVgpu` |
|---|---|---|---|---|
| yes | no | **Card is pgpu/unset but vGPU-capable** | **skip — no profiles** | fetch |
| no | yes | Card runs vGPU, list-time probe failed | fetch | fetch — real profiles if the probe recovered, else `[]` |
| no | no | pgpu-only card | skip | skip |

Row 1 is this bug. Row 2 is the case the extra arm covers; when the probe is still down, both arms report `[]` with `degraded: false`, and nothing downstream can tell that from a genuine pgpu-only card. Making empty profiles observable needs a hex-side change — `gpu_vgpu_profile_list` propagating its `nvidia-smi` exit status — which belongs in `cubecos`, not here.

Cards that support only `pgpu` still skip the fetch — `gpu_vgpu_profile_list` is a subprocess spawn, and the list path deliberately keeps those off the per-card path.

```mermaid
flowchart TD
    A["hex card"] --> B{"supportTypes<br/>include a vGPU type?"}
    B -->|yes| F["fetch gpu_vgpu_profile_list"]
    B -->|no| C{"current type<br/>is a vGPU type?"}
    C -->|"yes — list-time probe failed,<br/>card is running vGPU"| F
    C -->|no| D["skip: pgpu-only card,<br/>no subprocess spawn"]
    F --> G["profiles reported<br/>(empty if the probe is still down —<br/>hex reports exit 0 either way)"]
```

<br/>

### Test results (optional)

1). make sure the api docs have been updated

No spec change. `docs.yaml` already documents this behavior via the `gpu-002` example; the code now matches the contract it was published against.

2). make sure the api works properly

**Reproduced on cn13 before the fix.** Four RTX PRO 6000 Blackwell cards, three at `type: unset`:

| GPU | resourceType | supportResourceTypes | API sriov / mig | hex has |
|---|---|---|---|---|
| `GPU-29f1b0ad…` | unset | pgpu, sriovVgpu, migBackedVgpu | 0 / 0 | 29 / 11 |
| `GPU-a3bb3767…` | unset | pgpu, sriovVgpu, migBackedVgpu | 0 / 0 | 29 / 11 |
| `GPU-171566b8…` | unset | pgpu, sriovVgpu, migBackedVgpu | 0 / 0 | 29 / 11 |
| `GPU-0a5ba9ad…` | pgpu | pgpu | 0 / 0 | 0 (vfio-bound, correct) |

Every card reported `degraded: false` — the response looked complete while the profile data was dropped.

`hex_sdk gpu_vgpu_profile_list GPU-29f1b0ad-ada5-c5fb-ac9c-8d8832d6741b` on that node:

```json
sriov[0]:     {"id":1518,"name":"DC-2B","vramMiB":2048,"vmCountLimit":null,"count":0,"alias":null}
migBacked[0]: {"id":14,"name":"MIG 1g.24gb","vramMiB":23674.88,"vmCountLimit":4,"count":0,"alias":null}
```

That `migBacked` entry is the **pre-#905** GPU-Instance-Profile shape — the node still ran an older `sdk_gpu.sh` when this was captured. On current `cubecos` `develop` the same call returns vGPU types: `{"id":1549,"name":"DC-1-3Q","vramMiB":3072,"vmCountLimit":32}`. Neither shape changes what this PR does — the API forwards whatever hex returns — but the unit-test fixtures now carry the current one.

**Unit tests** — written first, watched fail, then fixed:

| Test | Covers |
|---|---|
| `TestBuildLocalGpuCardReportsProfilesForVgpuCapablePgpuCard` | SR-IOV-capable card at `pgpu` reports its profiles (the reported bug) |
| `TestBuildLocalGpuCardReportsProfilesForMigCapableUnsetCard` | MIG-only capability counts the same |
| `TestBuildLocalGpuCardSkipsProfileFetchForPgpuOnlyCard` | pgpu-only card never spawns the subprocess |

Fixtures match what hex returns on current `cubecos` `develop`: bare type names (`DC-2B`, `DC-1-3Q` — `sdk_gpu.sh` takes `awk '{print $NF}'` of the `Name` line), vGPU type ids, and `vmCountLimit` from the `Max Instances` line, which SR-IOV types do not have.

Existing tests stayed untouched: their fixtures carry `Type: sriovVgpu` with no `SupportTypes`, which is exactly the inconsistent-probe case the `|| isVgpu` arm covers.

Both realistic mutations were verified to fail the suite:

- gate replaced with `if true` → `TestBuildLocalGpuCardSkipsProfileFetchForPgpuOnlyCard` fails
- `supportsVgpu` dropping the MIG check → `TestBuildLocalGpuCardReportsProfilesForMigCapableUnsetCard` fails

`GOWORK=off go build ./...`, `go vet ./...`, and `CGO_ENABLED=1 GOWORK=off go test ./...` all exit 0.

