### PR TITLE
feat(tuning): nova.live.resize.* role mapping + skip unsupported tuning specs

### DIFF
--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -97,6 +97,11 @@ const (
 	NovaControlHostVcpu         = "nova.control.host.vcpu"
 	NovaDebugEnabled            = "nova.debug.enabled"
 	NovaGpuType                 = "nova.gpu.type"
+	NovaLiveResizeEnabled       = "nova.live.resize.enabled"
+	NovaLiveResizeFactor        = "nova.live.resize.factor"
+	NovaLiveResizeMaxVcpus      = "nova.live.resize.max.vcpus"
+	NovaLiveResizeMaxMemoryMb   = "nova.live.resize.max.memory.mb"
+	NovaLiveResizeMigrateTmout  = "nova.live.resize.migrate.timeout"
 	NovaOvercommitCpuRatio      = "nova.overcommit.cpu.ratio"
 	NovaOvercommitDiskRatio     = "nova.overcommit.disk.ratio"
 	NovaOvercommitRamRatio      = "nova.overcommit.ram.ratio"
@@ -195,6 +200,18 @@ func setTuningToRoles() {
 	tuningToRoles[NovaControlHostVcpu] = []*nodes.Role{nodes.GetControlConvergeRole(), nodes.GetEdgeCoreRole()}
 	tuningToRoles[NovaDebugEnabled] = nodes.AllRoles
 	tuningToRoles[NovaGpuType] = nodes.ComputeRoles
+	novaLiveResizeRoles := []*nodes.Role{
+		nodes.GetControlRole(),
+		nodes.GetComputeRole(),
+		nodes.GetControlConvergeRole(),
+		nodes.GetEdgeCoreRole(),
+		nodes.GetModeratorRole(),
+	}
+	tuningToRoles[NovaLiveResizeEnabled] = novaLiveResizeRoles
+	tuningToRoles[NovaLiveResizeFactor] = novaLiveResizeRoles
+	tuningToRoles[NovaLiveResizeMaxVcpus] = novaLiveResizeRoles
+	tuningToRoles[NovaLiveResizeMaxMemoryMb] = novaLiveResizeRoles
+	tuningToRoles[NovaLiveResizeMigrateTmout] = novaLiveResizeRoles
 	tuningToRoles[NovaOvercommitCpuRatio] = nodes.AllRoles
 	tuningToRoles[NovaOvercommitDiskRatio] = nodes.AllRoles
 	tuningToRoles[NovaOvercommitRamRatio] = nodes.AllRoles

--- a/internal/cubecos/tuning.go
+++ b/internal/cubecos/tuning.go
@@ -252,10 +252,13 @@ func setTuningSpecs() {
 	}
 
 	for _, rawSpec := range rawSpecs {
-		tunings.SetSpec(
-			rawSpec.Name,
-			convertToTuningSpec(rawSpec),
-		)
+		spec := convertToTuningSpec(rawSpec)
+		if strings.HasPrefix(spec.Limitation.Type, "invalid tuning spec") {
+			log.Warnf("tunings: skip %s: unsupported spec type(%s)", rawSpec.Name, rawSpec.Limitation.Type)
+			continue
+		}
+
+		tunings.SetSpec(rawSpec.Name, spec)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Companion to bigstack-oss/cubecos#1265 (nova live-resize).

- Register the five `nova.live.resize.*` tunings in `tuningToRoles` as AllRoles (nova-api/conductor on control, driver on compute). The unmapped-name fallback already resolves to AllRoles; entries keep the role map a complete inventory.
- fix: the Create Tuning page crashed ("Oops") on every deployment because `tuning_dump` emits pattern specs with limitation type `mix` (`net.if.mtu.*`, sysctl entries, glance/keystone.debug.enabled) that the UI formatter cannot render. Pre-existing bug, reproduced with stock binaries. Skip unsupported spec types at discovery so the API never serves them.

Verified E2E on sky 3cc: UI Create Tuning wizard → factor=8 on all hosts → policy → hex_config apply → nova.conf `[cube]` on all nodes → new instance boots with the 8x ceiling.

#### Which issue(s) this PR fixes

Fixes #633. Part of bigstack-oss/cubecos#1268

#### Special notes for your reviewer

cos-api discovers tuning specs from `hex_sdk tuning_dump` at startup — deployments that add tunings must restart cube-cos-api.

#### Additional documentation

```docs
bigstack-handbook kb/cubecos/blueprints/nova-live-resize.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkeJmP4qdsDpNzyN6hQs25
