### PR TITLE
fix(nodes): stop missing metrics from breaking node detail sync (#1258)

### DIFF
--- a/internal/apis/v1/bodies/resp.go
+++ b/internal/apis/v1/bodies/resp.go
@@ -1,6 +1,7 @@
 package bodies
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/firmwares"
@@ -10,6 +11,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/support"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/tunings"
 	"github.com/gin-gonic/gin"
+	log "go-micro.dev/v5/logger"
 )
 
 const (
@@ -72,13 +74,38 @@ type Fixpack struct {
 	Data   fixpacks.Fixpack `json:"data"`
 }
 
+const jsonContentType = "application/json; charset=utf-8"
+
+// The fallback body is encoded here, so the failure path cannot fail again.
+var encodeFailureBody = []byte(
+	`{"code":500,"status":"internal server error","msg":"failed to encode the response body"}`,
+)
+
+// writeJson encodes the body before it touches the wire. c.JSON writes the
+// content type first, and gin only records an encoder failure in c.Errors, so a
+// payload gin cannot encode leaves the client with a 200 and an empty body.
+// Peers read that empty body as a broken JSON document. Encode first, and answer
+// 500 when the payload is not encodable.
+func writeJson(c *gin.Context, code int, resp gin.H) {
+	body, err := json.Marshal(resp)
+	if err != nil {
+		log.Errorf("bodies: failed to encode the %d response body(%v)", code, err)
+		c.Data(http.StatusInternalServerError, jsonContentType, encodeFailureBody)
+		c.Abort()
+		return
+	}
+
+	c.Data(code, jsonContentType, body)
+}
+
 func SetOk(c *gin.Context, msg string, data any) {
 	resp := gin.H{Code: http.StatusOK, Status: "ok", Msg: msg}
 	if data != nil {
 		resp[Data] = data
 	}
 
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusOK,
 		resp,
 	)
@@ -90,14 +117,16 @@ func SetCreated(c *gin.Context, msg string, data any) {
 		resp[Data] = data
 	}
 
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusCreated,
 		resp,
 	)
 }
 
 func SetAccepted(c *gin.Context, msg string) {
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusAccepted,
 		gin.H{
 			Code:   http.StatusAccepted,
@@ -120,14 +149,16 @@ func SetBadRequest(c *gin.Context, err error, data any) {
 		resp[Data] = data
 	}
 
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusBadRequest,
 		resp,
 	)
 }
 
 func SetUnauthorized(c *gin.Context, err error) {
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusUnauthorized,
 		gin.H{
 			Code:   http.StatusUnauthorized,
@@ -138,7 +169,8 @@ func SetUnauthorized(c *gin.Context, err error) {
 }
 
 func SetNotFound(c *gin.Context, err error) {
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusNotFound,
 		gin.H{
 			Code:   http.StatusNotFound,
@@ -149,7 +181,8 @@ func SetNotFound(c *gin.Context, err error) {
 }
 
 func SetConflict(c *gin.Context, err error) {
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusConflict,
 		gin.H{
 			Code:   http.StatusConflict,
@@ -160,7 +193,8 @@ func SetConflict(c *gin.Context, err error) {
 }
 
 func SetTooManyRequests(c *gin.Context, err error) {
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusTooManyRequests,
 		gin.H{
 			Code:   http.StatusTooManyRequests,
@@ -171,7 +205,8 @@ func SetTooManyRequests(c *gin.Context, err error) {
 }
 
 func SetInternalServerError(c *gin.Context, err error) {
-	c.JSON(
+	writeJson(
+		c,
 		http.StatusInternalServerError,
 		gin.H{
 			Code:   http.StatusInternalServerError,

--- a/internal/apis/v1/bodies/resp_test.go
+++ b/internal/apis/v1/bodies/resp_test.go
@@ -1,0 +1,53 @@
+package bodies
+
+import (
+	"encoding/json"
+	osmath "math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	return c, recorder
+}
+
+// A node record that carries NaN cannot be encoded. gin writes the content type
+// before it encodes and only records the failure in c.Errors, so the response
+// reached the client as 200 with an empty body. Every peer then read it as
+// "unexpected end of JSON input".
+func TestSetOkAnswersServerErrorWhenTheBodyCannotEncode(t *testing.T) {
+	c, recorder := newTestContext(t)
+
+	SetOk(c, "fetch node successfully", map[string]float64{"usedPercent": osmath.NaN()})
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.NotEmpty(t, recorder.Body.Bytes(), "the response body is empty")
+
+	body := map[string]any{}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "internal server error", body[Status])
+}
+
+func TestSetOkWritesTheEncodedBody(t *testing.T) {
+	c, recorder := newTestContext(t)
+
+	SetOk(c, "fetch node successfully", map[string]string{"hostname": "cn07"})
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "application/json; charset=utf-8", recorder.Header().Get("Content-Type"))
+
+	body := map[string]any{}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "ok", body[Status])
+	require.Equal(t, map[string]any{"hostname": "cn07"}, body[Data])
+}

--- a/internal/cubecos/metric.go
+++ b/internal/cubecos/metric.go
@@ -244,6 +244,22 @@ func GetDataCenterUsage(hostSummary *HostSummary) (*DataCenterSummary, error) {
 	}, nil
 }
 
+// divide guards every metric ratio against a missing sample set. A zero divisor
+// gives NaN or Inf, json.Marshal rejects both, and gin then answers 200 with an
+// empty body — which breaks every peer that reads the response.
+func divide(dividend, divisor float64) float64 {
+	if divisor == 0 {
+		return 0
+	}
+
+	quotient := dividend / divisor
+	if osmath.IsNaN(quotient) || osmath.IsInf(quotient, 0) {
+		return 0
+	}
+
+	return quotient
+}
+
 func GetHostsCpuAverage(cpuStats []metric.Compute) metric.Compute {
 	totalCores := float64(0)
 	usedCores := float64(0)
@@ -262,9 +278,9 @@ func GetHostsCpuAverage(cpuStats []metric.Compute) metric.Compute {
 	return metric.Compute{
 		TotalCores:  totalCores,
 		UsedCores:   math.RoundDown(usedCores, 4),
-		UsedPercent: math.RoundDown(usedPercent/float64(len(cpuStats)), 4),
+		UsedPercent: math.RoundDown(divide(usedPercent, float64(len(cpuStats))), 4),
 		FreeCores:   math.RoundDown(freeCores, 4),
-		FreePercent: math.RoundDown(freePercent/float64(len(cpuStats)), 4),
+		FreePercent: math.RoundDown(divide(freePercent, float64(len(cpuStats))), 4),
 	}
 }
 
@@ -286,9 +302,9 @@ func GetHostsMemoryAverage(spaceStats []metric.Space) metric.Space {
 	return metric.Space{
 		TotalMiB:    math.RoundDown(totalMiB, 4),
 		UsedMiB:     math.RoundDown(usedMiB, 4),
-		UsedPercent: math.RoundDown(usedPercent/float64(len(spaceStats)), 4),
+		UsedPercent: math.RoundDown(divide(usedPercent, float64(len(spaceStats))), 4),
 		FreeMiB:     math.RoundDown(freeMiB, 4),
-		FreePercent: math.RoundDown(freePercent/float64(len(spaceStats)), 4),
+		FreePercent: math.RoundDown(divide(freePercent, float64(len(spaceStats))), 4),
 	}
 }
 
@@ -371,9 +387,9 @@ func GetHostCpuSummary(hostname string) (*metric.Compute, error) {
 	return &metric.Compute{
 		TotalCores:  float64(runtime.NumCPU()),
 		UsedCores:   math.RoundDown(usedCores, 4),
-		UsedPercent: math.RoundDown(usedCores/totalCores*100, 4),
+		UsedPercent: math.RoundDown(divide(usedCores, totalCores)*100, 4),
 		FreeCores:   math.RoundDown(freeCores, 4),
-		FreePercent: math.RoundDown(freeCores/totalCores*100, 4),
+		FreePercent: math.RoundDown(divide(freeCores, totalCores)*100, 4),
 	}, nil
 }
 
@@ -523,9 +539,20 @@ func GetHostDiskStorageSummary() (*metric.Space, error) {
 		spaceStatistic.FreeMiB = parseDiskFree(record)
 	}
 
-	spaceStatistic.UsedPercent = math.RoundDown(spaceStatistic.UsedMiB/spaceStatistic.TotalMiB*100, 4)
-	spaceStatistic.FreePercent = math.RoundDown(spaceStatistic.FreeMiB/spaceStatistic.TotalMiB*100, 4)
+	if spaceStatistic.TotalMiB == 0 {
+		log.Warnf(
+			"metrics: host %s has no disk metric in the query window, disk usage reports 0",
+			base.Hostname,
+		)
+	}
+
+	setSpaceUsagePercent(spaceStatistic)
 	return spaceStatistic, nil
+}
+
+func setSpaceUsagePercent(space *metric.Space) {
+	space.UsedPercent = math.RoundDown(divide(space.UsedMiB, space.TotalMiB)*100, 4)
+	space.FreePercent = math.RoundDown(divide(space.FreeMiB, space.TotalMiB)*100, 4)
 }
 
 func GetHostsDiskBandwidthHistory(readStmt, writeStmt string) (*metric.StorageTimeSeries, error) {

--- a/internal/cubecos/metric_test.go
+++ b/internal/cubecos/metric_test.go
@@ -1,0 +1,85 @@
+package cubecos
+
+import (
+	"encoding/json"
+	osmath "math"
+	"testing"
+
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/metric"
+	"github.com/stretchr/testify/require"
+)
+
+// A metric gap gives an empty stat slice. The average must stay 0, because
+// json.Marshal rejects NaN and answers with no body at all.
+func TestHostsCpuAverageWithoutStatsStaysZero(t *testing.T) {
+	average := GetHostsCpuAverage([]metric.Compute{})
+
+	require.False(t, osmath.IsNaN(average.UsedPercent), "usedPercent is NaN")
+	require.False(t, osmath.IsNaN(average.FreePercent), "freePercent is NaN")
+	require.Equal(t, float64(0), average.UsedPercent)
+	require.Equal(t, float64(0), average.FreePercent)
+
+	_, err := json.Marshal(average)
+	require.NoError(t, err)
+}
+
+func TestHostsCpuAverageWithStatsKeepsAveraging(t *testing.T) {
+	average := GetHostsCpuAverage([]metric.Compute{
+		{TotalCores: 8, UsedCores: 2, UsedPercent: 25, FreeCores: 6, FreePercent: 75},
+		{TotalCores: 8, UsedCores: 6, UsedPercent: 75, FreeCores: 2, FreePercent: 25},
+	})
+
+	require.Equal(t, float64(16), average.TotalCores)
+	require.Equal(t, float64(8), average.UsedCores)
+	require.Equal(t, float64(50), average.UsedPercent)
+	require.Equal(t, float64(50), average.FreePercent)
+}
+
+func TestHostsMemoryAverageWithoutStatsStaysZero(t *testing.T) {
+	average := GetHostsMemoryAverage([]metric.Space{})
+
+	require.False(t, osmath.IsNaN(average.UsedPercent), "usedPercent is NaN")
+	require.False(t, osmath.IsNaN(average.FreePercent), "freePercent is NaN")
+	require.Equal(t, float64(0), average.UsedPercent)
+	require.Equal(t, float64(0), average.FreePercent)
+
+	_, err := json.Marshal(average)
+	require.NoError(t, err)
+}
+
+// InfluxDB holds no disk row inside the query window, so the sizes stay at 0.
+// Both percent fields must stay 0 as well.
+func TestSpaceUsagePercentWithoutTotalStaysZero(t *testing.T) {
+	space := &metric.Space{}
+
+	setSpaceUsagePercent(space)
+
+	require.False(t, osmath.IsNaN(space.UsedPercent), "usedPercent is NaN")
+	require.False(t, osmath.IsNaN(space.FreePercent), "freePercent is NaN")
+	require.Equal(t, float64(0), space.UsedPercent)
+	require.Equal(t, float64(0), space.FreePercent)
+
+	_, err := json.Marshal(space)
+	require.NoError(t, err)
+}
+
+func TestSpaceUsagePercentWithTotalFillsBothPercents(t *testing.T) {
+	space := &metric.Space{TotalMiB: 1000, UsedMiB: 250, FreeMiB: 750}
+
+	setSpaceUsagePercent(space)
+
+	require.Equal(t, float64(25), space.UsedPercent)
+	require.Equal(t, float64(75), space.FreePercent)
+}
+
+func TestHostsMemoryAverageWithStatsKeepsAveraging(t *testing.T) {
+	average := GetHostsMemoryAverage([]metric.Space{
+		{TotalMiB: 1024, UsedMiB: 256, UsedPercent: 25, FreeMiB: 768, FreePercent: 75},
+		{TotalMiB: 1024, UsedMiB: 768, UsedPercent: 75, FreeMiB: 256, FreePercent: 25},
+	})
+
+	require.Equal(t, float64(2048), average.TotalMiB)
+	require.Equal(t, float64(1024), average.UsedMiB)
+	require.Equal(t, float64(50), average.UsedPercent)
+	require.Equal(t, float64(50), average.FreePercent)
+}

--- a/internal/operators/v1/nodes/sync.go
+++ b/internal/operators/v1/nodes/sync.go
@@ -190,6 +190,18 @@ func (o *Operator) askPeerNode(node nodes.Node) (*nodes.Node, error) {
 		SetHeaders(nodes.GetSecretHeaders()).
 		Get(node.GetNodeUrl())
 	if err != nil {
+		// A peer that cannot encode its own record answers 2xx with a JSON
+		// content type and no body. resty then reports the unmarshal failure,
+		// which says nothing about the peer being at fault.
+		if resp != nil && len(resp.Body()) == 0 {
+			err = fmt.Errorf(
+				"node %s answered %d with an empty body: %w",
+				node.Hostname,
+				resp.StatusCode(),
+				err,
+			)
+		}
+
 		log.Errorf("nodes: failed to get node details %s: %v", node.Hostname, err)
 		return nil, err
 	}

--- a/internal/operators/v1/nodes/sync_test.go
+++ b/internal/operators/v1/nodes/sync_test.go
@@ -1,0 +1,62 @@
+package node
+
+import (
+	oshttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bigstack-oss/bigstack-dependency-go/pkg/http"
+	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/stretchr/testify/require"
+)
+
+func newPeer(t *testing.T, handler oshttp.HandlerFunc) nodes.Node {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	require.NoError(t, http.NewGlobalHelper())
+
+	return nodes.Node{
+		Hostname:   "cn07",
+		DataCenter: "control",
+		Protocol:   "http",
+		Address:    strings.TrimPrefix(server.URL, "http://"),
+	}
+}
+
+// A peer that cannot encode its own record answers 200 with a JSON content type
+// and no body. The error must name that, instead of reporting the unmarshal
+// failure that hides where the fault is.
+func TestAskPeerNodeReportsAnEmptyBody(t *testing.T) {
+	peer := newPeer(t, func(w oshttp.ResponseWriter, r *oshttp.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(oshttp.StatusOK)
+	})
+
+	o := &Operator{}
+	node, err := o.askPeerNode(peer)
+
+	require.Nil(t, node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cn07")
+	require.Contains(t, err.Error(), "empty body")
+}
+
+func TestAskPeerNodeReturnsThePeerRecord(t *testing.T) {
+	peer := newPeer(t, func(w oshttp.ResponseWriter, r *oshttp.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(oshttp.StatusOK)
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"hostname":"cn07","vcpu":{"totalCores":8}}}`))
+	})
+
+	o := &Operator{}
+	node, err := o.askPeerNode(peer)
+
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	require.Equal(t, "cn07", node.Hostname)
+	require.Equal(t, float64(8), node.Vcpu.TotalCores)
+}


### PR DESCRIPTION
### What type of PR is this?

Bug fix.

<br/>

### Which issue(s) this PR fixes?

Fixes bigstack-oss/cubecos#1258

Trigger for the state this PR survives: bigstack-oss/cubecos#1259 (logstash OOM crash-loop stops every telegraf metric from reaching InfluxDB).

Handbook knowledge update for this defect: [bigstack-handbook#271](https://github.com/bigstack-oss/bigstack-handbook/pull/271) — the known-issue entry that records the failure chain and the recognition trick.

<br/>

### What this PR does?

**TLDR** — A metric gap no longer breaks the node API. `0/0` gave `NaN`, `json.Marshal` rejects `NaN`, and the node API then answered `200` with a 0-byte body. Every peer read that as `unexpected end of JSON input`, so node detail sync stopped across the whole cluster.

#### QA view

**Before.** On a cluster whose InfluxDB has no `disk` row in the last hour, every node logs one line per peer, every 30 seconds:

```
ERRO  nodes: failed to get node details cn07: unexpected end of JSON input
```

Peer records keep their fallback values, so `managementIP`, `serialNumber`, `vcpu`, `memory`, `storage`, `uptimeSeconds`, and `status` never update. The UI shows empty or stale fields for every node except the one serving the request.

**After.** Missing metrics report `0`. The node API always answers a complete JSON body, peer sync keeps working, and a node that truly cannot encode a body answers `500` with a message instead of a silent `200`.

**What to check.**

| # | Check | Expected |
|---|---|---|
| 1 | Ask a node for its own record: `curl -H "Node: <me>" -H "Authorization: Bearer $(cat /var/run/cube-cos-api/node_token)" http://<node-ip>:8082/api/v1/datacenters/<dc>/nodes/<same-node>` | `200` with a non-empty body |
| 2 | Read `storage` in that body on a node with no disk metrics | `usedPercent` and `freePercent` are `0`, no `NaN` anywhere |
| 3 | `journalctl -u cube-cos-api --since '10 min ago' \| grep 'unexpected end of JSON input'` on every node | No match |
| 4 | `journalctl -u cube-cos-api \| grep 'no disk metric in the query window'` on a node with no disk metrics | One warning naming the host |
| 5 | UI node list and node detail, control and compute | Serial, vcpu, memory, storage, and uptime are filled for every node |
| 6 | Restore the metric flow, wait 2 minutes, reload | Storage percent matches `df -h /` on each host |

No API shape change, so `api/docs.json` is untouched and the UI needs no update.

#### Developer view

| File | Change |
|---|---|
| `internal/cubecos/metric.go` | New `divide()` returns `0` when the divisor is `0`, or when the quotient is `NaN` or `Inf`. Applied to `GetHostsCpuAverage`, `GetHostsMemoryAverage`, `GetHostCpuSummary`, and `GetHostDiskStorageSummary`. The disk summary also warns when the query window holds no row, and its percent fields moved into `setSpaceUsagePercent()` so they can be tested without InfluxDB. |
| `internal/apis/v1/bodies/resp.go` | New `writeJson()` marshals first, then writes with `c.Data`. `c.JSON` writes the content type before it encodes, and gin 1.12 only pushes an encoder failure into `c.Errors`, so the client used to get `200` with no body and the serving node logged nothing. Every writer in this file now goes through `writeJson()`. |
| `internal/operators/v1/nodes/sync.go` | `askPeerNode` wraps the error when a peer answers with an empty body, so the log names the peer and the empty body instead of only the parse failure. |

Failure chain that the tests now pin:

```mermaid
graph TD
    A["no disk row in the query window"] --> B["divide() returns 0<br/>metric.go"]
    B --> C["node record encodes"]
    C --> D["writeJson marshals first<br/>bodies/resp.go"]
    D --> E["peer gets a complete body"]
    E --> F["node detail sync keeps running"]
    D -->|"payload still not encodable"| G["500 with a message<br/>+ error log on the serving node"]
    G --> H["askPeerNode names the peer<br/>and the empty body"]
```

<br/>

### Test results (optional)

1). make sure the api docs have been updated

`task check` — `generateApiDocs`, `go vet ./...`, and `go mod tidy` all clean. `api/docs.json` did not change, because no endpoint shape changed.

2). make sure the api works properly

New tests, each written before the fix and watched to fail for the right reason:

| Test | Failed before the fix with |
|---|---|
| `TestHostsCpuAverageWithoutStatsStaysZero` | `usedPercent is NaN` |
| `TestHostsMemoryAverageWithoutStatsStaysZero` | `usedPercent is NaN` |
| `TestSpaceUsagePercentWithoutTotalStaysZero` | helper did not exist |
| `TestSetOkAnswersServerErrorWhenTheBodyCannotEncode` | `expected: 500, actual: 200` with an empty body |
| `TestAskPeerNodeReportsAnEmptyBody` | `"unexpected end of JSON input" does not contain "cn07"` |

Guard tests keep the normal paths honest: `TestHostsCpuAverageWithStatsKeepsAveraging`, `TestHostsMemoryAverageWithStatsKeepsAveraging`, `TestSpaceUsagePercentWithTotalFillsBothPercents`, `TestSetOkWritesTheEncodedBody`, `TestAskPeerNodeReturnsThePeerRecord`.

`task test` — every package passes, no failures:

```
ok  github.com/bigstack-oss/cube-cos-api/internal/apis/v1/bodies
ok  github.com/bigstack-oss/cube-cos-api/internal/cubecos
ok  github.com/bigstack-oss/cube-cos-api/internal/operators/v1/nodes
ok  github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/grafana
ok  github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/nodes
ok  github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/supportfiles
ok  github.com/bigstack-oss/cube-cos-api/internal/apis/v1/handlers/triggers
ok  github.com/bigstack-oss/cube-cos-api/internal/definition/v1/gpu
ok  github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes
ok  github.com/bigstack-oss/cube-cos-api/internal/definition/v1/time
```

The bug was reproduced on the 10.231.0.100 cluster before the fix (`200`, `Content-Type: application/json`, `Content-Length: 0` from every node's own record). `TestAskPeerNodeReportsAnEmptyBody` reproduces that same reply with an `httptest` server, so the regression is covered without a cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

