### PR TITLE
fix(gpu): unblock pgpu -> vGPU switches + stop cutting off hex mid-carve

### DIFF
--- a/internal/apis/v1/handlers/nodes/gpu.go
+++ b/internal/apis/v1/handlers/nodes/gpu.go
@@ -428,13 +428,14 @@ func isSupportedType(supportTypes []gpu.SupportResourceType, t gpu.ResourceType)
 
 // validateGpuCardUpdate checks a resource-type change against the card's real
 // capabilities. profilesMap (keyed by profile Id) and totalVramMiB (from
-// nvidia-smi) are only consulted for vGPU types with profiles. Returns a
-// sentinel-wrapped error the handler maps to a status.
+// nvidia-smi) are only consulted for vGPU types with profiles; a nil
+// totalVramMiB means the card's total is unavailable and the VRAM check is
+// skipped. Returns a sentinel-wrapped error the handler maps to a status.
 func validateGpuCardUpdate(
 	card gpu.GpuFromHex,
 	req gpu.UpdateGpuCardRequest,
 	profilesMap map[uint32]gpu.VgpuProfileFromHex,
-	totalVramMiB int,
+	totalVramMiB *int,
 ) error {
 	if !isSupportedType(card.SupportTypes, req.ResourceType) {
 		return fmt.Errorf("gpu card %s does not support '%s' resource type: %w", card.Id, req.ResourceType, gpu.ErrUnsupportedType)
@@ -496,10 +497,16 @@ func validateGpuCardUpdate(
 	}
 
 	// The VRAM limit only applies to MIG-backed vGPU; SR-IOV profiles are fixed
-	// partitions constrained by the profile-count limit instead.
-	if req.ResourceType == gpu.ResourceTypeMigBackedVgpu && totalVramReqMiB > totalVramMiB {
+	// partitions constrained by the profile-count limit instead. A nil total
+	// means nvidia-smi could not report the card - the normal state of a
+	// still-vfio-bound pgpu - so the check is skipped here and left to
+	// config_gpu.cpp's ValidateVgpuProfiles, which enforces the same rule after
+	// the card is released from vfio-pci and fails closed. See
+	// getGpuTotalVramMiB.
+	if req.ResourceType == gpu.ResourceTypeMigBackedVgpu &&
+		totalVramMiB != nil && totalVramReqMiB > *totalVramMiB {
 		return fmt.Errorf("gpu %s: requested vram %d MiB exceeds device total %d MiB: %w",
-			card.Id, totalVramReqMiB, totalVramMiB, gpu.ErrExceedVramLimit)
+			card.Id, totalVramReqMiB, *totalVramMiB, gpu.ErrExceedVramLimit)
 	}
 
 	return nil
@@ -841,10 +848,10 @@ func (h *helper) updateLocalGpuCard() error {
 		return err
 	}
 
-	// vGPU profile/VRAM limits need the GPU's available profiles (hex) and its
-	// total VRAM (nvidia-smi). Only gather them when profiles are actually supplied.
+	// vGPU profile limits need the GPU's available profiles (hex). Only gather
+	// them when profiles are actually supplied.
 	var profilesMap map[uint32]gpu.VgpuProfileFromHex
-	var totalVramMiB int
+	var totalVramMiB *int
 	if isVgpuType(h.gpuCardReq.ResourceType) && len(h.gpuCardReq.Profiles) > 0 {
 		profilesMap, _, err = getNodeVgpuProfilesMap(card.Id)
 		if err != nil {
@@ -852,10 +859,13 @@ func (h *helper) updateLocalGpuCard() error {
 			return err
 		}
 
-		totalVramMiB, err = getGpuTotalVramMiB(card.Id)
-		if err != nil {
-			log.Errorf("gpu(%s): failed to get total vram for gpu %s: %v", h.reqId, h.gpuId, err)
-			return err
+		// The card's total VRAM is only ever consulted for MIG-backed vGPU;
+		// SR-IOV profiles are fixed partitions bounded by the profile-count
+		// limit instead (see validateGpuCardUpdate). Querying nvidia-smi for
+		// SR-IOV as well made a pgpu -> sriovVgpu switch fail on a value that
+		// request would never have used.
+		if h.gpuCardReq.ResourceType == gpu.ResourceTypeMigBackedVgpu {
+			totalVramMiB = getGpuTotalVramMiB(card.Id)
 		}
 	}
 
@@ -938,18 +948,41 @@ func deleteUpdatingGpuReqViaMongo(h *helper, gpuId string) error {
 	)
 }
 
-// getGpuTotalVramMiB reads the physical GPU's total VRAM via nvidia-smi. Used
-// as the budget for the vGPU VRAM-limit validation.
-func getGpuTotalVramMiB(uuid string) (int, error) {
+// getGpuTotalVramMiB reads the physical GPU's total VRAM via nvidia-smi, the
+// budget for the MIG-backed VRAM-limit validation. A nil result means "not
+// available", not "zero": the caller skips that check rather than failing the
+// request.
+//
+// The card being absent from nvidia-smi is the *expected* answer while it is
+// still a pgpu. A passthrough card is bound to vfio-pci and therefore invisible
+// to nvidia-smi (see sdk_gpu.sh's gpu_device_list and the pgpu branch of
+// gpu_release_resource), and hex only hands it back to the nvidia driver inside
+// gpu_resource_set - that is, after this validation has already run. Returning
+// an error here failed every pgpu -> migBackedVgpu switch with a 500 before hex
+// was ever called.
+//
+// Skipping the check costs nothing, because it is not the authoritative one.
+// config_gpu.cpp's ValidateVgpuProfiles runs the identical rule (its own
+// GetGpuTotalVramMiB against the same requested total) inside gpu_resource_set,
+// and it runs it *after* gpu_unbind_vfio_pci - so it reads a card nvidia-smi
+// can actually see, and it fails closed: an unreadable total is rejected there
+// rather than waved through. That check also rolls the card back to vfio-pci if
+// it trips, so a rejected request still leaves a pgpu exactly as it was. This
+// one is only an early, friendlier error for a caller who already knows the
+// card's total; when it cannot know, deferring to hex is the correct answer,
+// not a bypass.
+func getGpuTotalVramMiB(uuid string) *int {
 	devices, err := getNvidiaSmiDevices()
 	if err != nil {
-		return 0, fmt.Errorf("nvidiasmi: failed to query devices for gpu %s: %w", uuid, err)
+		log.Errorf("nvidiasmi: failed to query devices for gpu %s: %v; skipping the vram limit check", uuid, err)
+		return nil
 	}
 
 	device, ok := devices[uuid]
 	if !ok {
-		return 0, fmt.Errorf("nvidiasmi: device %s not reported by nvidia-smi", uuid)
+		log.Warnf("nvidiasmi: device %s not reported by nvidia-smi (expected while it is a vfio-bound pgpu); skipping the vram limit check", uuid)
+		return nil
 	}
 
-	return device.MemoryTotalMiB, nil
+	return &device.MemoryTotalMiB
 }

--- a/internal/apis/v1/handlers/nodes/gpu_test.go
+++ b/internal/apis/v1/handlers/nodes/gpu_test.go
@@ -1159,7 +1159,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 	totalVramMiB := 16384
 
 	t.Run("unsupported resource type -> 409 sentinel", func(t *testing.T) {
-		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypeMigBackedVgpu}, nil, 0)
+		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypeMigBackedVgpu}, nil, nil)
 		require.ErrorIs(t, err, gpu.ErrUnsupportedType)
 	})
 
