### PR TITLE
feat(gpu): report per-card GPU history links on the card listing

### DIFF
--- a/internal/apis/v1/handlers/grafana/links.go
+++ b/internal/apis/v1/handlers/grafana/links.go
@@ -101,21 +101,56 @@ func genStoragesLink() string {
 	)
 }
 
-// panel 50 = GPU Utilization on the device dashboard (UID i-device).
-// Filtered by the hidden $GPU_HOST variable (gpu.host's `host` tag), NOT $HOST.
-func genGpuUtilizationHistoryLink(c *gin.Context) string {
-	return fmt.Sprintf(
-		"https://%s/grafana/d/i-device/device?orgId=1&var-GPU_HOST=%s&from=now-3h&to=now&viewPanel=50",
+// The device dashboard's GPU panel ids, pinned here as deep-link targets:
+// renumbering or reordering them in device.json breaks these links.
+const (
+	deviceGpuUtilizationPanelId = 50
+	deviceGpuVramPanelId        = 51
+)
+
+// deviceGpuHistoryLink builds a device-dashboard deep link (UID i-device) to one
+// GPU history panel.
+//
+// $GPU_HOST is gpu.host's `host` tag, NOT $HOST (which comes from ipmi_sensor and
+// can differ). pciAddress is optional and scopes the chart to a single card via
+// the hidden $GPU_PCIID variable, whose values are gpu.host's `pciid` tag --
+// byte-identical to the pciAddress the GPU listing reports for the same card, so
+// no translation is needed. Passing an empty pciAddress omits the variable
+// entirely rather than sending it empty: it defaults to All, and an empty value
+// would match no card at all.
+func deviceGpuHistoryLink(hostname, pciAddress string, panelId int) string {
+	link := fmt.Sprintf(
+		"https://%s/grafana/d/i-device/device?orgId=1&var-GPU_HOST=%s",
 		base.DataCenterVip,
-		c.Param("hostname"),
+		url.QueryEscape(hostname),
 	)
+	if pciAddress != "" {
+		// A PCI address carries colons, so it has to be escaped to survive as a
+		// query value.
+		link += "&var-GPU_PCIID=" + url.QueryEscape(pciAddress)
+	}
+
+	return fmt.Sprintf("%s&from=now-3h&to=now&viewPanel=%d", link, panelId)
 }
 
-// panel 51 = GPU VRAM Usage on the device dashboard (UID i-device).
+// DeviceGpuUtilizationHistoryLink and DeviceGpuVramHistoryLink are the
+// per-card history links, exported for the GPU listing handler to report inline
+// with each card. The UI offers them from a single GPU's row, so they have to
+// answer for that card rather than for every card on the node.
+func DeviceGpuUtilizationHistoryLink(hostname, pciAddress string) string {
+	return deviceGpuHistoryLink(hostname, pciAddress, deviceGpuUtilizationPanelId)
+}
+
+func DeviceGpuVramHistoryLink(hostname, pciAddress string) string {
+	return deviceGpuHistoryLink(hostname, pciAddress, deviceGpuVramPanelId)
+}
+
+// The node-scoped endpoints keep answering for the whole node: they are handed
+// only a hostname, so they cannot name a card.
+func genGpuUtilizationHistoryLink(c *gin.Context) string {
+	return deviceGpuHistoryLink(c.Param("hostname"), "", deviceGpuUtilizationPanelId)
+}
+
 func genGpuVramHistoryLink(c *gin.Context) string {
-	return fmt.Sprintf(
-		"https://%s/grafana/d/i-device/device?orgId=1&var-GPU_HOST=%s&from=now-3h&to=now&viewPanel=51",
-		base.DataCenterVip,
-		c.Param("hostname"),
-	)
+	return deviceGpuHistoryLink(c.Param("hostname"), "", deviceGpuVramPanelId)
 }

--- a/internal/apis/v1/handlers/grafana/links.go
+++ b/internal/apis/v1/handlers/grafana/links.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/base"
 	"github.com/gin-gonic/gin"
@@ -15,14 +16,49 @@ func genHostLink(c *gin.Context) string {
 	)
 }
 
-// InstanceDashboardLink is the Grafana instance dashboard URL for a VM. It is
-// exported for other handlers (e.g. GPU attached instances) that report links
-// to the same dashboard.
+// InstanceDashboardLink is the Grafana instance dashboard URL for a VM, as
+// served by the generic /grafana/instances/{instanceId} endpoint. That endpoint
+// knows nothing but the id, so the link cannot pin the dashboard's tenant and
+// hostname variables; callers that do know them should use
+// InstanceVgpuDashboardLink instead.
 func InstanceDashboardLink(instanceId string) string {
 	return fmt.Sprintf(
 		"https://%s/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=%s",
 		base.DataCenterVip,
 		instanceId,
+	)
+}
+
+// instanceVgpuMemoryPanelId is the Memory Usage panel in the instance
+// dashboard's vGPU row (dashboard UID PVW6vU7Wz). Pinned here as a deep-link
+// target, so renumbering or reordering that row's panels in instance.json
+// breaks these links -- same cross-team contract as the device dashboard's
+// panels 50 and 51.
+const instanceVgpuMemoryPanelId = 37
+
+// InstanceVgpuDashboardLink is the deep link to one VM's vGPU usage.
+//
+// Pinning var-UUID alone is not enough. UUID is the tail of a
+// TID -> TENANT -> HOSTNAME -> UUID chain of query variables that all refresh on
+// dashboard load, so leaving the first two unset lets them resolve to whatever
+// their query returns first -- in practice the tenant's alphabetically first VM,
+// which then labels the page with a different VM than the one being charted.
+// var-TID is matched against the metrics' tenant_id tag and collapses TENANT to
+// the owning project; var-HOSTNAME pins the picker to this VM.
+//
+// viewPanel is required because the vGPU row ships collapsed: a link to the
+// dashboard alone lands on a page with no GPU chart visible. Memory is the panel
+// to open because it renders for every vGPU flavour, while GPU utilization is
+// empty for a MIG-backed vGPU by design.
+func InstanceVgpuDashboardLink(instanceId, tenantId, vmName string) string {
+	return fmt.Sprintf(
+		"https://%s/grafana/d/PVW6vU7Wz/instance?orgId=1&refresh=5m&var-TID=%s&var-HOSTNAME=%s&var-UUID=%s&from=now-3h&to=now&viewPanel=%d",
+		base.DataCenterVip,
+		url.QueryEscape(tenantId),
+		// A VM name is user-supplied and may contain spaces or '&'.
+		url.QueryEscape(vmName),
+		url.QueryEscape(instanceId),
+		instanceVgpuMemoryPanelId,
 	)
 }
 

--- a/internal/apis/v1/handlers/grafana/links_test.go
+++ b/internal/apis/v1/handlers/grafana/links_test.go
@@ -36,3 +36,28 @@ func TestInstanceVgpuDashboardLinkEscapesValues(t *testing.T) {
 
 	require.Contains(t, link, "var-HOSTNAME=my+vm%26x")
 }
+
+// A link offered from one GPU's row has to name that card, or every row on the
+// node yields the same chart.
+func TestDeviceGpuHistoryLinksPinTheCard(t *testing.T) {
+	util := DeviceGpuUtilizationHistoryLink("cn13", "00000001:04:00.0")
+	vram := DeviceGpuVramHistoryLink("cn13", "00000001:04:00.0")
+
+	for _, link := range []string{util, vram} {
+		require.Contains(t, link, "/grafana/d/i-device/device")
+		require.Contains(t, link, "var-GPU_HOST=cn13")
+		// Colons have to survive as an escaped query value.
+		require.Contains(t, link, "var-GPU_PCIID=00000001%3A04%3A00.0")
+	}
+	require.Contains(t, util, "viewPanel=50")
+	require.Contains(t, vram, "viewPanel=51")
+}
+
+// An empty PCI address must drop the variable rather than send it empty: it
+// defaults to All, while an empty value would match no card at all.
+func TestDeviceGpuHistoryLinkOmitsEmptyCard(t *testing.T) {
+	link := DeviceGpuUtilizationHistoryLink("cn13", "")
+
+	require.Contains(t, link, "var-GPU_HOST=cn13")
+	require.NotContains(t, link, "GPU_PCIID")
+}

--- a/internal/apis/v1/handlers/grafana/links_test.go
+++ b/internal/apis/v1/handlers/grafana/links_test.go
@@ -13,3 +13,26 @@ func TestInstanceDashboardLink(t *testing.T) {
 	require.Contains(t, link, "/grafana/d/PVW6vU7Wz/instance")
 	require.True(t, strings.HasSuffix(link, "var-UUID=vm-1"))
 }
+
+func TestInstanceVgpuDashboardLink(t *testing.T) {
+	link := InstanceVgpuDashboardLink("vm-1", "proj-1", "instance-1")
+
+	require.Contains(t, link, "/grafana/d/PVW6vU7Wz/instance")
+	// Pinning all three is what keeps the page from labelling this VM's chart
+	// with the tenant's alphabetically first VM.
+	require.Contains(t, link, "var-TID=proj-1")
+	require.Contains(t, link, "var-HOSTNAME=instance-1")
+	require.Contains(t, link, "var-UUID=vm-1")
+	// The vGPU row ships collapsed, so the link has to open a panel directly.
+	require.Contains(t, link, "viewPanel=37")
+	// kiosk=tv was removed in Grafana 11; it must not be carried over.
+	require.NotContains(t, link, "kiosk")
+}
+
+// A VM name is user-supplied: unescaped, a space or '&' would truncate or
+// corrupt the variable that follows it.
+func TestInstanceVgpuDashboardLinkEscapesValues(t *testing.T) {
+	link := InstanceVgpuDashboardLink("vm-1", "proj-1", "my vm&x")
+
+	require.Contains(t, link, "var-HOSTNAME=my+vm%26x")
+}

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -671,7 +671,12 @@ func createConsoleViaOpenstack(vmId string) (*remoteconsoles.RemoteConsole, erro
 // getOpenstackServerNamesViaHelper returns a map of server id to name in a single
 // Openstack round trip, used to resolve vGPU attached-instance names in bulk.
 func getOpenstackServerNamesViaHelper() (map[string]string, error) {
-	serverList, err := openstack.GetGlobalHelper().ListServers(servers.ListOpts{})
+	// AllTenants is required: the API authenticates as a single project (admin),
+	// so a plain list returns only that project's servers and a vGPU VM owned by
+	// any other project would come back nameless. The per-instance GetServer this
+	// prefetch replaced was unaffected, because fetching one server by id is not
+	// project-scoped for an admin token.
+	serverList, err := openstack.GetGlobalHelper().ListServers(servers.ListOpts{AllTenants: true})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -32,7 +32,7 @@ var (
 	getNvidiaSmiDevices         = cubecos.GetNvidiaSmiDevices
 	getNvidiaSmiVgpuInstances   = cubecos.GetNvidiaSmiVgpuInstances
 	buildInstanceLinks          = buildInstanceLinksViaOpenstack
-	getOpenstackServerNames     = getOpenstackServerNamesViaHelper
+	getOpenstackServers         = getOpenstackServersViaHelper
 	createConsole               = createConsoleViaOpenstack
 	getNodeGpuById              = cubecos.GetNodeGpuById
 	updateNodeGpuCardViaHex     = cubecos.UpdateNodeGpuCard
@@ -41,13 +41,22 @@ var (
 	deleteUpdatingGpuReq        = deleteUpdatingGpuReqViaMongo
 )
 
+// openstackServer is the per-VM enrichment an attached instance needs from
+// Openstack: its display name, and the project that owns it -- the latter only
+// so the Grafana deep link can pin the dashboard's tenant variable to the right
+// project (see grafana.InstanceVgpuDashboardLink).
+type openstackServer struct {
+	Name     string
+	TenantId string
+}
+
 // buildLocalGpuCardOpts carries data fetched once per listLocalGpuCards
 // request (Openstack server names, nvidia-smi's device and vGPU-instance
 // snapshots) into each card's build. nvidia-smi is a subprocess spawn, not an
 // in-process library call, so it is invoked once per request here rather than
 // once per GPU on the node.
 type buildLocalGpuCardOpts struct {
-	ServerNames map[string]string
+	Servers map[string]openstackServer
 	// NvidiaSmiDevices/NvidiaSmiAvailable come from one `nvidia-smi -q` call.
 	// NvidiaSmiAvailable is false only when that call itself could not be run;
 	// a device simply absent from NvidiaSmiDevices (e.g. vfio-pci passthrough)
@@ -75,12 +84,13 @@ type listAttachedInstancesOpts struct {
 	// VgpuInstances/VgpuInstancesAvailable: see buildLocalGpuCardOpts.
 	VgpuInstances          []cubecos.NvidiaSmiVgpuInstance
 	VgpuInstancesAvailable bool
-	// ServerNames maps Openstack server id to name, prefetched once per request
-	// so vGPU instance names do not cost a GetServer round trip each. A nil map
-	// means the prefetch failed outright, so a name missing for an attached
-	// instance is a real enrichment loss (degrade); a non-nil map that simply
-	// lacks an id means that one VM is absent (soft, reported without a name).
-	ServerNames map[string]string
+	// Servers maps Openstack server id to that VM's name and owning project,
+	// prefetched once per request so an attached instance does not cost a
+	// GetServer round trip each. A nil map means the prefetch failed outright, so
+	// a missing entry is a real enrichment loss (degrade); a non-nil map that
+	// simply lacks an id means that one VM is absent (soft, reported without a
+	// name).
+	Servers map[string]openstackServer
 	// Enrichment accumulates the card's degraded state as attached-instance
 	// enrichment is gathered.
 	Enrichment *enrichment
@@ -121,7 +131,7 @@ func (h *helper) listLocalGpuCards() ([]gpu.GpuCard, error) {
 	// Resolve vGPU instance names in a single Openstack round trip rather than
 	// one GetServer per attached instance. A nil map signals the prefetch failed,
 	// which degrades any vGPU card that has attached instances needing a name.
-	serverNames := h.resolveServerNames(hexGpusMap)
+	serversById := h.resolveServers(hexGpusMap)
 
 	nvidiaSmiDevices, nvidiaSmiErr := getNvidiaSmiDevices()
 	if nvidiaSmiErr != nil {
@@ -142,7 +152,7 @@ func (h *helper) listLocalGpuCards() ([]gpu.GpuCard, error) {
 		hexGpu := hexGpusMap[pciAddress]
 
 		gpuCard, err := h.buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-			ServerNames:            serverNames,
+			Servers:                serversById,
 			NvidiaSmiDevices:       nvidiaSmiDevices,
 			NvidiaSmiAvailable:     nvidiaSmiErr == nil,
 			VgpuInstances:          vgpuInstancesByPci[hexGpu.PciAddress],
@@ -163,34 +173,35 @@ func (h *helper) listLocalGpuCards() ([]gpu.GpuCard, error) {
 	return gpuCards, nil
 }
 
-// resolveServerNames prefetches Openstack server names (id -> name) when the
-// node has any vGPU, whose attached-instance names come from Openstack. On a
-// lookup failure it returns nil (instances reported without a name) rather than
-// failing the listing; the nil map lets callers mark affected cards degraded.
-func (h *helper) resolveServerNames(hexGpusMap map[string]gpu.GpuFromHex) map[string]string {
-	needsServerNames := false
+// resolveServers prefetches the Openstack servers (id -> name + owning project)
+// when the node has any vGPU, whose attached-instance enrichment comes from
+// Openstack. On a lookup failure it returns nil (instances reported without a
+// name) rather than failing the listing; the nil map lets callers mark affected
+// cards degraded.
+func (h *helper) resolveServers(hexGpusMap map[string]gpu.GpuFromHex) map[string]openstackServer {
+	needsServers := false
 	for _, hexGpu := range hexGpusMap {
 		if isVgpu(hexGpu) {
-			needsServerNames = true
+			needsServers = true
 			break
 		}
 	}
-	if !needsServerNames {
-		return map[string]string{}
+	if !needsServers {
+		return map[string]openstackServer{}
 	}
 
-	serverNames, err := getOpenstackServerNames()
+	serversById, err := getOpenstackServers()
 	if err != nil {
 		log.Warnf("gpu(%s): failed to list Openstack servers for name resolution on node %s: %v; reporting instances without names", h.reqId, h.node, err)
 		return nil
 	}
 
-	return serverNames
+	return serversById
 }
 
 // resolveVgpuInstances fetches active vGPU instances once for the whole node
 // when hex reports at least one vGPU-type GPU, skipping the nvidia-smi call
-// entirely on pgpu-only nodes (mirrors resolveServerNames's lazy Openstack
+// entirely on pgpu-only nodes (mirrors resolveServers's lazy Openstack
 // prefetch).
 func (h *helper) resolveVgpuInstances(hexGpusMap map[string]gpu.GpuFromHex) (map[string][]cubecos.NvidiaSmiVgpuInstance, error) {
 	needsVgpu := false
@@ -286,10 +297,10 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 		}
 	}
 
-	// A nil server-name map means the getOpenstackServerNames call failed, so
+	// A nil server map means the getOpenstackServers call failed, so
 	// attached-instance name enrichment is unavailable for the whole node: flag
 	// the card degraded.
-	if opts.ServerNames == nil {
+	if opts.Servers == nil {
 		enr.degrade("gpu: Openstack server prefetch failed on node %s; gpu %s reported without instance names (degraded)", h.node, hexGpu.Id)
 	}
 
@@ -304,7 +315,7 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 		HexProfilesMap:           hexProfilesMap,
 		VgpuInstances:            opts.VgpuInstances,
 		VgpuInstancesAvailable:   opts.VgpuInstancesAvailable,
-		ServerNames:              opts.ServerNames,
+		Servers:                  opts.Servers,
 		Enrichment:               enr,
 	})
 	if err != nil {
@@ -557,7 +568,14 @@ func listPgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedIn
 			AllocatedMiB: deviceMemoryUsedMiB,
 			TotalMiB:     deviceMemoryTotalMiB,
 		},
-		Links: buildInstanceLinks(attachedInstance.Id),
+		// hex supplies a pgpu's instance name, so the prefetched server map is
+		// consulted only for the owning project the Grafana link needs. It is
+		// absent on a pgpu-only node, where the prefetch is skipped entirely.
+		Links: buildInstanceLinks(instanceLinkOpts{
+			InstanceId: attachedInstance.Id,
+			TenantId:   opts.Servers[attachedInstance.Id].TenantId,
+			VmName:     attachedInstance.Name,
+		}),
 	})
 
 	return &attachedInstances
@@ -573,7 +591,7 @@ func listPgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedIn
 // the whole node listing, so a single GPU being reset does not take down the
 // listing for every other card.
 func listVgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedInstance {
-	deviceUUID, hexProfilesMap, serverNames, enr := opts.DeviceUUID, opts.HexProfilesMap, opts.ServerNames, opts.Enrichment
+	deviceUUID, hexProfilesMap, serversById, enr := opts.DeviceUUID, opts.HexProfilesMap, opts.Servers, opts.Enrichment
 
 	attachedInstances := []gpu.AttachedInstance{}
 	if !opts.IsDeviceVisible {
@@ -597,29 +615,40 @@ func listVgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedIn
 		hexProfile := hexProfilesMap[instance.VgpuTypeId]
 		profileAlias := hexProfile.Alias
 
-		// The server name is enrichment resolved from the prefetched map. A missing
-		// name just logs here (the instance is reported without one); a nil map
-		// means the prefetch failed outright, which the caller already flagged as
-		// degraded on the card itself.
-		serverName, ok := serverNames[instance.VmUUID]
+		// The name and owning project are enrichment resolved from the prefetched
+		// map. A missing entry just logs here (the instance is reported without a
+		// name, and its link cannot pin the dashboard's tenant); a nil map means the
+		// prefetch failed outright, which the caller already flagged as degraded on
+		// the card itself.
+		server, ok := serversById[instance.VmUUID]
 		if !ok {
 			log.Warnf("gpu: Openstack server %s not found in prefetched servers; reporting instance without name", instance.VmUUID)
 		}
 
 		attachedInstances = append(attachedInstances, gpu.AttachedInstance{
 			Id:                 instance.VmUUID,
-			Name:               serverName,
+			Name:               server.Name,
 			ProfileAlias:       profileAlias,
 			UtilizationPercent: instance.GpuUtilizationPercent,
 			MemoryUsage: gpu.InstanceMemoryUsage{
 				AllocatedMiB: instance.MemoryUsedMiB,
 				TotalMiB:     instance.MemoryTotalMiB,
 			},
-			Links: buildInstanceLinks(instance.VmUUID),
+			Links: buildInstanceLinks(instanceLinkOpts{InstanceId: instance.VmUUID, TenantId: server.TenantId, VmName: server.Name}),
 		})
 	}
 
 	return &attachedInstances
+}
+
+// instanceLinkOpts is what the Grafana deep link needs about one attached
+// instance. It is a struct rather than positional arguments so that adding a
+// dashboard variable later does not ripple through every call site and test
+// seam.
+type instanceLinkOpts struct {
+	InstanceId string
+	TenantId   string
+	VmName     string
 }
 
 // buildInstanceLinksViaOpenstack builds the links reported inline with each
@@ -628,9 +657,9 @@ func listVgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedIn
 // instance on every GPU-list poll floods Nova with sessions that are almost
 // always discarded. The console is minted on demand via the dedicated
 // getGpuInstanceConsole endpoint instead.
-func buildInstanceLinksViaOpenstack(vmId string) gpu.InstanceLinks {
+func buildInstanceLinksViaOpenstack(opts instanceLinkOpts) gpu.InstanceLinks {
 	return gpu.InstanceLinks{
-		Grafana: grafana.InstanceDashboardLink(vmId),
+		Grafana: grafana.InstanceVgpuDashboardLink(opts.InstanceId, opts.TenantId, opts.VmName),
 	}
 }
 
@@ -668,9 +697,9 @@ func createConsoleViaOpenstack(vmId string) (*remoteconsoles.RemoteConsole, erro
 	return result.Extract()
 }
 
-// getOpenstackServerNamesViaHelper returns a map of server id to name in a single
-// Openstack round trip, used to resolve vGPU attached-instance names in bulk.
-func getOpenstackServerNamesViaHelper() (map[string]string, error) {
+// getOpenstackServersViaHelper returns a map of server id to the enrichment an
+// attached instance needs, in a single Openstack round trip.
+func getOpenstackServersViaHelper() (map[string]openstackServer, error) {
 	// AllTenants is required: the API authenticates as a single project (admin),
 	// so a plain list returns only that project's servers and a vGPU VM owned by
 	// any other project would come back nameless. The per-instance GetServer this
@@ -681,12 +710,13 @@ func getOpenstackServerNamesViaHelper() (map[string]string, error) {
 		return nil, err
 	}
 
-	serverNames := make(map[string]string, len(serverList))
+	// Not named `servers`: that is the gophercloud package used just above.
+	byId := make(map[string]openstackServer, len(serverList))
 	for _, server := range serverList {
-		serverNames[server.ID] = server.Name
+		byId[server.ID] = openstackServer{Name: server.Name, TenantId: server.TenantID}
 	}
 
-	return serverNames, nil
+	return byId, nil
 }
 
 func toProfileCollection(

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -32,6 +32,7 @@ var (
 	getNvidiaSmiDevices         = cubecos.GetNvidiaSmiDevices
 	getNvidiaSmiVgpuInstances   = cubecos.GetNvidiaSmiVgpuInstances
 	buildInstanceLinks          = buildInstanceLinksViaOpenstack
+	buildGpuCardLinks           = buildGpuCardLinksViaGrafana
 	getOpenstackServers         = getOpenstackServersViaHelper
 	createConsole               = createConsoleViaOpenstack
 	getNodeGpuById              = cubecos.GetNodeGpuById
@@ -346,6 +347,7 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 		SriovVgpuProfileCountLimit: hexGpu.SriovVgpuProfileCountLimit,
 		Profiles:                   profileCollection,
 		AttachedInstances:          attachedInstances,
+		Links:                      buildGpuCardLinks(h.node, hexGpu.PciAddress),
 		Degraded:                   enr.degraded,
 	}
 
@@ -639,6 +641,17 @@ func listVgpuAttachedInstances(opts listAttachedInstancesOpts) *[]gpu.AttachedIn
 	}
 
 	return &attachedInstances
+}
+
+// buildGpuCardLinksViaGrafana builds the history links reported inline with each
+// GPU card. Both are pure string building from data already in hand -- the node
+// name and the card's PCI address -- so they cost nothing per card and need no
+// extra endpoint for the UI to call per row.
+func buildGpuCardLinksViaGrafana(hostname, pciAddress string) gpu.GpuCardLinks {
+	return gpu.GpuCardLinks{
+		WorkloadHistory: grafana.DeviceGpuUtilizationHistoryLink(hostname, pciAddress),
+		VramHistory:     grafana.DeviceGpuVramHistoryLink(hostname, pciAddress),
+	}
 }
 
 // instanceLinkOpts is what the Grafana deep link needs about one attached

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -61,11 +61,14 @@ type buildLocalGpuCardOpts struct {
 }
 
 type listAttachedInstancesOpts struct {
-	IsDeviceVisible          bool
-	DeviceUUID               string
-	DeviceMemoryUsedMiB      int
-	DeviceMemoryTotalMiB     int
-	DeviceGpuUtilizationRate uint32
+	IsDeviceVisible bool
+	DeviceUUID      string
+	// The Device* stats are nil when nvidia-smi could not report them; a pgpu's
+	// attached instance is reported with the card's own numbers, so it inherits
+	// their absence rather than substituting a zero.
+	DeviceMemoryUsedMiB      *int
+	DeviceMemoryTotalMiB     *int
+	DeviceGpuUtilizationRate *uint32
 	NodeName                 string
 	HexGpu                   gpu.GpuFromHex
 	HexProfilesMap           map[uint32]gpu.VgpuProfileFromHex
@@ -205,8 +208,12 @@ func (h *helper) resolveVgpuInstances(hexGpusMap map[string]gpu.GpuFromHex) (map
 }
 
 func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCardOpts) (gpu.GpuCard, error) {
-	var memoryUsedMiB, memoryTotalMiB int
-	var memoryUtilizationPercent, gpuUtilizationPercent uint32
+	// All four stay nil unless nvidia-smi actually reported them: an absent
+	// device (pgpu bound to vfio-pci) has no stats, and a MIG-enabled card has
+	// no utilization. nil is reported as JSON null so a consumer can tell
+	// "cannot be measured" from a real 0.
+	var memoryUsedMiB, memoryTotalMiB *int
+	var memoryUtilizationPercent, gpuUtilizationPercent *uint32
 	enr := &enrichment{}
 
 	// Relies on hex reporting the GPU id as nvidia-smi's own UUID.
@@ -217,8 +224,10 @@ func (h *helper) buildLocalGpuCard(hexGpu gpu.GpuFromHex, opts buildLocalGpuCard
 	// stats.
 	switch {
 	case isDeviceVisible:
-		memoryUsedMiB = device.MemoryUsedMiB
-		memoryTotalMiB = device.MemoryTotalMiB
+		// A returned device record always carries both framebuffer numbers;
+		// utilization may still be nil (MIG).
+		usedMiB, totalMiB := device.MemoryUsedMiB, device.MemoryTotalMiB
+		memoryUsedMiB, memoryTotalMiB = &usedMiB, &totalMiB
 		memoryUtilizationPercent = device.MemoryUtilizationPercent
 		gpuUtilizationPercent = device.GpuUtilizationPercent
 	case !opts.NvidiaSmiAvailable:

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -658,9 +658,18 @@ type instanceLinkOpts struct {
 // always discarded. The console is minted on demand via the dedicated
 // getGpuInstanceConsole endpoint instead.
 func buildInstanceLinksViaOpenstack(opts instanceLinkOpts) gpu.InstanceLinks {
-	return gpu.InstanceLinks{
-		Grafana: grafana.InstanceVgpuDashboardLink(opts.InstanceId, opts.TenantId, opts.VmName),
+	// Both variables are required for the link to survive the dashboard's own
+	// variable refresh. A pgpu-only node skips the Openstack prefetch, so the
+	// tenant is unknown there; an instance missing from the prefetch has neither.
+	// Reporting no link beats reporting one that lands on another VM, and a pgpu
+	// has no vGPU series to chart in the first place.
+	if opts.TenantId == "" || opts.VmName == "" {
+		return gpu.InstanceLinks{}
 	}
+
+	link := grafana.InstanceVgpuDashboardLink(opts.InstanceId, opts.TenantId, opts.VmName)
+
+	return gpu.InstanceLinks{Grafana: &link}
 }
 
 // getGpuInstanceConsole mints a Nova console for a single attached instance on

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -24,7 +24,7 @@ func restoreGpuSeams(t *testing.T) {
 	origGetNvidiaSmiDevices := getNvidiaSmiDevices
 	origGetNvidiaSmiVgpuInstances := getNvidiaSmiVgpuInstances
 	origBuildInstanceLinks := buildInstanceLinks
-	origGetOpenstackServerNames := getOpenstackServerNames
+	origGetOpenstackServers := getOpenstackServers
 	origCreateConsole := createConsole
 	origGetNodeGpuById := getNodeGpuById
 	origUpdateNodeGpuCardViaHex := updateNodeGpuCardViaHex
@@ -44,7 +44,7 @@ func restoreGpuSeams(t *testing.T) {
 		getNvidiaSmiDevices = origGetNvidiaSmiDevices
 		getNvidiaSmiVgpuInstances = origGetNvidiaSmiVgpuInstances
 		buildInstanceLinks = origBuildInstanceLinks
-		getOpenstackServerNames = origGetOpenstackServerNames
+		getOpenstackServers = origGetOpenstackServers
 		createConsole = origCreateConsole
 		getNodeGpuById = origGetNodeGpuById
 		updateNodeGpuCardViaHex = origUpdateNodeGpuCardViaHex
@@ -108,7 +108,7 @@ func TestListLocalGpuCardsIncludesGpusInvisibleToNvidiaSmi(t *testing.T) {
 		return &gpu.PgpuAttachedInstanceFromHex{Id: "vm-1", Name: "instance-1"}, nil
 	}
 
-	buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+	buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 		return gpu.InstanceLinks{}
 	}
 
@@ -273,7 +273,7 @@ func TestBuildLocalGpuCardReportsProfilesForVgpuCapablePgpuCard(t *testing.T) {
 	}
 
 	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-		ServerNames: map[string]string{},
+		Servers: map[string]openstackServer{},
 		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
 			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 98304},
 		},
@@ -330,7 +330,7 @@ func TestBuildLocalGpuCardReportsProfilesForMigCapableUnsetCard(t *testing.T) {
 	}
 
 	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-		ServerNames: map[string]string{},
+		Servers: map[string]openstackServer{},
 		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
 			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 81920},
 		},
@@ -369,7 +369,7 @@ func TestBuildLocalGpuCardSkipsProfileFetchForPgpuOnlyCard(t *testing.T) {
 	}
 
 	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-		ServerNames: map[string]string{},
+		Servers: map[string]openstackServer{},
 		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
 			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 16384},
 		},
@@ -419,7 +419,7 @@ func TestBuildLocalGpuCardVgpuProfiles(t *testing.T) {
 
 	h := &helper{node: "node-1"}
 	card, err := h.buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-		ServerNames: map[string]string{},
+		Servers: map[string]openstackServer{},
 		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
 			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 8192},
 		},
@@ -464,7 +464,7 @@ func TestBuildLocalGpuCardDegradesOnProfileFetchFailure(t *testing.T) {
 	}
 
 	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-		ServerNames: map[string]string{},
+		Servers: map[string]openstackServer{},
 		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
 			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 8192},
 		},
@@ -494,10 +494,10 @@ func TestBuildLocalGpuCardDegradesOnServerPrefetchFailure(t *testing.T) {
 		return map[uint32]gpu.VgpuProfileFromHex{}, gpu.VgpuProfileCollectionFromHex{}, nil
 	}
 
-	// nil ServerNames == prefetch failed. No active vGPU: the card still
+	// nil Servers == prefetch failed. No active vGPU: the card still
 	// degrades because names are unavailable.
 	card, err := (&helper{node: "node-1"}).buildLocalGpuCard(hexGpu, buildLocalGpuCardOpts{
-		ServerNames: nil,
+		Servers: nil,
 		NvidiaSmiDevices: map[string]cubecos.NvidiaSmiDevice{
 			hexGpu.Id: {UUID: hexGpu.Id, MemoryTotalMiB: 8192},
 		},
@@ -611,8 +611,8 @@ func TestListPgpuAttachedInstances(t *testing.T) {
 		}
 
 		links := gpu.InstanceLinks{Grafana: "https://grafana.example/vm-1"}
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
-			require.Equal(t, "vm-1", vmId)
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
+			require.Equal(t, "vm-1", opts.InstanceId)
 			return links
 		}
 
@@ -650,7 +650,7 @@ func TestListPgpuAttachedInstances(t *testing.T) {
 		getNodePgpuAttachedInstance = func(pciAddress string) (*gpu.PgpuAttachedInstanceFromHex, error) {
 			return &gpu.PgpuAttachedInstanceFromHex{Id: "vm-1", Name: "instance-1"}, nil
 		}
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			return gpu.InstanceLinks{}
 		}
 
@@ -725,8 +725,8 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 	})
 
 	t.Run("attached instance is reported with server name", func(t *testing.T) {
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
-			return gpu.InstanceLinks{Grafana: "https://grafana.example/" + vmId}
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
+			return gpu.InstanceLinks{Grafana: "https://grafana.example/" + opts.InstanceId}
 		}
 
 		enr := &enrichment{}
@@ -741,7 +741,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				{VmUUID: "vm-9", VgpuTypeId: profileId, MemoryUsedMiB: ptr(1024), MemoryTotalMiB: ptr(4096), GpuUtilizationPercent: ptr(uint32(33))},
 			},
 			VgpuInstancesAvailable: true,
-			ServerNames:            map[string]string{"vm-9": "instance-9"},
+			Servers:                map[string]openstackServer{"vm-9": {Name: "instance-9", TenantId: "proj-9"}},
 			Enrichment:             enr,
 		})
 
@@ -764,7 +764,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 	// A MIG-backed vGPU reports its framebuffer but N/A for utilization, so the
 	// instance must carry the memory numbers and a nil utilization.
 	t.Run("reports a MIG-backed instance without utilization", func(t *testing.T) {
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			return gpu.InstanceLinks{}
 		}
 
@@ -778,7 +778,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				{VmUUID: "vm-9", VgpuTypeId: profileId, MemoryUsedMiB: ptr(144), MemoryTotalMiB: ptr(2048)},
 			},
 			VgpuInstancesAvailable: true,
-			ServerNames:            map[string]string{"vm-9": "instance-9"},
+			Servers:                map[string]openstackServer{"vm-9": {Name: "instance-9", TenantId: "proj-9"}},
 			Enrichment:             enr,
 		})
 
