### PR TITLE
fix(ci): clone the openapi submodule over HTTPS in the rpm jail

### DIFF
--- a/build/cube-cos-api-rpm.Dockerfile
+++ b/build/cube-cos-api-rpm.Dockerfile
@@ -9,7 +9,7 @@ RUN wget -q --no-check-certificate https://go.dev/dl/go1.26.5.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.26.5.linux-amd64.tar.gz
 RUN rm go1.26.5.linux-amd64.tar.gz
 
-RUN dnf install -y go-task rpmdevtools gh
+RUN dnf install -y go-task rpmdevtools gh git openssh-clients
 RUN dnf install -y make automake gcc gcc-c++ kernel-devel
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 

--- a/build/cube-cos-api-rpm.Dockerfile
+++ b/build/cube-cos-api-rpm.Dockerfile
@@ -20,6 +20,15 @@ RUN mkdir -p /home/${USER}/workspace
 RUN chown -R ${USER}:${USER} /home/${USER}/workspace
 USER ${USER}
 
+# rpm:prepareTarball runs `git submodule update --init`, and api/cube-cos-openapi is
+# registered with an SSH URL. Multibranch tag jobs read their Jenkinsfile from the tag
+# commit, so every tag cut before the sshagent fix still reaches github.com with no SSH
+# identity and dies on "Permission denied (publickey)". cube-cos-openapi is public, so
+# clone it over HTTPS. Scoped to that one repo, which leaves origin on SSH.
+RUN git config --global \
+    url."https://github.com/bigstack-oss/cube-cos-openapi.git".insteadOf \
+    "git@github.com:bigstack-oss/cube-cos-openapi.git"
+
 ENV GOPATH=/home/${USER}/go
 ENV PATH=${PATH}:/usr/local/go/bin:${GOPATH}/bin
 


### PR DESCRIPTION
### What type of PR is this?

`fix` / `build` — CI infrastructure. No product code changes; the only file touched is `build/cube-cos-api-rpm.Dockerfile`.

<br/>

### Which issue(s) this PR fixes?

Fixes #614

Concretely, it fixes the `cos_api_rpm/v3.1.0-dev-d61d52a` build failure at https://10.32.200.10/job/cos_api_rpm/job/v3.1.0-dev-d61d52a/2/

<br/>

### What this PR does?

**Symptom.** `cos_api_rpm` tag builds die in the `release` stage:

```
task: [rpm:prepareTarball] git submodule update --init
Cloning into '.../api/cube-cos-openapi'...
git@github.com: Permission denied (publickey).
fatal: clone of 'git@github.com:bigstack-oss/cube-cos-openapi.git' into submodule path ... failed
```

**Why 0b555db did not fix it.** 0b555db already declared `GITHUB_SSH_KEY` and wrapped `rpm:build` in `sshagent([GITHUB_SSH_KEY])` on `develop`, and that is the right fix going forward. It cannot repair this build, or any other already-cut tag: multibranch **tag** jobs read their Jenkinsfile from the immutable tag commit, so all 28 existing tags keep the pre-fix pipeline forever.

The Docker image is the only lever that applies retroactively — the Jenkinsfile pins it as `localhost:5000/cube-cos-api-rpm` (i.e. `:latest`), which is resolved at build time rather than at tag time.

**Why the failure looked intermittent.** The configuration that made this work was never tracked anywhere. It was a hand-built overlay image that existed on exactly one of three build hosts:

| host | rpm image | HTTPS rewrite baked in | outcome |
| --- | --- | --- | --- |
| bldsrv-200-11 | 2026-07-22 | no | `v3.1.0-dev-d61d52a` failed here |
| bldsrv-200-14 | 2026-07-23 | yes (untracked overlay) | `v3.1.0-dev-861b147` passed here on 2026-07-23 |
| bldsrv-200-10 | absent | — | `manifest unknown` |

Since `label 'bldsrv_prod'` resolves across all three, whether a tag built at all was a coin flip decided by which node picked up the job.

**The change.** Two commits, both in `build/cube-cos-api-rpm.Dockerfile`:

