### PR TITLE
feat(gpu): report workload and VRAM history links on a GPU-attached instance

### DIFF
--- a/internal/apis/v1/handlers/grafana/links.go
+++ b/internal/apis/v1/handlers/grafana/links.go
@@ -19,8 +19,8 @@ func genHostLink(c *gin.Context) string {
 // InstanceDashboardLink is the Grafana instance dashboard URL for a VM, as
 // served by the generic /grafana/instances/{instanceId} endpoint. That endpoint
 // knows nothing but the id, so the link cannot pin the dashboard's tenant and
-// hostname variables; callers that do know them should use
-// InstanceVgpuDashboardLink instead.
+// hostname variables; callers that do know them should use the per-VM history
+// links below instead.
 func InstanceDashboardLink(instanceId string) string {
 	return fmt.Sprintf(
 		"https://%s/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=%s",
@@ -29,14 +29,16 @@ func InstanceDashboardLink(instanceId string) string {
 	)
 }
 
-// instanceVgpuMemoryPanelId is the Memory Usage panel in the instance
-// dashboard's vGPU row (dashboard UID PVW6vU7Wz). Pinned here as a deep-link
-// target, so renumbering or reordering that row's panels in instance.json
-// breaks these links -- same cross-team contract as the device dashboard's
-// panels 50 and 51.
-const instanceVgpuMemoryPanelId = 37
+// The instance dashboard's vGPU panel ids (dashboard UID PVW6vU7Wz), pinned here
+// as deep-link targets: renumbering or reordering that row's panels in
+// instance.json breaks these links -- the same cross-team contract as the device
+// dashboard's panels 50 and 51.
+const (
+	instanceVgpuWorkloadPanelId = 36
+	instanceVgpuVramPanelId     = 37
+)
 
-// InstanceVgpuDashboardLink is the deep link to one VM's vGPU usage.
+// instanceVgpuHistoryLink is the deep link to one VM's vGPU usage.
 //
 // Pinning var-UUID alone is not enough. UUID is the tail of a
 // TID -> TENANT -> HOSTNAME -> UUID chain of query variables that all refresh on
@@ -47,10 +49,9 @@ const instanceVgpuMemoryPanelId = 37
 // the owning project; var-HOSTNAME pins the picker to this VM.
 //
 // viewPanel is required because the vGPU row ships collapsed: a link to the
-// dashboard alone lands on a page with no GPU chart visible. Memory is the panel
-// to open because it renders for every vGPU flavour, while GPU utilization is
-// empty for a MIG-backed vGPU by design.
-func InstanceVgpuDashboardLink(instanceId, tenantId, vmName string) string {
+// dashboard alone lands on a page with no GPU chart visible, so each link opens
+// the one panel it answers for.
+func instanceVgpuHistoryLink(instanceId, tenantId, vmName string, panelId int) string {
 	return fmt.Sprintf(
 		"https://%s/grafana/d/PVW6vU7Wz/instance?orgId=1&refresh=5m&var-TID=%s&var-HOSTNAME=%s&var-UUID=%s&from=now-3h&to=now&viewPanel=%d",
 		base.DataCenterVip,
@@ -58,8 +59,25 @@ func InstanceVgpuDashboardLink(instanceId, tenantId, vmName string) string {
 		// A VM name is user-supplied and may contain spaces or '&'.
 		url.QueryEscape(vmName),
 		url.QueryEscape(instanceId),
-		instanceVgpuMemoryPanelId,
+		panelId,
 	)
+}
+
+// InstanceVgpuWorkloadHistoryLink and InstanceVgpuVramHistoryLink are the
+// per-VM history links, exported for the GPU listing handler to report inline
+// with each attached instance. They mirror the card-level pair: the UI offers
+// them from one VM's row, so each has to answer for that VM.
+//
+// The workload panel is empty for a MIG-backed vGPU, whose hardware reports no
+// utilization at all -- the same "the panel exists, it just has no series" case
+// the card-level workload link already answers for on a MIG-enabled card. The
+// link says where to look; it does not promise a series.
+func InstanceVgpuWorkloadHistoryLink(instanceId, tenantId, vmName string) string {
+	return instanceVgpuHistoryLink(instanceId, tenantId, vmName, instanceVgpuWorkloadPanelId)
+}
+
+func InstanceVgpuVramHistoryLink(instanceId, tenantId, vmName string) string {
+	return instanceVgpuHistoryLink(instanceId, tenantId, vmName, instanceVgpuVramPanelId)
 }
 
 func genInstanceLink(c *gin.Context) string {

--- a/internal/apis/v1/handlers/grafana/links_test.go
+++ b/internal/apis/v1/handlers/grafana/links_test.go
@@ -14,25 +14,30 @@ func TestInstanceDashboardLink(t *testing.T) {
 	require.True(t, strings.HasSuffix(link, "var-UUID=vm-1"))
 }
 
-func TestInstanceVgpuDashboardLink(t *testing.T) {
-	link := InstanceVgpuDashboardLink("vm-1", "proj-1", "instance-1")
+func TestInstanceVgpuHistoryLinks(t *testing.T) {
+	workload := InstanceVgpuWorkloadHistoryLink("vm-1", "proj-1", "instance-1")
+	vram := InstanceVgpuVramHistoryLink("vm-1", "proj-1", "instance-1")
 
-	require.Contains(t, link, "/grafana/d/PVW6vU7Wz/instance")
-	// Pinning all three is what keeps the page from labelling this VM's chart
-	// with the tenant's alphabetically first VM.
-	require.Contains(t, link, "var-TID=proj-1")
-	require.Contains(t, link, "var-HOSTNAME=instance-1")
-	require.Contains(t, link, "var-UUID=vm-1")
-	// The vGPU row ships collapsed, so the link has to open a panel directly.
-	require.Contains(t, link, "viewPanel=37")
-	// kiosk=tv was removed in Grafana 11; it must not be carried over.
-	require.NotContains(t, link, "kiosk")
+	for _, link := range []string{workload, vram} {
+		require.Contains(t, link, "/grafana/d/PVW6vU7Wz/instance")
+		// Pinning all three is what keeps the page from labelling this VM's chart
+		// with the tenant's alphabetically first VM.
+		require.Contains(t, link, "var-TID=proj-1")
+		require.Contains(t, link, "var-HOSTNAME=instance-1")
+		require.Contains(t, link, "var-UUID=vm-1")
+		// kiosk=tv was removed in Grafana 11; it must not be carried over.
+		require.NotContains(t, link, "kiosk")
+	}
+	// The vGPU row ships collapsed, so each link has to open its own panel
+	// directly: 36 is GPU Usage, 37 is Memory Usage.
+	require.Contains(t, workload, "viewPanel=36")
+	require.Contains(t, vram, "viewPanel=37")
 }
 
 // A VM name is user-supplied: unescaped, a space or '&' would truncate or
 // corrupt the variable that follows it.
-func TestInstanceVgpuDashboardLinkEscapesValues(t *testing.T) {
-	link := InstanceVgpuDashboardLink("vm-1", "proj-1", "my vm&x")
+func TestInstanceVgpuHistoryLinkEscapesValues(t *testing.T) {
+	link := InstanceVgpuWorkloadHistoryLink("vm-1", "proj-1", "my vm&x")
 
 	require.Contains(t, link, "var-HOSTNAME=my+vm%26x")
 }

--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -45,7 +45,7 @@ var (
 // openstackServer is the per-VM enrichment an attached instance needs from
 // Openstack: its display name, and the project that owns it -- the latter only
 // so the Grafana deep link can pin the dashboard's tenant variable to the right
-// project (see grafana.InstanceVgpuDashboardLink).
+// project (see grafana.InstanceVgpuWorkloadHistoryLink).
 type openstackServer struct {
 	Name     string
 	TenantId string
@@ -664,8 +664,13 @@ type instanceLinkOpts struct {
 	VmName     string
 }
 
-// buildInstanceLinksViaOpenstack builds the links reported inline with each
-// attached instance. It deliberately carries no console link: creating a Nova
+// buildInstanceLinksViaOpenstack builds the two history links reported inline
+// with each attached instance, one per panel of the instance dashboard's vGPU
+// row. Both are pure string building from data already in hand, so they cost
+// nothing per instance and need no extra endpoint for the UI to call per row --
+// the same shape as the card-level pair.
+//
+// It deliberately carries no console link: creating a Nova
 // console is a write that mints a short-lived token, and doing it for every
 // instance on every GPU-list poll floods Nova with sessions that are almost
 // always discarded. The console is minted on demand via the dedicated
@@ -680,9 +685,10 @@ func buildInstanceLinksViaOpenstack(opts instanceLinkOpts) gpu.InstanceLinks {
 		return gpu.InstanceLinks{}
 	}
 
-	link := grafana.InstanceVgpuDashboardLink(opts.InstanceId, opts.TenantId, opts.VmName)
+	workload := grafana.InstanceVgpuWorkloadHistoryLink(opts.InstanceId, opts.TenantId, opts.VmName)
+	vram := grafana.InstanceVgpuVramHistoryLink(opts.InstanceId, opts.TenantId, opts.VmName)
 
-	return gpu.InstanceLinks{Grafana: &link}
+	return gpu.InstanceLinks{WorkloadHistory: &workload, VramHistory: &vram}
 }
 
 // getGpuInstanceConsole mints a Nova console for a single attached instance on

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -621,7 +621,10 @@ func TestListPgpuAttachedInstances(t *testing.T) {
 			return &gpu.PgpuAttachedInstanceFromHex{Id: "vm-1", Name: "instance-1"}, nil
 		}
 
-		links := gpu.InstanceLinks{Grafana: ptr("https://grafana.example/vm-1")}
+		links := gpu.InstanceLinks{
+			WorkloadHistory: ptr("https://grafana.example/vm-1?viewPanel=36"),
+			VramHistory:     ptr("https://grafana.example/vm-1?viewPanel=37"),
+		}
 		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
 			require.Equal(t, "vm-1", opts.InstanceId)
 			return links
@@ -737,7 +740,10 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 
 	t.Run("attached instance is reported with server name", func(t *testing.T) {
 		buildInstanceLinks = func(opts instanceLinkOpts) gpu.InstanceLinks {
-			return gpu.InstanceLinks{Grafana: ptr("https://grafana.example/" + opts.InstanceId)}
+			return gpu.InstanceLinks{
+				WorkloadHistory: ptr("https://grafana.example/" + opts.InstanceId + "?viewPanel=36"),
+				VramHistory:     ptr("https://grafana.example/" + opts.InstanceId + "?viewPanel=37"),
+			}
 		}
 
 		enr := &enrichment{}
@@ -768,7 +774,10 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 				AllocatedMiB: ptr(1024),
 				TotalMiB:     ptr(4096),
 			},
-			Links: gpu.InstanceLinks{Grafana: ptr("https://grafana.example/vm-9")},
+			Links: gpu.InstanceLinks{
+				WorkloadHistory: ptr("https://grafana.example/vm-9?viewPanel=36"),
+				VramHistory:     ptr("https://grafana.example/vm-9?viewPanel=37"),
+			},
 		}, (*instances)[0])
 	})
 
@@ -914,10 +923,11 @@ func TestListVgpuAttachedInstances(t *testing.T) {
 	})
 }
 
-// The list-time links carry only the Grafana dashboard; the console is minted
+// The list-time links carry the two history charts only; the console is minted
 // on demand via getGpuInstanceConsole and is not part of the listing. All three
 // dashboard variables must be pinned, or the page labels this VM's chart with
-// another VM's name.
+// another VM's name, and each link must open its own panel because the vGPU row
+// ships collapsed.
 func TestBuildInstanceLinksViaOpenstack(t *testing.T) {
 	links := buildInstanceLinksViaOpenstack(instanceLinkOpts{
 		InstanceId: "vm-1",
@@ -925,28 +935,36 @@ func TestBuildInstanceLinksViaOpenstack(t *testing.T) {
 		VmName:     "instance-1",
 	})
 
-	require.NotNil(t, links.Grafana)
-	require.Contains(t, *links.Grafana, "/grafana/d/PVW6vU7Wz/instance")
-	require.Contains(t, *links.Grafana, "var-UUID=vm-1")
-	require.Contains(t, *links.Grafana, "var-TID=proj-1")
-	require.Contains(t, *links.Grafana, "var-HOSTNAME=instance-1")
+	require.NotNil(t, links.WorkloadHistory)
+	require.NotNil(t, links.VramHistory)
+	for _, link := range []string{*links.WorkloadHistory, *links.VramHistory} {
+		require.Contains(t, link, "/grafana/d/PVW6vU7Wz/instance")
+		require.Contains(t, link, "var-UUID=vm-1")
+		require.Contains(t, link, "var-TID=proj-1")
+		require.Contains(t, link, "var-HOSTNAME=instance-1")
+	}
+	require.Contains(t, *links.WorkloadHistory, "viewPanel=36")
+	require.Contains(t, *links.VramHistory, "viewPanel=37")
 }
 
-// A link that cannot pin the dashboard's variables must be absent rather than
+// Links that cannot pin the dashboard's variables must be absent rather than
 // wrong: without the owning project the page can chart one VM under another VM's
 // name, and a pgpu -- the case that has no tenant, because a pgpu-only node skips
-// the Openstack prefetch -- has no vGPU series to chart at all.
-func TestBuildInstanceLinksOmitsUnpinnableLink(t *testing.T) {
+// the Openstack prefetch -- has no vGPU series to chart at all. The guard covers
+// both links, not just one: a half-pinned pair would still mislabel.
+func TestBuildInstanceLinksOmitsUnpinnableLinks(t *testing.T) {
 	t.Run("no tenant", func(t *testing.T) {
 		links := buildInstanceLinksViaOpenstack(instanceLinkOpts{InstanceId: "vm-1", VmName: "instance-1"})
 
-		require.Nil(t, links.Grafana)
+		require.Nil(t, links.WorkloadHistory)
+		require.Nil(t, links.VramHistory)
 	})
 
 	t.Run("no vm name", func(t *testing.T) {
 		links := buildInstanceLinksViaOpenstack(instanceLinkOpts{InstanceId: "vm-1", TenantId: "proj-1"})
 
-		require.Nil(t, links.Grafana)
+		require.Nil(t, links.WorkloadHistory)
+		require.Nil(t, links.VramHistory)
 	})
 }
 

--- a/internal/definition/v1/gpu/gpu.go
+++ b/internal/definition/v1/gpu/gpu.go
@@ -170,14 +170,22 @@ type InstanceMemoryUsage struct {
 	TotalMiB     *int `json:"totalMiB"`
 }
 
+// InstanceLinks are the history charts for one attached instance -- the VM-level
+// counterpart of GpuCardLinks, and named to match it: workload and VRAM each open
+// their own panel in the instance dashboard's vGPU row.
 type InstanceLinks struct {
-	// Grafana is nil when the dashboard variables cannot be pinned. The instance
+	// Both are nil when the dashboard variables cannot be pinned. The instance
 	// dashboard resolves its tenant, hostname and instance variables on load, so a
 	// link built without the owning project can label this VM's chart with another
-	// VM -- and a GPU passed through to a VM has no vGPU series to chart anyway.
-	// Same rule as the stats above: what cannot be produced correctly is absent,
-	// not zeroed.
-	Grafana *string `json:"grafana"`
+	// VM. Same rule as the stats above: what cannot be produced correctly is
+	// absent, not zeroed.
+	//
+	// An empty chart, unlike a wrong one, is not a reason to omit a link: a
+	// MIG-backed vGPU has no utilization series, so its workload link opens an
+	// empty panel -- exactly what the card-level workloadHistory does on a
+	// MIG-enabled card.
+	WorkloadHistory *string `json:"workloadHistory"`
+	VramHistory     *string `json:"vramHistory"`
 }
 
 // InstanceConsole is the on-demand console link for an attached instance. It is


### PR DESCRIPTION
Closes part of bigstack-oss/cubecos#823. Spec PR: bigstack-oss/cube-cos-openapi#110.

**Merge order:** openapi#110 first, then I re-bump the submodule pointer here to its merged sha, then this one. Merging this first would pin a commit that only exists on a branch.

## What changes

`attachedInstances[].links` on `GET /nodes/{nodeName}/gpuCards`:

```diff
 links:
-  grafana: <instance dashboard, viewPanel=37>
+  workloadHistory: <instance dashboard, viewPanel=36>   # GPU Usage
+  vramHistory:     <instance dashboard, viewPanel=37>   # Memory Usage
```

The single link was hardwired to Memory Usage, so a VM's **workload** history was reachable only by opening the instance dashboard's collapsed vGPU row by hand. The new pair is named to match the `workloadHistory` / `vramHistory` each GPU card already reports, so the card table and the attached-instance table speak one contract.

Both stay inline with the listing (pure string building from data already in hand — a per-row action costs no extra request). The console stays on its own endpoint for the opposite reason: minting one is a Nova write.

## Behaviour rules, unchanged in spirit

| case | workloadHistory | vramHistory | why |
| --- | --- | --- | --- |
| SR-IOV vGPU | link | link | both panels have series |
| MIG-backed vGPU | link (**empty panel**) | link | hardware reports no utilization; see below |
| tenant or VM name unresolvable (pgpu-only node, instance missing from the prefetch) | `null` | `null` | the dashboard's variables cannot be pinned, so the page would label this VM's chart with another VM |

The two are omitted **together** — a half-pinned pair mislabels just as badly as one.

## The one decision worth a second opinion

A MIG-backed vGPU has **no utilization series at all**, so its `workloadHistory` opens an empty panel. Measured on cn13 today (all three resource types carved simultaneously):

```
influx -database telegraf -execute 'SELECT last(util_gpu) AS util, last(mem_used) AS mem FROM "gpu.vm" WHERE time > now()-30m GROUP BY vm_uuid, "name"'

k8s-gpu-mig    (DC-1-12Q, MIG-backed)  util: <field absent>   mem: 784
test-mig-vgpu  (DC-1-2Q,  MIG-backed)  util: <field absent>   mem: 144
k8s-gpu-sriov  (DC-12Q,   SR-IOV)      util: 0                mem: 512
```

`util_gpu` is **absent**, not 0 — consistent with `nvidia-smi vgpu -q` reporting `Utilization → N/A` for a MIG-backed vGPU while `FB Memory Usage` is fine, and with `utilizationPercent: null` that this same response already reports for those two instances.

I kept the link and let the panel be empty, matching the merged card-level stance ("a card with no series … still gets a link; the chart is simply empty"). The alternative — `workloadHistory: null` for MIG-backed rows so the UI can disable the button — is defensible too and is a one-line change in each PR. @raven-pan your call; I'll switch both before merge if you prefer it.

## ⚠️ Frontend must land in the same release

This renames a field. `cube-cos-ui` reads `links.grafana` on an attached instance in `packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx` (Action column) — that fails to compile against the regenerated SDK, which is the intended outcome rather than silently reading `undefined`. The same row gains a second button; Console is untouched (still `GET …/gpuCards/instances/{instanceId}/console`, minted on demand).

## Submodule pointer

The bump here also catches api up to the **four** GPU doc commits already merged in cube-cos-openapi that `develop`'s pointer predates (`fab3c3b`, `ad46f27`, `c865681`, plus `058c464`). Until now the binary's embedded `docs.json` — hence the live Swagger — described neither the nullable GPU stats nor the per-card history links that are already shipping.

## Verification

Built and tested in the x86 jail container (never on the arm64 Mac):

```
yq -o=json -I=4 api/cube-cos-openapi/docs.yaml > api/docs.json     # 102 paths
CGO_ENABLED=1 GOWORK=off GOOS=linux GOARCH=amd64 go build -o bin/cube-cos-api cmd/main.go   # ok
CGO_ENABLED=1 GOWORK=off go test ./...                            # all packages ok, no FAIL
CGO_ENABLED=1 GOWORK=off go vet ./internal/apis/v1/handlers/...    # clean
```

Unit tests cover: both links pin all three dashboard variables and open panel 36 / 37 respectively; a user-supplied VM name stays escaped; both links absent when tenant or name is missing.

**Not yet verified live** — the binary is not deployed to cn13 (the only vGPU node), so the JSON above has not been curled from a running build. The pre-change response was curled there today, which is where the panel/series evidence comes from.