@@ -795,7 +795,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 	// server map (e.g. the VM is being torn down) is reported without a name
 	// rather than failing the whole GPU listing.
 	t.Run("instance missing from server map reported without name", func(t *testing.T) {
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			return gpu.InstanceLinks{}
 		}
 
@@ -808,7 +808,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				{VmUUID: "vm-9", VgpuTypeId: profileId},
 			},
 			VgpuInstancesAvailable: true,
-			ServerNames:            map[string]string{},
+			Servers:                map[string]openstackServer{},
 			Enrichment:             enr,
 		})
 
@@ -824,7 +824,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 	// buildLocalGpuCard, not here: this layer only reports the instance without a
 	// name and does not itself degrade. See TestBuildLocalGpuCardDegradesOnServerPrefetchFailure.
 	t.Run("nil server map does not degrade at this layer", func(t *testing.T) {
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			return gpu.InstanceLinks{}
 		}
 
@@ -837,7 +837,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				{VmUUID: "vm-9", VgpuTypeId: profileId},
 			},
 			VgpuInstancesAvailable: true,
-			ServerNames:            nil,
+			Servers:                nil,
 			Enrichment:             enr,
 		})
 
@@ -850,7 +850,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 	// MIG-backed vGPU type IDs are not hex profile ids; the GI profile id is
 	// resolved via the pre-fetched type map instead of used directly.
 	t.Run("mig-backed instance resolves profile id via type map", func(t *testing.T) {
-		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			return gpu.InstanceLinks{}
 		}
 
@@ -868,7 +868,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				{VmUUID: "vm-9", VgpuTypeId: vgpuTypeId},
 			},
 			VgpuInstancesAvailable: true,
