### PR TITLE
fix(gpu): send Nova microversion 2.6 for instance consoles (#1250)

### DIFF
--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -19,6 +19,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// remoteConsoleMicroversion is the first Nova microversion that serves
+// POST /servers/{id}/remote-consoles.
+const remoteConsoleMicroversion = "2.6"
+
 // Seams for unit tests: hex_sdk CLI, nvidia-smi, and Openstack are
 // unavailable there.
 var (
@@ -637,12 +641,17 @@ func (h *helper) getGpuInstanceConsole() (*gpu.InstanceConsole, error) {
 }
 
 func createConsoleViaOpenstack(vmId string) (*remoteconsoles.RemoteConsole, error) {
-	openstackHelper := openstack.GetGlobalHelper()
+	// Nova only routes POST /servers/{id}/remote-consoles from microversion 2.6.
+	// The shared compute client sends no microversion header, so Nova falls back
+	// to 2.1 and answers 404. Copy the client and raise the microversion here
+	// instead of mutating the shared one, which every other caller reads.
+	compute := *openstack.GetGlobalHelper().Compute
+	compute.Microversion = remoteConsoleMicroversion
 
 	ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
 	defer cancel()
 
-	result := remoteconsoles.Create(ctx, openstackHelper.Compute, vmId, remoteconsoles.CreateOpts{
+	result := remoteconsoles.Create(ctx, &compute, vmId, remoteconsoles.CreateOpts{
 		Protocol: remoteconsoles.ConsoleProtocolVNC,
 		Type:     remoteconsoles.ConsoleTypeNoVNC,
 	})

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -239,7 +239,24 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 	hexProfilesMap := map[uint32]gpu.VgpuProfileFromHex{}
 	hexProfileCollection := gpu.VgpuProfileCollectionFromHex{}
 
-	if isVgpu(hexGpu) {
+	// Profiles are capability data, not state: hex builds them from nvidia-smi
+	// and never reads the configured type, and a client needs them to switch a
+	// pgpu/unset card into vGPU mode. Gating on the current type alone made that
+	// a dead end - no profiles reported, so nothing to request.
+	//
+	// The current type still counts on its own, as a second chance rather than a
+	// safeguard: supportTypes and the profile list both come from
+	// `nvidia-smi vgpu -s -v`, but from two hex calls made at different moments
+	// (gpu_device_list when the card list was built, gpu_vgpu_profile_list here).
+	// A probe that failed for the first can succeed for the second, so a card
+	// that is demonstrably running vGPU still gets asked.
+	//
+	// It buys no degraded flag. gpu_vgpu_profile_list sends nvidia-smi's stderr
+	// to /dev/null and never checks its exit status, so a failed probe returns
+	// {"sriov":[],"migBacked":[]} with exit 0 and the fetch below sees no error.
+	// Empty profile lists therefore never mean "degraded" - they mean either "no
+	// vGPU types" or "the probe failed", and the two are indistinguishable here.
+	if supportsVgpu(hexGpu) || isVgpu(hexGpu) {
 		var profErr error
 		// Must be the GPU UUID, not the PCI address: gpu_vgpu_profile_list looks
 		// the card up in /etc/cube/cos/gpu/config.json by its `.id` field, which
@@ -359,6 +376,15 @@ func (h *helper) listRemoteGpuCards() ([]gpu.GpuCard, error) {
 
 func isVgpu(hexGpu gpu.GpuFromHex) bool {
 	return isVgpuType(hexGpu.Type)
+}
+
+// supportsVgpu reports whether the card can be put into a vGPU mode, whatever
+// mode it is in now. Use it for capability data (the profile list); use isVgpu
+// for runtime data that only exists while the card actually runs vGPU (attached
+// instances, Openstack server-name resolution).
+func supportsVgpu(hexGpu gpu.GpuFromHex) bool {
+	return isSupportedType(hexGpu.SupportTypes, gpu.ResourceTypeSriovVgpu) ||
+		isSupportedType(hexGpu.SupportTypes, gpu.ResourceTypeMigBackedVgpu)
 }
 
 func isVgpuType(t gpu.ResourceType) bool {

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -222,6 +222,161 @@ func TestListLocalGpuCardsDegradesOnNvidiaSmiFaults(t *testing.T) {
 	})
 }
 
+// A card's vGPU profiles are capability data, not state: they say what the card
+// could be partitioned into, which is exactly what a client needs to switch a
+// pgpu card into vGPU mode. hex agrees - gpu_vgpu_profile_list builds them from
+// `nvidia-smi vgpu -s -v` and never reads the card's configured type - and so
+// does the API contract (docs.yaml's gpu-002 example is a pgpu card reporting
+// sriovVgpu profiles). Gating the fetch on the card's *current* type instead
+// makes the switch impossible: no profiles reported, so nothing to request.
+func TestBuildLocalGpuCardReportsProfilesForVgpuCapablePgpuCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	hexGpu := gpu.GpuFromHex{
+		Id:           "GPU-88888888-8888-8888-8888-888888888888",
+		Name:         "NVIDIA RTX Pro 6000 Blackwell",
+		Type:         gpu.ResourceTypePgpu,
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeSriovVgpu},
+		PciAddress:   "0000:06:00.0",
+		Status:       gpu.GpuStatusIdle,
+		Allocation:   &gpu.AllocationSummary{Current: 0, Total: 1},
+	}
+
+	// Mirrors what hex reports for an SR-IOV-capable card that is not currently
+	// partitioned: the profile comes from nvidia-smi (id, name, vram), while
+	// count/alias come from config.json, which holds no entry for this card yet.
+	// The name is the bare type suffix - sdk_gpu.sh takes `awk '{print $NF}'` of
+	// nvidia-smi's Name line, so "NVIDIA RTX Pro 6000 Blackwell DC-2B" arrives as
+	// "DC-2B". SR-IOV profiles carry no vmCountLimit: their nvidia-smi block has
+	// no `Max Instances` line, and sdk_gpu.sh defaults the field to null.
+	getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+		require.Equal(t, hexGpu.Id, gpuId)
+
+		profile := gpu.VgpuProfileFromHex{
+			Id:           1518,
+			Name:         "DC-2B",
+			VramMiB:      2048,
+			Count:        0,
+			Alias:        nil,
+			VmCountLimit: nil,
+		}
+
+		return map[uint32]gpu.VgpuProfileFromHex{profile.Id: profile},
+			gpu.VgpuProfileCollectionFromHex{Sriov: &[]gpu.VgpuProfileFromHex{profile}},
+			nil
+	}
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
+		ServerNames: map[string]string{},
+		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
+			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 98304},
+		},
+		NvidiaSmiAvailable:     true,
+		VgpuInstancesAvailable: true,
+	})
+
+	require.NoError(t, err)
+	require.False(t, card.Degraded)
+	require.Equal(t, []gpu.VgpuProfile{{
+		Id:         1518,
+		Name:       "DC-2B",
+		VramMiB:    2048,
+		Count:      0,
+		Remaining:  nil,
+		AliasName:  nil,
+		CountLimit: nil,
+	}}, card.Profiles.SriovVgpu)
+	require.Empty(t, card.Profiles.MigBackedVgpu)
+}
+
+// MIG capability counts the same as SR-IOV: an unset card that can only be
+// partitioned MIG-backed still reports the profiles needed to configure it.
+func TestBuildLocalGpuCardReportsProfilesForMigCapableUnsetCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	hexGpu := gpu.GpuFromHex{
+		Id:           "GPU-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Name:         "NVIDIA A100",
+		Type:         gpu.ResourceTypeUnset,
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypeMigBackedVgpu},
+		PciAddress:   "0000:08:00.0",
+		Status:       gpu.GpuStatusUnassigned,
+	}
+
+	// Post-#905 shape: a MIG-backed entry is a vGPU *type*, not a GPU Instance
+	// Profile, so its id is the vGPU type id and its name carries the slice count
+	// ("DC-1-3Q") that MIG_PROFILE_NAME_REGEX keys off. vmCountLimit is the
+	// `Max Instances` line of the same nvidia-smi block; SR-IOV types have none.
+	vmCountLimit := 32
+	getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+		profile := gpu.VgpuProfileFromHex{
+			Id:           1549,
+			Name:         "DC-1-3Q",
+			VramMiB:      3072,
+			Count:        0,
+			Alias:        nil,
+			VmCountLimit: &vmCountLimit,
+		}
+
+		return map[uint32]gpu.VgpuProfileFromHex{profile.Id: profile},
+			gpu.VgpuProfileCollectionFromHex{MigBacked: &[]gpu.VgpuProfileFromHex{profile}},
+			nil
+	}
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
+		ServerNames: map[string]string{},
+		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
+			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 81920},
+		},
+		NvidiaSmiAvailable:     true,
+		VgpuInstancesAvailable: true,
+	})
+
+	require.NoError(t, err)
+	require.False(t, card.Degraded)
+	require.Len(t, card.Profiles.MigBackedVgpu, 1)
+	require.Equal(t, uint32(1549), card.Profiles.MigBackedVgpu[0].Id)
+	require.Equal(t, &vmCountLimit, card.Profiles.MigBackedVgpu[0].CountLimit)
+	require.Empty(t, card.Profiles.SriovVgpu)
+}
+
+// The other side of the gate: a card that supports only pgpu has no vGPU
+// profiles to report, so hex is never asked for them. gpu_vgpu_profile_list is a
+// subprocess spawn per card, and the list path deliberately keeps those off the
+// per-card path (see buildLocalGpuCardOpts).
+func TestBuildLocalGpuCardSkipsProfileFetchForPgpuOnlyCard(t *testing.T) {
+	restoreGpuSeams(t)
+
+	hexGpu := gpu.GpuFromHex{
+		Id:           "GPU-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+		Name:         "NVIDIA T4",
+		Type:         gpu.ResourceTypePgpu,
+		SupportTypes: []gpu.SupportResourceType{gpu.SupportResourceTypePgpu},
+		PciAddress:   "0000:09:00.0",
+		Status:       gpu.GpuStatusIdle,
+		Allocation:   &gpu.AllocationSummary{Current: 0, Total: 1},
+	}
+
+	getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+		t.Errorf("gpu_vgpu_profile_list must not be spawned for a pgpu-only card (gpu %s)", gpuId)
+		return nil, gpu.VgpuProfileCollectionFromHex{}, nil
+	}
+
+	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
+		ServerNames: map[string]string{},
+		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
+			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 16384},
+		},
+		NvidiaSmiAvailable:     true,
+		VgpuInstancesAvailable: true,
+	})
+
+	require.NoError(t, err)
+	require.False(t, card.Degraded)
+	require.Empty(t, card.Profiles.SriovVgpu)
+	require.Empty(t, card.Profiles.MigBackedVgpu)
+}
+
 func TestBuildLocalGpuCardVgpuProfiles(t *testing.T) {
 	restoreGpuSeams(t)
 


### PR DESCRIPTION
### What type of PR is this?

Bug fix.

<br/>

### Which issue(s) this PR fixes?

Fixes bigstack-oss/cubecos#1250

Companion PR: [bigstack-oss/bigstack-handbook#243](https://github.com/bigstack-oss/bigstack-handbook/pull/243) — the known-issue entry and the Topic edit that record this behavior for the team.

<br/>

### What this PR does?

#### QA perspective

The GPU instance console endpoint always failed with HTTP 500, on every instance and every node. The error text said the instance was not found, even when the instance was running.

```json
{"code": 500, "msg": "... but got 404 instead: {\"itemNotFound\": {\"code\": 404, \"message\": \"The resource could not be found.\"}}"}
```

Nova can serve that console. The API asked for a route that exists only in a newer Nova API version, so Nova had no route to match and answered 404. The API now sends `OpenStack-API-Version: compute 2.6` on the console request, and only on that request.

| Repo | Role |
|---|---|
| `cube-cos-api` | **Root cause and fix.** |
| `cube-cos-ui` | **Affected.** The GPU instance console button now opens a console instead of showing a 500 |
| `cubecos` | **Not at fault.** Nova served the console correctly all along |
| `cube-cos-openapi` | **Contract unchanged.** The spec already documents a 200 with a console link |

Check list:

| # | Command / steps | Expected outcome |
|---|---|---|
| 1 | `curl -k https://<node-ip>/api/v1/datacenters/<dc>/nodes/<node>/gpuCards/instances/<instance-id>/console` for a running GPU-attached instance | HTTP 200. Body carries `data.console` holding a `https://…:6080/vnc_auto.html?path=%3Ftoken%3D…` URL |
| 2 | Open that URL in a browser | The console loads and accepts keyboard input |
| 3 | In the UI, open a GPU-attached instance console from the GPU cards view | The console opens. No 500 banner |
| 4 | Call the same endpoint with an instance id that does not exist | Still an error, and the message reads `Instance <uuid> could not be found.` — not `The resource could not be found.` |
| 5 | `GET /api/v1/datacenters/<dc>/nodes/<node>/gpuCards` right after step 1 | HTTP 200, card list unchanged. Proves the version bump did not leak into other Nova calls |

#### Developer perspective

`createConsoleViaOpenstack` (`internal/apis/v1/handlers/nodes/gpu.go:639`) called `remoteconsoles.Create` with the shared client from `openstack.GetGlobalHelper().Compute`.

That client carries no microversion. `newComputeCli` in `bigstack-dependency-go` (`pkg/openstack/v2/openstack.go:352`) builds it from `EndpointOpts` alone, so `ServiceClient.Microversion` stays empty, gophercloud sends no `OpenStack-API-Version` header, and Nova defaults to 2.1.

`POST /servers/{id}/remote-consoles` first appears in Nova microversion 2.6. Below 2.6 the route is not registered, so the request never reached a server lookup — the router missed and returned a generic `itemNotFound`. gophercloud states the same requirement in `openstack/compute/v2/remoteconsoles/doc.go:4`.

The fix copies the shared client and raises the microversion on the copy:

```go
compute := *openstack.GetGlobalHelper().Compute
compute.Microversion = remoteConsoleMicroversion
```

Mutating the shared client would work for this endpoint and change every other Nova call in the process. Nova microversions gate response fields as well as routes, so a global bump can alter payloads that other handlers already parse. The copy keeps the blast radius at one call.

Two different 404s share one status code:

| Nova message | Meaning |
|---|---|
| `The resource could not be found.` | The route does not exist — microversion too low. This bug |
| `Instance <uuid> could not be found.` | The instance is really absent, or outside the token's project |

Present since `ca700dea refactor(gpu): harden GPU node API and NVML runtime lifecycle`, which added the console call. The endpoint has never worked.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

`task check` runs clean. `api/docs.json` is unchanged — this PR changes no endpoint shape.

<br/>

2). make sure the api works properly

Measured on cn13 against Nova directly. Same request, same token, only the version header differs:

| Microversion sent | Nova reply |
|---|---|
| none (2.1) | `{"itemNotFound": {"code": 404, "message": "The resource could not be found."}}` |
| 2.6 | `{"remote_console": {"protocol": "vnc", "type": "novnc", "url": "https://10.231.0.13:6080/vnc_auto.html?path=%3Ftoken%3D…"}}` |

`go build ./...`, `go vet ./...`, and `go test ./internal/apis/v1/handlers/nodes/` all pass.

**Not yet verified:** the built binary calling Nova end to end. The unit tests stub `createConsole`, so no test covers this path. Verify with check list step 1 on a node running this build.

<br/>

3). handbook knowledge update (issue DoD)

Landed in [bigstack-oss/bigstack-handbook#243](https://github.com/bigstack-oss/bigstack-handbook/pull/243):

- New known-issue `kb/cubecos/known-issues/nova-remote-console-microversion-404.md` — how to tell the two Nova 404s apart, the CLI workaround, and why the microversion goes on a client copy rather than the shared client
- `kb/cubecos/architecture/gpu-card-apis.md` — the console section now states the 2.6 prerequisite, and both files cross-link

The entry lands with `status: open`. Flip it to `fixed-in:<release>` once this PR ships.