@@ -1167,21 +1167,21 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypePgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}},
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrProfilesNotAllowed)
 	})
 
 	t.Run("gpu in use by status -> 409 sentinel", func(t *testing.T) {
 		inUse := card
 		inUse.Status = gpu.GpuStatusInUse
-		err := validateGpuCardUpdate(inUse, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, 0)
+		err := validateGpuCardUpdate(inUse, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, nil)
 		require.ErrorIs(t, err, gpu.ErrGpuInUse)
 	})
 
 	t.Run("gpu in use by allocation -> 409 sentinel", func(t *testing.T) {
 		inUse := card
 		inUse.Allocation = &gpu.AllocationSummary{Current: 1, Total: 1}
-		err := validateGpuCardUpdate(inUse, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, 0)
+		err := validateGpuCardUpdate(inUse, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, nil)
 		require.ErrorIs(t, err, gpu.ErrGpuInUse)
 	})
 
@@ -1189,7 +1189,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 999, Count: 1}},
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrProfileNotFound)
 	})
 
@@ -1203,7 +1203,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(limited, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 3}}, // sum 3 > limit 2
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrExceedProfileCountLimit)
 	})
 
@@ -1216,7 +1216,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeMigBackedVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 58, Count: 1}}, // total count 2 > limit 1
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.NoError(t, err)
 	})
 
