### PR TITLE
chore: hand code ownership to raven and the back-end team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jdjgya @traviswu-bigstack
+* @raven-pan @bigstack-oss/back-end


### PR DESCRIPTION
### What type of PR is this?

chore — repository housekeeping. No production code, no API surface change.

<br/>

### Which issue(s) this PR fixes?

None. Housekeeping-only change to `.github/CODEOWNERS`; no ticket was opened.

Companion to bigstack-oss/bigstack-dependency-go#85, which adds the same ownership line to the shared Go library. Same rule, same two owners — reviewing one covers both. They can merge independently; neither blocks the other.

<br/>

### What this PR does?

Hands code ownership of the whole repo to `@raven-pan` plus the `@bigstack-oss/back-end` team.

```diff
-* @jdjgya @traviswu-bigstack
+* @raven-pan @bigstack-oss/back-end
```

| Owner | Before | After |
|---|---|---|
| `@jdjgya` | Owner | Removed |
| `@traviswu-bigstack` | Owner | Removed |
| `@raven-pan` | — | Owner |
| `@bigstack-oss/back-end` | — | Owner (team) |

**Developer view**

- Single line changed in `.github/CODEOWNERS:1`.
- The `*` rule keeps two entries, so every PR still lands on two owners — one person and one team.
- Swapping the second individual for a team means review coverage no longer depends on one person being available.
- GitHub auto-requests review from `@raven-pan` and from the team on every new PR against this repo. Neither `@jdjgya` nor `@traviswu-bigstack` gets auto-requested anymore.
- Both owners resolve: `@raven-pan` verified via `gh api users/raven-pan`, and `@bigstack-oss/back-end` returns 204 on `gh api orgs/bigstack-oss/teams/back-end/repos/bigstack-oss/cube-cos-api`, so the team already has access to this repo — no "unknown owner" warning.

**QA view**

- Nothing ships to a node. No RPM, no binary, no API endpoint, no config file on the target system changes.
- The only observable effect is inside GitHub: who gets pulled into review on `bigstack-oss/cube-cos-api` pull requests.
- No dependency on `cubecos`, `cube-cos-ui`, or `cube-cos-openapi`.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

Not applicable — `api/cube-cos-openapi` submodule and `api/docs.json` are untouched.

<br/>

2). make sure the api works properly

Not applicable — no Go source changed, so the built binary is byte-identical apart from the commit stamp.

**Repeatable check list**

| # | Step | Expectation |
|---|---|---|
| 1 | Open any new PR against `develop` in this repo | Review is auto-requested from `@raven-pan` and `@bigstack-oss/back-end` |
| 2 | Check the same PR's reviewer list | Neither `@jdjgya` nor `@traviswu-bigstack` is auto-requested |
| 3 | Check the GitHub "Code owners" banner on that PR | No "unknown owner" or unresolvable-handle warning |
| 4 | Open `.github/CODEOWNERS` on `develop` after merge | Line reads `* @raven-pan @bigstack-oss/back-end` |
| 5 | Have a `@bigstack-oss/back-end` member approve a PR | The code-owner review requirement is satisfied |