-			ServerNames:            map[string]string{},
+			Servers:                map[string]openstackServer{},
 			Enrichment:             enr,
 		})
 
@@ -893,7 +893,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				{VmUUID: "vm-9", VgpuTypeId: 0x619},
 			},
 			VgpuInstancesAvailable: true,
-			ServerNames:            map[string]string{},
+			Servers:                map[string]openstackServer{},
 			Enrichment:             enr,
 		})
 
@@ -904,12 +904,20 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 }
 
 // The list-time links carry only the Grafana dashboard; the console is minted
-// on demand via getGpuInstanceConsole and is not part of the listing.
+// on demand via getGpuInstanceConsole and is not part of the listing. All three
+// dashboard variables must be pinned, or the page labels this VM's chart with
+// another VM's name.
 func TestBuildInstanceLinksViaOpenstack(t *testing.T) {
-	links := buildInstanceLinksViaOpenstack("vm-1")
+	links := buildInstanceLinksViaOpenstack(instanceLinkOpts{
+		InstanceId: "vm-1",
+		TenantId:   "proj-1",
+		VmName:     "instance-1",
+	})
 
 	require.Contains(t, links.Grafana, "/grafana/d/PVW6vU7Wz/instance")
 	require.Contains(t, links.Grafana, "var-UUID=vm-1")
+	require.Contains(t, links.Grafana, "var-TID=proj-1")
+	require.Contains(t, links.Grafana, "var-HOSTNAME=instance-1")
 }
 
 func TestGetGpuInstanceConsole(t *testing.T) {
@@ -952,53 +960,53 @@ func TestGetGpuInstanceConsole(t *testing.T) {
 	})
 }
 