@@ -1227,7 +1227,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeMigBackedVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 5}}, // vmCountLimit is 4; 2048*5 = 10240 <= 16384 so vram is not what trips
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrExceedProfileCountLimit)
 	})
 
@@ -1235,7 +1235,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 5}}, // vmCountLimit is 4, but ignored for sriov
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.NoError(t, err)
 	})
 
@@ -1246,8 +1246,22 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeMigBackedVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 58, Count: 5}}, // 4096*5 = 20480 > 16384
-		}, profilesMap, 16384)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrExceedVramLimit)
+	})
+
+	// A pgpu is bound to vfio-pci and therefore invisible to nvidia-smi, so its
+	// total VRAM is simply unknown while it is being switched over. Skip the
+	// check rather than reject a carve the driver may well accept once hex has
+	// rebound the card.
+	t.Run("mig-backed with an unknown device total skips the vram check", func(t *testing.T) {
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+		err := validateGpuCardUpdate(migCard, gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 58, Count: 5}}, // 20480 MiB: would trip a known 16384 total
+		}, profilesMap, nil)
+		require.NoError(t, err)
 	})
 
 	// SR-IOV profiles are fixed partitions; their total VRAM is not checked against device memory.
@@ -1255,12 +1269,12 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 58, Count: 5}}, // 20480 > 16384, but ignored for sriov
-		}, profilesMap, 16384)
+		}, profilesMap, &totalVramMiB)
 		require.NoError(t, err)
 	})
 
 	t.Run("valid pgpu update passes", func(t *testing.T) {
-		require.NoError(t, validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, 0))
+		require.NoError(t, validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{ResourceType: gpu.ResourceTypePgpu}, nil, nil))
 	})
 
 	// TODO: What?
@@ -1268,14 +1282,14 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		require.NoError(t, validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 2}, {Id: 58, Count: 1}}, // 2048*2+4096 = 8192
-		}, profilesMap, totalVramMiB))
+		}, profilesMap, &totalVramMiB))
 	})
 
 	t.Run("non-positive profile count -> 400 sentinel", func(t *testing.T) {
 		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 0}},
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrInvalidProfileCount)
 	})
 
@@ -1283,7 +1297,7 @@ func TestValidateGpuCardUpdate(t *testing.T) {
 		err := validateGpuCardUpdate(card, gpu.UpdateGpuCardRequest{
 			ResourceType: gpu.ResourceTypeSriovVgpu,
 			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 1}, {Id: 57, Count: 1}}, // same id twice
-		}, profilesMap, totalVramMiB)
+		}, profilesMap, &totalVramMiB)
 		require.ErrorIs(t, err, gpu.ErrDuplicateProfile)
 	})
 }
@@ -1380,7 +1394,7 @@ func TestUpdateLocalGpuCard(t *testing.T) {
 		require.True(t, deleted)
 	})
 