1. `fix(ci):` bake the HTTPS rewrite for the submodule into the image, so `git submodule update --init` needs no SSH identity. `cube-cos-openapi` is public. The rewrite is scoped to that single repo URL — `origin` stays on SSH, which is what the pipeline's `init` stage sets it to and what `cube-cos-api-binary.Jenkinsfile` needs for pushing tags.
2. `build(rpm-jail):` install `git` and `openssh-clients` explicitly. Neither was ever requested — `/usr/bin/git` and `/usr/bin/ssh-keyscan` were in the image only because `gh` pulled `git-core` and `openssh-clients` in transitively, so a dependency change in `gh` would have broken the pipeline with nothing in this repo to explain it. The `init` stage calls `ssh-keyscan` directly, every rpm task shells out to `git`, and `sshagent` needs `ssh-agent`.

This makes the previously-untracked overlay a tracked, reproducible property of the image. `sshagent` from 0b555db is retained and remains correct — it is what keeps this working if `cube-cos-openapi` ever goes private.

**Considered and rejected:** adding `alwaysPull true` to the Jenkinsfile. It is pinned in the Jenkinsfile so it would not help any existing tag, and on this fleet it converts a stale-cache build into a hard failure on any host whose registry lacks the image. Rebuilding on each host directly achieves the same thing without that risk.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

Not applicable — no API surface change. The `yq -o=json api/cube-cos-openapi/docs.yaml` step in the spec does now run, which it could not before, since the submodule is finally present.

2). make sure the api works properly

Verified in two stages.

**Stage 1 — isolated, before touching any shared state.** On `bldsrv-200-11`, built this Dockerfile under a scratch tag (`cube-cos-api-rpm:sshfix-verify`, never `:latest`) and replayed the failing pipeline inside it against tag `v3.1.0-dev-d61d52a`, deliberately **without** `sshagent` and with no SSH key present — exactly what the pre-fix tag's Jenkinsfile does:

```
Wrote: /home/jenkins/rpmbuild/RPMS/x86_64/cube-cos-api-v3.1.0-1.fc35.d61d52a.x86_64.rpm
-rw-r--r--. 1 jenkins jenkins 22423914 cube-cos-api-v3.1.0-1.fc35.d61d52a.x86_64.rpm
```

Also confirmed `fedora:35` still resolves both new packages, and the rebuilt image reports `openssh-clients-8.7p1-3.fc35` with `git`, `ssh`, `ssh-agent` and `ssh-keyscan` all on `PATH`.

**Stage 2 — the real job.** Rebuilt `:latest` from this Dockerfile on all three bldsrv hosts and re-triggered the failing tag job. **Build #3: SUCCESS in 2m12s**, on `bldsrv_prod_200.11` — the same node that failed build #2:

```
159: Submodule 'api/cube-cos-openapi' (git@github.com:...) registered for path 'api/cube-cos-openapi'
161: Submodule path 'api/cube-cos-openapi': checked out '29a175097ca95227871c931b3c699faac710d1e7'
2344: Wrote: .../cube-cos-api-v3.1.0-1.fc35.d61d52a.x86_64.rpm
```

No `Permission denied (publickey)`. The submodule is still *registered* with the SSH URL — the rewrite happens at clone time, which is the intended mechanism. The rpm reached the GitHub release: `cube-cos-api-v3.1.0-1.fc35.d61d52a.x86_64.rpm`, 22,423,953 bytes.

<br/>

### Fleet state after this PR

Each host's previous `:latest` was backed up and pushed as `localhost:5000/cube-cos-api-rpm:pre-openapi-https-20260812` before being replaced, so rollback is a retag and push. `bldsrv-200-10` now has the rpm image for the first time, closing the `manifest unknown` coin flip.

**Note — one unrelated defect left in place:** `bldsrv-200-14` runs host `jenkins` at uid **1001**, while both Jenkinsfiles force `args '-u 1000:1000'`. Containerized `sh` steps there cannot write the workspace mount and hang until the pipeline timeout. Build #3 landed on 200.11 so this stayed latent, but a future rpm build that lands on 200.14 will hang. That is a host provisioning issue (`setfacl -R -m u:1000:rwx -m d:u:1000:rwx /home/jenkins/workspace`, or renumber `jenkins` to uid 1000), not something this PR can address.