-func TestResolveServerNames(t *testing.T) {
+func TestResolveServers(t *testing.T) {
 	restoreGpuSeams(t)
 
 	t.Run("skips openstack when node has no vgpu", func(t *testing.T) {
 		called := false
-		getOpenstackServerNames = func() (map[string]string, error) {
+		getOpenstackServers = func() (map[string]openstackServer, error) {
 			called = true
 			return nil, nil
 		}
 
-		names := (&helper{node: "node-1"}).resolveServerNames(map[string]gpu.GpuFromHex{
+		servers := (&helper{node: "node-1"}).resolveServers(map[string]gpu.GpuFromHex{
 			"0000:01:00.0": {Type: gpu.ResourceTypePgpu},
 		})
 
 		require.False(t, called)
-		require.NotNil(t, names)
-		require.Empty(t, names)
+		require.NotNil(t, servers)
+		require.Empty(t, servers)
 	})
 
-	t.Run("fetches names once when a vgpu is present", func(t *testing.T) {
+	t.Run("fetches servers once when a vgpu is present", func(t *testing.T) {
 		calls := 0
-		getOpenstackServerNames = func() (map[string]string, error) {
+		getOpenstackServers = func() (map[string]openstackServer, error) {
 			calls++
-			return map[string]string{"vm-9": "instance-9"}, nil
+			return map[string]openstackServer{"vm-9": {Name: "instance-9", TenantId: "proj-9"}}, nil
 		}
 
-		names := (&helper{node: "node-1"}).resolveServerNames(map[string]gpu.GpuFromHex{
+		servers := (&helper{node: "node-1"}).resolveServers(map[string]gpu.GpuFromHex{
 			"0000:01:00.0": {Type: gpu.ResourceTypeSriovVgpu},
 			"0000:02:00.0": {Type: gpu.ResourceTypeMigBackedVgpu},
 		})
 
 		require.Equal(t, 1, calls)
-		require.Equal(t, map[string]string{"vm-9": "instance-9"}, names)
+		require.Equal(t, map[string]openstackServer{"vm-9": {Name: "instance-9", TenantId: "proj-9"}}, servers)
 	})
 
 	// A server-listing failure is enrichment: names degrade to a nil map (the
 	// unavailable sentinel) rather than failing the whole listing.
 	t.Run("returns nil on openstack error", func(t *testing.T) {
-		getOpenstackServerNames = func() (map[string]string, error) {
+		getOpenstackServers = func() (map[string]openstackServer, error) {
 			return nil, errors.New("openstack unavailable")
 		}
 
-		names := (&helper{node: "node-1"}).resolveServerNames(map[string]gpu.GpuFromHex{
+		servers := (&helper{node: "node-1"}).resolveServers(map[string]gpu.GpuFromHex{
 			"0000:01:00.0": {Type: gpu.ResourceTypeSriovVgpu},
 		})
 
-		require.Nil(t, names)
+		require.Nil(t, servers)
 	})
 }
 
@@ -1433,7 +1441,7 @@ func TestBuildLocalGpuCardReportsIsProcessing(t *testing.T) {
 		Type:       gpu.ResourceTypePgpu,
 		Status:     gpu.GpuStatusIdle,
 	}, buildLocalGpuCardOpts{
-		ServerNames:        map[string]string{},
+		Servers:            map[string]openstackServer{},
 		NvidiaSmiDevices:   map[string]cubecos.NvidiaSmiDevice{},
 		NvidiaSmiAvailable: true,
 	})

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -24,6 +24,7 @@ func restoreGpuSeams(t *testing.T) {
 	origGetNvidiaSmiDevices := getNvidiaSmiDevices
 	origGetNvidiaSmiVgpuInstances := getNvidiaSmiVgpuInstances
 	origBuildInstanceLinks := buildInstanceLinks
+	origBuildGpuCardLinks := buildGpuCardLinks
 	origGetOpenstackServers := getOpenstackServers
 	origCreateConsole := createConsole
 	origGetNodeGpuById := getNodeGpuById
@@ -44,6 +45,7 @@ func restoreGpuSeams(t *testing.T) {
 		getNvidiaSmiDevices = origGetNvidiaSmiDevices
 		getNvidiaSmiVgpuInstances = origGetNvidiaSmiVgpuInstances
 		buildInstanceLinks = origBuildInstanceLinks
+		buildGpuCardLinks = origBuildGpuCardLinks
 		getOpenstackServers = origGetOpenstackServers
 		createConsole = origCreateConsole
 		getNodeGpuById = origGetNodeGpuById
@@ -145,6 +147,15 @@ func TestListLocalGpuCardsIncludesGpusInvisibleToNvidiaSmi(t *testing.T) {
 
 	require.Equal(t, visibleUUID, visibleCard.Id)
 	require.Equal(t, "0000:02:00.0", visibleCard.PciAddress)
+	// The history links are reported per card, so they must name this card and
+	// not just the node -- otherwise every row on the node links to the same
+	// chart. They are built for a passthrough card too: the card exists, the
+	// chart simply has no series for it.
+	for _, link := range []string{visibleCard.Links.WorkloadHistory, visibleCard.Links.VramHistory} {
+		require.Contains(t, link, "var-GPU_HOST=node-1")
+		require.Contains(t, link, "var-GPU_PCIID=0000%3A02%3A00.0")
+	}
+	require.Contains(t, passthroughCard.Links.WorkloadHistory, "var-GPU_PCIID=0000%3A01%3A00.0")
 	require.Equal(t, gpu.VramInfo{
 		AllocatedMiB:       ptr(2048),
 		TotalMiB:           ptr(8192),

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -610,7 +610,7 @@ func TestListPgpuAttachedInstances(t *testing.T) {
 			return &gpu.PgpuAttachedInstanceFromHex{Id: "vm-1", Name: "instance-1"}, nil
 		}
 
-		links := gpu.InstanceLinks{Grafana: "https://grafana.example/vm-1"}
+		links := gpu.InstanceLinks{Grafana: ptr("https://grafana.example/vm-1")}
 		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			require.Equal(t, "vm-1", opts.InstanceId)
 			return links
@@ -726,7 +726,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 
 	t.Run("attached instance is reported with server name", func(t *testing.T) {
 		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
-			return gpu.InstanceLinks{Grafana: "https://grafana.example/" + opts.InstanceId}
+			return gpu.InstanceLinks{Grafana: ptr("https://grafana.example/" + opts.InstanceId)}
 		}
 
 		enr := &enrichment{}
@@ -757,7 +757,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				AllocatedMiB: ptr(1024),
 				TotalMiB:     ptr(4096),
 			},
-			Links: gpu.InstanceLinks{Grafana: "https://grafana.example/vm-9"},
+			Links: gpu.InstanceLinks{Grafana: ptr("https://grafana.example/vm-9")},
 		}, (*instances)[0])
 	})
 
@@ -914,10 +914,29 @@ func TestBuildInstanceLinksViaOpenstack(t *testing.T) {
 		VmName:     "instance-1",
 	})
 
-	require.Contains(t, links.Grafana, "/grafana/d/PVW6vU7Wz/instance")
-	require.Contains(t, links.Grafana, "var-UUID=vm-1")
-	require.Contains(t, links.Grafana, "var-TID=proj-1")
-	require.Contains(t, links.Grafana, "var-HOSTNAME=instance-1")
+	require.NotNil(t, links.Grafana)
+	require.Contains(t, *links.Grafana, "/grafana/d/PVW6vU7Wz/instance")
+	require.Contains(t, *links.Grafana, "var-UUID=vm-1")
+	require.Contains(t, *links.Grafana, "var-TID=proj-1")
+	require.Contains(t, *links.Grafana, "var-HOSTNAME=instance-1")
+}
+
+// A link that cannot pin the dashboard's variables must be absent rather than
+// wrong: without the owning project the page can chart one VM under another VM's
+// name, and a pgpu -- the case that has no tenant, because a pgpu-only node skips
+// the Openstack prefetch -- has no vGPU series to chart at all.
+func TestBuildInstanceLinksOmitsUnpinnableLink(t *testing.T) {
+	t.Run("no tenant", func(t *testing.T) {
+		links := buildInstanceLinksViaOpenstack(instanceLinkOpts{InstanceId: "vm-1", VmName: "instance-1"})
+
+		require.Nil(t, links.Grafana)
+	})
+
+	t.Run("no vm name", func(t *testing.T) {
+		links := buildInstanceLinksViaOpenstack(instanceLinkOpts{InstanceId: "vm-1", TenantId: "proj-1"})
+
+		require.Nil(t, links.Grafana)
+	})
 }
 
 func TestGetGpuInstanceConsole(t *testing.T) {

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 // Restores the test seams after each test so stubs do not leak between tests.
 func restoreGpuSeams(t *testing.T) {
 	t.Helper()
@@ -115,8 +119,8 @@ func TestListLocalGpuCardsIncludesGpusInvisibleToNvidiaSmi(t *testing.T) {
 				UUID:                     visibleUUID,
 				MemoryUsedMiB:            2048,
 				MemoryTotalMiB:           8192,
-				MemoryUtilizationPercent: 40,
-				GpuUtilizationPercent:    55,
+				MemoryUtilizationPercent: ptr(uint32(40)),
+				GpuUtilizationPercent:    ptr(uint32(55)),
 			},
 		}, nil
 	}
@@ -133,18 +137,20 @@ func TestListLocalGpuCardsIncludesGpusInvisibleToNvidiaSmi(t *testing.T) {
 	require.Equal(t, passthroughUUID, passthroughCard.Id)
 	require.Equal(t, "0000:01:00.0", passthroughCard.PciAddress)
 	require.Equal(t, gpu.GpuStatusInUse, passthroughCard.Status.Current)
-	// nvidia-smi data is unavailable for a passthrough GPU; hex data is still reported.
+	// nvidia-smi data is unavailable for a passthrough GPU; hex data is still
+	// reported. Every stat must be nil (JSON null) rather than 0, so a consumer
+	// cannot read an unmeasurable card as an idle one.
 	require.Equal(t, gpu.VramInfo{}, passthroughCard.Vram)
 	require.Equal(t, gpu.GpuInfo{}, passthroughCard.Gpu)
 
 	require.Equal(t, visibleUUID, visibleCard.Id)
 	require.Equal(t, "0000:02:00.0", visibleCard.PciAddress)
 	require.Equal(t, gpu.VramInfo{
-		AllocatedMiB:       2048,
-		TotalMiB:           8192,
-		UtilizationPercent: 40,
+		AllocatedMiB:       ptr(2048),
+		TotalMiB:           ptr(8192),
+		UtilizationPercent: ptr(uint32(40)),
 	}, visibleCard.Vram)
-	require.Equal(t, gpu.GpuInfo{UtilizationPercent: 55}, visibleCard.Gpu)
+	require.Equal(t, gpu.GpuInfo{UtilizationPercent: ptr(uint32(55))}, visibleCard.Gpu)
 
 	require.Equal(t, reservedUUID, reservedCard.Id)
 	require.Equal(t, gpu.VramInfo{}, reservedCard.Vram)
@@ -612,9 +618,9 @@ func TestListPgpuAttachedInstances(t *testing.T) {
 
 		enr := &enrichment{}
 		instances := listPgpuAttachedInstances(listAttachedInstancesOpts{
-			DeviceMemoryUsedMiB:      2048,
-			DeviceMemoryTotalMiB:     8192,
-			DeviceGpuUtilizationRate: 55,
+			DeviceMemoryUsedMiB:      ptr(2048),
+			DeviceMemoryTotalMiB:     ptr(8192),
+			DeviceGpuUtilizationRate: ptr(uint32(55)),
 			HexGpu: gpu.GpuFromHex{
 				Type:       gpu.ResourceTypePgpu,
 				Allocation: &gpu.AllocationSummary{Current: 1, Total: 1},
@@ -629,13 +635,38 @@ func TestListPgpuAttachedInstances(t *testing.T) {
 			Id:                 "vm-1",
 			Name:               "instance-1",
 			ProfileAlias:       nil,
-			UtilizationPercent: 55,
+			UtilizationPercent: ptr(uint32(55)),
 			MemoryUsage: gpu.InstanceMemoryUsage{
-				AllocatedMiB: 2048,
-				TotalMiB:     8192,
+				AllocatedMiB: ptr(2048),
+				TotalMiB:     ptr(8192),
 			},
 			Links: links,
 		}, (*instances)[0])
+	})
+
+	// A pgpu's card is invisible to nvidia-smi, so the instance inherits that
+	// absence: every stat must be nil rather than a zero that reads as idle.
+	t.Run("reports nil stats when the device is invisible", func(t *testing.T) {
+		getNodePgpuAttachedInstance = func(pciAddress string) (*gpu.PgpuAttachedInstanceFromHex, error) {
+			return &gpu.PgpuAttachedInstanceFromHex{Id: "vm-1", Name: "instance-1"}, nil
+		}
+		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+			return gpu.InstanceLinks{}
+		}
+
+		enr := &enrichment{}
+		instances := listPgpuAttachedInstances(listAttachedInstancesOpts{
+			HexGpu: gpu.GpuFromHex{
+				Type:       gpu.ResourceTypePgpu,
+				Allocation: &gpu.AllocationSummary{Current: 1, Total: 1},
+			},
+			Enrichment: enr,
+		})
+
+		require.False(t, enr.degraded)
+		require.Len(t, *instances, 1)
+		require.Nil(t, (*instances)[0].UtilizationPercent)
+		require.Equal(t, gpu.InstanceMemoryUsage{}, (*instances)[0].MemoryUsage)
 	})
 }
 
@@ -707,7 +738,7 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 			// type-map lookup involved.
 			HexProfilesMap: map[uint32]gpu.VgpuProfileFromHex{profileId: {Alias: &alias}},
 			VgpuInstances: []cubecos.NvidiaSmiVgpuInstance{
-				{VmUUID: "vm-9", VgpuTypeId: profileId, MemoryUsedMiB: 1024, MemoryTotalMiB: 4096, GpuUtilizationPercent: 33},
+				{VmUUID: "vm-9", VgpuTypeId: profileId, MemoryUsedMiB: ptr(1024), MemoryTotalMiB: ptr(4096), GpuUtilizationPercent: ptr(uint32(33))},
 			},
 			VgpuInstancesAvailable: true,
 			ServerNames:            map[string]string{"vm-9": "instance-9"},
@@ -721,13 +752,43 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 			Id:                 "vm-9",
 			Name:               "instance-9",
 			ProfileAlias:       &alias,
-			UtilizationPercent: 33,
+			UtilizationPercent: ptr(uint32(33)),
 			MemoryUsage: gpu.InstanceMemoryUsage{
-				AllocatedMiB: 1024,
-				TotalMiB:     4096,
+				AllocatedMiB: ptr(1024),
+				TotalMiB:     ptr(4096),
 			},
 			Links: gpu.InstanceLinks{Grafana: "https://grafana.example/vm-9"},
 		}, (*instances)[0])
+	})
+
+	// A MIG-backed vGPU reports its framebuffer but N/A for utilization, so the
+	// instance must carry the memory numbers and a nil utilization.
+	t.Run("reports a MIG-backed instance without utilization", func(t *testing.T) {
+		buildInstanceLinks = func(vmId string) gpu.InstanceLinks {
+			return gpu.InstanceLinks{}
+		}
+
+		enr := &enrichment{}
+		instances := listVgpuAttachedInstances(listAttachedInstancesOpts{
+			IsDeviceVisible: true,
+			DeviceUUID:      "GPU-44444444-4444-4444-4444-444444444444",
+			HexGpu:          gpu.GpuFromHex{Type: gpu.ResourceTypeMigBackedVgpu},
+			HexProfilesMap:  map[uint32]gpu.VgpuProfileFromHex{profileId: {Alias: &alias}},
+			VgpuInstances: []cubecos.NvidiaSmiVgpuInstance{
+				{VmUUID: "vm-9", VgpuTypeId: profileId, MemoryUsedMiB: ptr(144), MemoryTotalMiB: ptr(2048)},
+			},
+			VgpuInstancesAvailable: true,
+			ServerNames:            map[string]string{"vm-9": "instance-9"},
+			Enrichment:             enr,
+		})
+
+		require.False(t, enr.degraded)
+		require.Len(t, *instances, 1)
+		require.Nil(t, (*instances)[0].UtilizationPercent)
+		require.Equal(t, gpu.InstanceMemoryUsage{
+			AllocatedMiB: ptr(144),
+			TotalMiB:     ptr(2048),
+		}, (*instances)[0].MemoryUsage)
 	})
 
 	// The server name is enrichment: an instance absent from the prefetched

--- a/internal/cubecos/gpu_nvidiasmi.go
+++ b/internal/cubecos/gpu_nvidiasmi.go
@@ -15,24 +15,35 @@ import (
 // reservation out of Used that the previous NVML v1 GetMemoryInfo() call
 // folded into a single "Total - Free" number, so callers that want the old
 // allocatedMiB semantics need both fields summed back together.
+// MemoryTotalMiB and MemoryUsedMiB are plain values because a device record is
+// only returned when both were parsed (see parseNvidiaSmiDeviceBlock). The
+// utilization fields are pointers because nvidia-smi reports them as `N/A`
+// whenever the card cannot produce them at all -- most notably once MIG is
+// enabled, where NVIDIA provides no device-level utilization -- and a nil there
+// must stay distinguishable from a real 0%.
 type NvidiaSmiDevice struct {
 	UUID                     string
 	MemoryTotalMiB           int
 	MemoryUsedMiB            int
-	GpuUtilizationPercent    uint32
-	MemoryUtilizationPercent uint32
+	GpuUtilizationPercent    *uint32
+	MemoryUtilizationPercent *uint32
 }
 
 // NvidiaSmiVgpuInstance is one active vGPU instance as reported by `nvidia-smi
 // vgpu -q`. VgpuTypeId is the vGPU Type ID, which is what hex reports as the
 // profile id for both vGPU flavours, so it maps straight onto a hex profile
 // with no further lookup.
+//
+// Unlike a device record, an instance is reported as soon as it has a VM UUID,
+// so none of its stats are guaranteed present: a MIG-backed vGPU reports its
+// framebuffer but `N/A` for every utilization, and a nil must not be reported
+// as 0.
 type NvidiaSmiVgpuInstance struct {
 	VmUUID                string
 	VgpuTypeId            uint32
-	MemoryUsedMiB         int
-	MemoryTotalMiB        int
-	GpuUtilizationPercent uint32
+	MemoryUsedMiB         *int
+	MemoryTotalMiB        *int
+	GpuUtilizationPercent *uint32
 }
 
 // GetNvidiaSmiDevices runs `nvidia-smi -q` once and returns every GPU
@@ -147,11 +158,11 @@ func parseNvidiaSmiDeviceBlock(lines []string) (NvidiaSmiDevice, bool) {
 			}
 		case section == "Utilization" && key == "GPU":
 			if n, err := parseLeadingUint32Field(value); err == nil {
-				device.GpuUtilizationPercent = n
+				device.GpuUtilizationPercent = &n
 			}
 		case section == "Utilization" && key == "Memory":
 			if n, err := parseLeadingUint32Field(value); err == nil {
-				device.MemoryUtilizationPercent = n
+				device.MemoryUtilizationPercent = &n
 			}
 		}
 	}
@@ -228,15 +239,15 @@ func parseNvidiaSmiVgpuInstanceBlock(lines []string) []NvidiaSmiVgpuInstance {
 			switch {
 			case section == "FB Memory Usage" && key == "Total":
 				if n, err := parseLeadingIntField(value); err == nil {
-					current.MemoryTotalMiB = n
+					current.MemoryTotalMiB = &n
 				}
 			case section == "FB Memory Usage" && key == "Used":
 				if n, err := parseLeadingIntField(value); err == nil {
-					current.MemoryUsedMiB = n
+					current.MemoryUsedMiB = &n
 				}
 			case section == "Utilization" && key == "GPU":
 				if n, err := parseLeadingUint32Field(value); err == nil {
-					current.GpuUtilizationPercent = n
+					current.GpuUtilizationPercent = &n
 				}
 			}
 		}

--- a/internal/cubecos/gpu_nvidiasmi_test.go
+++ b/internal/cubecos/gpu_nvidiasmi_test.go
@@ -106,6 +106,10 @@ const nvidiaSmiVgpuQFixture = `GPU 00000001:C8:00.0
             Decoder                       : 0 %
 `
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestParseNvidiaSmiDevices(t *testing.T) {
 	devices := parseNvidiaSmiDevices(nvidiaSmiQFixture)
 
@@ -117,8 +121,54 @@ func TestParseNvidiaSmiDevices(t *testing.T) {
 	// Reserved(2288) + Used(5952), matching the legacy NVML v1 GetMemoryInfo
 	// "Total - Free" semantics the existing API contract keeps.
 	require.Equal(t, 8240, device.MemoryUsedMiB)
-	require.Equal(t, uint32(0), device.GpuUtilizationPercent)
-	require.Equal(t, uint32(0), device.MemoryUtilizationPercent)
+	require.Equal(t, ptr(uint32(0)), device.GpuUtilizationPercent)
+	require.Equal(t, ptr(uint32(0)), device.MemoryUtilizationPercent)
+}
+
+// Real `nvidia-smi -q` output from a MIG-enabled card on cn13, trimmed to the
+// sections that matter: the nested MIG Device block carries its own FB numbers
+// (which must not shadow the device-level ones) and every utilization is N/A,
+// because NVIDIA reports no device-level utilization once MIG is on.
+const nvidiaSmiQMigFixture = `GPU 00000001:04:00.0
+    Product Name                          : NVIDIA RTX PRO 6000 Blackwell Server Edition
+    GPU UUID                              : GPU-171566b8-60f0-9c5e-7388-59b5583f7b97
+    MIG Mode
+        Current                           : Enabled
+        Pending                           : Enabled
+    MIG Device
+        Index                             : 0
+        GPU Instance ID                   : 3
+        FB Memory Usage
+            Total                         : 23680 MiB
+            Reserved                      : 0 MiB
+            Used                          : 2029 MiB
+            Free                          : 21652 MiB
+    FB Memory Usage
+        Total                             : 97887 MiB
+        Reserved                          : 2288 MiB
+        Used                              : 2029 MiB
+        Free                              : 93572 MiB
+    Utilization
+        GPU                               : N/A
+        Memory                            : N/A
+        Encoder                           : N/A
+        Decoder                           : N/A
+`
+
+// A MIG-enabled card must report the device-level framebuffer (not the GPU
+// instance's) and nil utilization -- reporting 0% there is indistinguishable
+// from a genuinely idle card.
+func TestParseNvidiaSmiDevicesMigEnabled(t *testing.T) {
+	devices := parseNvidiaSmiDevices(nvidiaSmiQMigFixture)
+
+	device, ok := devices["GPU-171566b8-60f0-9c5e-7388-59b5583f7b97"]
+	require.True(t, ok)
+	require.Equal(t, 97887, device.MemoryTotalMiB)
+	// Reserved(2288) + Used(2029) from the device-level block, not the GPU
+	// instance's 23680/2029.
+	require.Equal(t, 4317, device.MemoryUsedMiB)
+	require.Nil(t, device.GpuUtilizationPercent)
+	require.Nil(t, device.MemoryUtilizationPercent)
 }
 
 // A device block missing a required field (no GPU UUID line, e.g. a stripped
@@ -148,18 +198,54 @@ func TestParseNvidiaSmiVgpuInstances(t *testing.T) {
 	require.Equal(t, NvidiaSmiVgpuInstance{
 		VmUUID:                "083bc63f-0a3c-4647-9bb4-27f905b7d7bb",
 		VgpuTypeId:            1519,
-		MemoryUsedMiB:         128,
-		MemoryTotalMiB:        3072,
-		GpuUtilizationPercent: 0,
+		MemoryUsedMiB:         ptr(128),
+		MemoryTotalMiB:        ptr(3072),
+		GpuUtilizationPercent: ptr(uint32(0)),
 	}, instances[0])
 
 	require.Equal(t, NvidiaSmiVgpuInstance{
 		VmUUID:                "f0adb76f-7612-4c68-84b4-375a4e6c5476",
 		VgpuTypeId:            1519,
-		MemoryUsedMiB:         128,
-		MemoryTotalMiB:        3072,
-		GpuUtilizationPercent: 12,
+		MemoryUsedMiB:         ptr(128),
+		MemoryTotalMiB:        ptr(3072),
+		GpuUtilizationPercent: ptr(uint32(12)),
 	}, instances[1])
+}
+
+// Real `nvidia-smi vgpu -q` output from cn13 with a MIG-backed vGPU
+// (GPU Instance ID set) attached to a VM whose guest driver had already
+// reported its version -- so the N/A utilization is the hardware's answer, not
+// a not-ready artifact. Framebuffer is reported, utilization is not.
+const nvidiaSmiVgpuQMigBackedFixture = `GPU 00000001:04:00.0
+    Active vGPUs                          : 1
+    vGPU ID                               : 3251669307
+        VM UUID                           : de083752-e908-421a-a965-b18f302e5cb0
+        VM Name                           : instance-00000012
+        vGPU Name                         : NVIDIA RTX Pro 6000 Blackwell DC-1-2Q
+        vGPU Type                         : 1546
+        Guest Driver Version              : 580.105.08
+        GPU Instance ID                   : 3
+        FB Memory Usage
+            Total                         : 2048 MiB
+            Used                          : 144 MiB
+            Free                          : 1904 MiB
+        Utilization
+            GPU                           : N/A
+            Memory                        : N/A
+            Encoder                       : N/A
+            Decoder                       : N/A
+`
+
+func TestParseNvidiaSmiVgpuInstancesMigBacked(t *testing.T) {
+	instances := parseNvidiaSmiVgpuInstances(nvidiaSmiVgpuQMigBackedFixture)["00000001:04:00.0"]
+
+	require.Equal(t, []NvidiaSmiVgpuInstance{{
+		VmUUID:                "de083752-e908-421a-a965-b18f302e5cb0",
+		VgpuTypeId:            1546,
+		MemoryUsedMiB:         ptr(144),
+		MemoryTotalMiB:        ptr(2048),
+		GpuUtilizationPercent: nil,
+	}}, instances)
 }
 
 func TestParseNvidiaSmiVgpuInstancesNoActiveVgpus(t *testing.T) {

--- a/internal/definition/v1/gpu/gpu.go
+++ b/internal/definition/v1/gpu/gpu.go
@@ -162,7 +162,13 @@ type InstanceMemoryUsage struct {
 }
 
 type InstanceLinks struct {
-	Grafana string `json:"grafana"`
+	// Grafana is nil when the dashboard variables cannot be pinned. The instance
+	// dashboard resolves its tenant, hostname and instance variables on load, so a
+	// link built without the owning project can label this VM's chart with another
+	// VM -- and a GPU passed through to a VM has no vGPU series to chart anyway.
+	// Same rule as the stats above: what cannot be produced correctly is absent,
+	// not zeroed.
+	Grafana *string `json:"grafana"`
 }
 
 // InstanceConsole is the on-demand console link for an attached instance. It is

--- a/internal/definition/v1/gpu/gpu.go
+++ b/internal/definition/v1/gpu/gpu.go
@@ -106,14 +106,22 @@ type GpuCard struct {
 	Degraded bool `json:"degraded"`
 }
 
+// A nil field means the number does not exist for this card, not that it is
+// zero. Two situations produce it and neither is a fault, so neither sets
+// Degraded: a card handed to a VM as a pgpu is bound to vfio-pci and invisible
+// to nvidia-smi, so it has no runtime stats at all; and a card with MIG enabled
+// reports its framebuffer but `N/A` for utilization, because NVIDIA provides no
+// device-level utilization once the card is partitioned (per-GPU-instance
+// numbers would need DCGM). Reporting 0 instead would be indistinguishable from
+// an idle card.
 type VramInfo struct {
-	AllocatedMiB       int    `json:"allocatedMiB"`
-	TotalMiB           int    `json:"totalMiB"`
-	UtilizationPercent uint32 `json:"utilizationPercent"`
+	AllocatedMiB       *int    `json:"allocatedMiB"`
+	TotalMiB           *int    `json:"totalMiB"`
+	UtilizationPercent *uint32 `json:"utilizationPercent"`
 }
 
 type GpuInfo struct {
-	UtilizationPercent uint32 `json:"utilizationPercent"`
+	UtilizationPercent *uint32 `json:"utilizationPercent"`
 }
 
 type AllocationSummary struct {
@@ -136,18 +144,21 @@ type VgpuProfile struct {
 	CountLimit *int    `json:"countLimit"`
 }
 
+// UtilizationPercent and MemoryUsage are nil for the same reasons as VramInfo's
+// fields: a pgpu's card is invisible to the host, and a MIG-backed vGPU reports
+// framebuffer but no utilization.
 type AttachedInstance struct {
 	Id                 string              `json:"id"`
 	Name               string              `json:"name"`
 	ProfileAlias       *string             `json:"profileAlias"`
-	UtilizationPercent uint32              `json:"utilizationPercent"`
+	UtilizationPercent *uint32             `json:"utilizationPercent"`
 	MemoryUsage        InstanceMemoryUsage `json:"memoryUsage"`
 	Links              InstanceLinks       `json:"links"`
 }
 
 type InstanceMemoryUsage struct {
-	AllocatedMiB int `json:"allocatedMiB"`
-	TotalMiB     int `json:"totalMiB"`
+	AllocatedMiB *int `json:"allocatedMiB"`
+	TotalMiB     *int `json:"totalMiB"`
 }
 
 type InstanceLinks struct {

--- a/internal/definition/v1/gpu/gpu.go
+++ b/internal/definition/v1/gpu/gpu.go
@@ -98,6 +98,7 @@ type GpuCard struct {
 	SriovVgpuProfileCountLimit *int                  `json:"sriovVgpuProfileCountLimit"`
 	Profiles                   GpuProfileCollection  `json:"profiles"`
 	AttachedInstances          *[]AttachedInstance   `json:"attachedInstances"`
+	Links                      GpuCardLinks          `json:"links"`
 	Status                     GpuStatusInfo         `json:"status"`
 	// Degraded is true when runtime enrichment that this card should have
 	// had (stats, attached instances) could not be obtained, so its capacity
@@ -142,6 +143,14 @@ type VgpuProfile struct {
 	Remaining  *int    `json:"remaining"`
 	AliasName  *string `json:"aliasName"`
 	CountLimit *int    `json:"countLimit"`
+}
+
+// GpuCardLinks are the history charts for this one card. They are reported
+// inline with the card because the UI offers them from its row, and a link built
+// per node would be identical on every row of the same node.
+type GpuCardLinks struct {
+	WorkloadHistory string `json:"workloadHistory"`
+	VramHistory     string `json:"vramHistory"`
 }
 
 // UtilizationPercent and MemoryUsage are nil for the same reasons as VramInfo's


### PR DESCRIPTION
### What type of PR is this?

/kind feature

<br/>

### Which issue(s) this PR fixes?

bigstack-oss/cubecos#824 and #825 (the API half).

<br/>

### What this PR does?

The UI offers "View Workload History" and "View VRAM History" from each GPU row's
menu, but the links available so far were built per node: every row on the same
node produced the same URL and the chart answered for the whole node. Worse, from
a MIG card's row you would see the other cards' lines and none for the card you
actually asked about.

Report the two links **inline with each card** in
`GET .../nodes/{nodeName}/gpuCards`:

```json
"links": {
  "workloadHistory": "https://<vip>/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=50",
  "vramHistory":     "…&viewPanel=51"
}
```

Inline rather than behind their own endpoint, for the same reason the attached
instances carry their Grafana link inline: the UI already fetches this response to
draw the table, and both values are pure string building from data in hand (node
name + the card's PCI address), so a per-row action costs no extra request.

The card is named by the new hidden `$GPU_PCIID` dashboard variable
(bigstack-oss/cubecos#1287). Its values are `gpu.host`'s `pciid` tag, which is
byte-identical to the card's `pciAddress` — verified on cn13 across all four cards
— so nothing has to be translated.

Two details worth knowing:

- **Empty pciAddress omits the variable** rather than sending it empty. The
  variable defaults to `All`; an empty value would match no card at all. That is
  what the two node-scoped `/grafana/devices/{hostname}/…` endpoints keep doing —
  they are handed only a hostname, so they cannot name a card. They are unchanged.
- **A card with no series still gets a link.** An empty chart is the honest answer
  for a passed-through GPU or for utilization on a MIG-enabled card, and it matches
  the null stats the same card reports, so nothing needs disabling in the UI.

⚠️ **Cross-team contract**: panel ids **50** (GPU Utilization) and **51** (VRAM)
in `device.json` are pinned by these links, and so is the variable name
`var-GPU_PCIID`. Renumbering or reordering that row breaks them.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

Companion PR bigstack-oss/cube-cos-openapi#108 — **merge that one first**, then
this PR's submodule pointer is re-bumped to the merged sha.

2). make sure the api works properly

`go vet` clean and `go test -count=1` green in the x86 jail container; build
produces an x86-64 binary with the regenerated spec embedded. New tests: per-card
link pins host + escaped PCI address + the right panel, and an empty PCI address
drops the variable instead of emptying it; the listing test asserts the links on
both a visible and a passthrough card.

> Depends on cubecos#1287 for the dashboard variable. Until that lands, a link
> carrying `var-GPU_PCIID` is simply ignored by the dashboard — it does not break,
> it just still shows every card.
>
> **Stacked on cube-cos-api#635 — the conflicts are already resolved.**
> An earlier version of this description claimed the two would merge cleanly in
> either order. They do not: integrating them locally conflicted in four files, so
> this branch is now rebased on top of #635 and carries its four commits as well.
> Nobody has to resolve anything at merge time.
>
> What conflicted, for the record:
>
> | file | conflict |
> | --- | --- |
> | `handlers/grafana/links_test.go` | both append tests at end of file |
> | `definition/v1/gpu/gpu.go` | one turns fields into pointers, the other adds `GpuCardLinks`, adjacent lines |
> | `handlers/nodes/gpu.go` | seam block and the new function land next to each other — and this change referenced `getOpenstackServerNames`, which #635 renames to `getOpenstackServers` |
> | `handlers/nodes/gpu_test.go` | seam save/restore, two places |
>
> All additive except the rename, which is why resolving it mechanically would have
> left code that does not compile.
>
> **Merge order: #635 first.** Once it lands, `develop` is this branch's parent and
> what remains here is a single commit — a plain fast-forward. Reviewing only this
> change is `git diff fix/823-gpu-usage-unavailable-vs-zero..fix/824-825-per-gpu-history-link`
> (5 files, +105/-12).
>
> The integrated result is what was verified: `go vet` clean, `go test -count=1`
> green, and both features confirmed together on cn13 (per-card links narrow panel
> 51 from six series to two, and the null stats still hold for MIG-backed and
> pgpu cards).