-	t.Run("valid sriov vgpu update gathers profiles + vram then calls hex", func(t *testing.T) {
+	t.Run("valid sriov vgpu update gathers profiles and never queries nvidia-smi", func(t *testing.T) {
 		vmLimit := 4
 		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return card, nil }
 		getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
@@ -1389,10 +1403,13 @@ func TestUpdateLocalGpuCard(t *testing.T) {
 				57: {Id: 57, VramMiB: 2048, VmCountLimit: &vmLimit},
 			}, gpu.VgpuProfileCollectionFromHex{}, nil
 		}
+		// SR-IOV never consults the card's total VRAM (its profiles are fixed
+		// partitions), and a card still bound to vfio-pci as a pgpu is invisible
+		// to nvidia-smi anyway - so asking at all turned every pgpu -> sriovVgpu
+		// switch into a 500 on a value the request would never have used.
 		getNvidiaSmiDevices = func() (map[string]cubecos.NvidiaSmiDevice, error) {
-			return map[string]cubecos.NvidiaSmiDevice{
-				"GPU-1": {UUID: "GPU-1", MemoryTotalMiB: 16384},
-			}, nil
+			t.Error("sriov vgpu validation must not query nvidia-smi")
+			return nil, nil
 		}
 
 		var hexCalled bool
@@ -1405,6 +1422,101 @@ func TestUpdateLocalGpuCard(t *testing.T) {
 
 		require.NoError(t, h.updateLocalGpuCard())
 		require.True(t, hexCalled)
+	})
+
+	// The pgpu -> migBackedVgpu path. The card is still bound to vfio-pci when
+	// this runs, so nvidia-smi cannot report it; hex only rebinds it to the
+	// nvidia driver inside gpu_resource_set, i.e. after validation. The request
+	// must therefore still reach hex instead of failing with a 500.
+	t.Run("mig-backed vgpu update proceeds when nvidia-smi cannot see the vfio-bound card", func(t *testing.T) {
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return migCard, nil }
+		// hex rebuilds a vfio-bound card's profiles from the static vGPU type
+		// XML, leaving the runtime vmCountLimit null.
+		getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+			return map[uint32]gpu.VgpuProfileFromHex{
+				57: {Id: 57, VramMiB: 2048},
+			}, gpu.VgpuProfileCollectionFromHex{}, nil
+		}
+		getNvidiaSmiDevices = func() (map[string]cubecos.NvidiaSmiDevice, error) {
+			return map[string]cubecos.NvidiaSmiDevice{}, nil // the pgpu is absent from the listing
+		}
+		upsertUpdatingGpuReq = func(h *helper, gpuId string) error { return nil }
+		deleteUpdatingGpuReq = func(h *helper, gpuId string) error { return nil }
+
+		var hexCalled bool
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error { hexCalled = true; return nil }
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 2}},
+		}}
+
+		require.NoError(t, h.updateLocalGpuCard())
+		require.True(t, hexCalled)
+	})
+
+	// nvidia-smi being unusable altogether is degraded information, not grounds
+	// to reject here: config_gpu.cpp's ValidateVgpuProfiles enforces the same
+	// VRAM rule inside gpu_resource_set - after the card leaves vfio-pci, and
+	// failing closed - so an over-committed carve is still refused.
+	t.Run("mig-backed vgpu update proceeds when nvidia-smi is unavailable", func(t *testing.T) {
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return migCard, nil }
+		getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+			return map[uint32]gpu.VgpuProfileFromHex{
+				57: {Id: 57, VramMiB: 2048},
+			}, gpu.VgpuProfileCollectionFromHex{}, nil
+		}
+		getNvidiaSmiDevices = func() (map[string]cubecos.NvidiaSmiDevice, error) {
+			return nil, errors.New("nvidia-smi not found")
+		}
+		upsertUpdatingGpuReq = func(h *helper, gpuId string) error { return nil }
+		deleteUpdatingGpuReq = func(h *helper, gpuId string) error { return nil }
+
+		var hexCalled bool
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error { hexCalled = true; return nil }
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 2}},
+		}}
+
+		require.NoError(t, h.updateLocalGpuCard())
+		require.True(t, hexCalled)
+	})
+
+	// ...and when nvidia-smi *can* report the card, the limit still bites.
+	t.Run("mig-backed vgpu update over a reported device total is rejected", func(t *testing.T) {
+		migCard := card
+		migCard.SupportTypes = []gpu.SupportResourceType{gpu.SupportResourceTypePgpu, gpu.SupportResourceTypeMigBackedVgpu}
+
+		getNodeGpuById = func(nodeName, gpuId string) (gpu.GpuFromHex, error) { return migCard, nil }
+		getNodeVgpuProfilesMap = func(gpuId string) (map[uint32]gpu.VgpuProfileFromHex, gpu.VgpuProfileCollectionFromHex, error) {
+			return map[uint32]gpu.VgpuProfileFromHex{
+				57: {Id: 57, VramMiB: 2048},
+			}, gpu.VgpuProfileCollectionFromHex{}, nil
+		}
+		getNvidiaSmiDevices = func() (map[string]cubecos.NvidiaSmiDevice, error) {
+			return map[string]cubecos.NvidiaSmiDevice{
+				"GPU-1": {UUID: "GPU-1", MemoryTotalMiB: 16384},
+			}, nil
+		}
+
+		hexCalled := false
+		updateNodeGpuCardViaHex = func(gpuId string, req gpu.UpdateGpuCardRequest) error { hexCalled = true; return nil }
+
+		h := &helper{node: "node-1", gpuId: "GPU-1", gpuCardReq: gpu.UpdateGpuCardRequest{
+			ResourceType: gpu.ResourceTypeMigBackedVgpu,
+			Profiles:     []gpu.UpdateGpuCardProfile{{Id: 57, Count: 10}}, // 2048*10 = 20480 > 16384
+		}}
+
+		require.ErrorIs(t, h.updateLocalGpuCard(), gpu.ErrExceedVramLimit)
+		require.False(t, hexCalled)
 	})
 
 	t.Run("hex failure still clears the record", func(t *testing.T) {

--- a/internal/cubecos/nodes.go
+++ b/internal/cubecos/nodes.go
@@ -415,8 +415,31 @@ func GetNodeGpuById(nodeName, gpuId string) (gpu.GpuFromHex, error) {
 
 // UpdateNodeGpuCard sets a GPU's resource type via hex_config. Profiles, when
 // present, are passed as a single JSON-string positional argument.
+//
+// The timeout is deliberately far longer than the 30s used by the read-only
+// hex_sdk calls in this file, because this call *mutates hardware*. A resource
+// switch releases the card from vfio-pci, carves it (sriov-manage -e brings up
+// 48 VFs; a MIG-backed carve enables MIG mode and creates GPU instances),
+// rewrites /etc/nova/nova.d/gpu.conf and then restarts the nova services.
+// Measured on cn13 (RTX PRO 6000 Blackwell, 2026-08-20): pgpu -> sriovVgpu took
+// 37.7s and pgpu -> migBackedVgpu 30.4s, so 30s cut the first one off mid-flight
+// and left the second passing only by luck.
+//
+// What the old timeout actually cost is worse than a slow request: CommandContext
+// SIGKILLs hex_config on expiry, i.e. it kills a process partway through
+// repartitioning a GPU, with the hardware, /etc/cube/cos/gpu/config.json and
+// nova's config able to disagree afterwards. The point of the longer budget is to
+// let that sequence finish, not merely to return a 200.
+//
+// Note the caller may still not see the result: haproxy fronting this API is
+// configured with `timeout server 1m` and nginx's /cos-api/ location takes the
+// 60s proxy_read_timeout default, so a switch that runs past a minute is reported
+// to the client as a gateway timeout regardless of the value here - the work
+// still completes. Making the response honest needs the endpoint to go
+// asynchronous (return 202 and let the caller poll Status.IsProcessing, which
+// the ReqGpuCollection record already drives); that is a separate change.
 func UpdateNodeGpuCard(gpuId string, req gpu.UpdateGpuCardRequest) error {
-	ctx, cancel := context.WithTimeout(wait.CtxSeconds(30))
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(180))
 	defer cancel()
 
 	args := []string{"gpu_resource_set", gpuId, string(req.ResourceType)}


### PR DESCRIPTION
Closes #638. No OpenAPI change: status codes and response schema are untouched, so there is no companion `cube-cos-openapi` PR and no merge-order dance.

## What changes

Two independent fixes, one per commit.

### 1. `pgpu` → vGPU no longer 500s on nvidia-smi

`updateLocalGpuCard` read the card's total VRAM from `nvidia-smi` as a pre-flight check. A `pgpu` is bound to `vfio-pci` and is invisible to nvidia-smi — hex only hands it back to the nvidia driver *inside* `gpu_resource_set`, i.e. after this validation runs. So every `pgpu` → `sriovVgpu` / `migBackedVgpu` request with profiles died before hex was called.

```diff
-if isVgpuType(h.gpuCardReq.ResourceType) && len(h.gpuCardReq.Profiles) > 0 {
-    profilesMap, _, err = getNodeVgpuProfilesMap(card.Id)
-    ...
-    totalVramMiB, err = getGpuTotalVramMiB(card.Id)   // 500s on a vfio-bound card
-    if err != nil { return err }
+if isVgpuType(h.gpuCardReq.ResourceType) && len(h.gpuCardReq.Profiles) > 0 {
+    profilesMap, _, err = getNodeVgpuProfilesMap(card.Id)
+    ...
+    if h.gpuCardReq.ResourceType == gpu.ResourceTypeMigBackedVgpu {
+        totalVramMiB = getGpuTotalVramMiB(card.Id)     // *int; nil = unknown
+    }
 }
```

Two things were wrong, and both are fixed:

| | before | after |
| --- | --- | --- |
| who needs the total | gathered for `isVgpuType()` — includes SR-IOV | only `migBackedVgpu`, matching its single use at `gpu.go:500` |
| card not reportable | error → 500 | `nil` → skip the VRAM rule, log a warning |

**Skipping is not a bypass.** `config_gpu.cpp`'s `ValidateVgpuProfiles` (L981-991) enforces the same rule inside `gpu_resource_set` — *after* `gpu_unbind_vfio_pci`, so it reads a card nvidia-smi can actually see — and it **fails closed**, rolling the card back to vfio-pci if it trips. The API-side check was a shadow of that one, running at the only point in the sequence where it could never succeed.

This also matches what the read path already does: `gpu.go:261` degrades a card nvidia-smi cannot see rather than failing it.

### 2. A resource switch gets 180s instead of 30s

Carving a GPU takes **25–60s** on real hardware (release from vfio-pci → 48 VFs or MIG mode + GPU instances → rewrite `/etc/nova/nova.d/gpu.conf` → restart nova). At 30s, `exec.CommandContext` **SIGKILLed hex_config partway through repartitioning a GPU**, and the caller got a `500 signal: killed` for work that then completed anyway. 180s matches the precedent in `firmware.go:84`; the read-only `hex_sdk` queries in that file keep their 30s.

## Verification (cn13, RTX PRO 6000 Blackwell)

Card `GPU-0a5ba9ad-…`, `pgpu` / `idle`. The node's other three cards were `inUse` and untouched; the test card was returned to `pgpu` / `vfio-pci` / `numvfs=0` afterwards.

| operation | elapsed | result |
| --- | --- | --- |
| pgpu → sriovVgpu | 33.4s | **200** (was `500 signal: killed`) |
| sriovVgpu → pgpu | 26.4s | 200 |
| pgpu → migBackedVgpu | 32.3s | 200 |

Landed state: `sriov_numvfs=48`, `driver=nvidia`, VF `0001:c8:00.2` at `current_vgpu_type=1518`, nova alias `nvidia_rtx_pro_6000_blackwell_dc_2b_1518`; for MIG, `mig.mode.current=Enabled` with GI `MIG 1g.24gb+gfx` (profile 47).

Negative cases, using card total 97887 MiB and profile 1546 (2048 MiB, `vmCountLimit=48`) so that `count=48` → 98304 MiB trips **only** the VRAM rule:

| case | result |
| --- | --- |
| unknown profile id, card visible | `400 vgpu profile 99999 not found` |
| over-commit, card **visible** | `409 requested vram 98304 MiB exceeds device total 97887 MiB` |
| over-commit, card **invisible** (pgpu) | `500 exit status 1` — hex caught it (`exceeds the 97887 MiB available`) and rolled the card back to pgpu + vfio-pci |

`go test -race ./internal/apis/v1/handlers/nodes/` green on arm64 and in the x86 jail container. Four cases added: the SR-IOV path asserts nvidia-smi is **not** queried; the MIG path proceeds both when the card is invisible and when nvidia-smi is unavailable; and the limit still bites when nvidia-smi does report the card.

## Deliberately not in scope

The false failure is rarer, not gone. haproxy fronts this API with `timeout server 1m` and nginx's `/cos-api/` takes the 60s `proxy_read_timeout` default, and measured durations (25.3–60.05s) sit right against that ceiling — one run through the proxy took 60.05s and was cut off with no body while the switch completed; the same operation direct to `:8082` took 32.3s and returned 200. Making the response honest needs the endpoint to go asynchronous (202 + polling `Status.IsProcessing`, which the `ReqGpuCollection` record already drives) — a breaking API change that needs UI coordination, so it belongs in its own ticket. Detail in #638.
