### PR TITLE
fix(licenses): locate license members by extension, not by filename

### DIFF
--- a/internal/cubecos/license.go
+++ b/internal/cubecos/license.go
@@ -2,7 +2,6 @@ package cubecos
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -362,13 +361,25 @@ func checkLicenseErr(err error) error {
 }
 
 func parseLicenseDat(file string) (*licenses.License, error) {
-	err := unzipLicense(file)
+	work, err := os.MkdirTemp(filepath.Dir(file), "members")
+	if err != nil {
+		log.Errorf("licenses: failed to create work dir(%v)", err)
+		return nil, err
+	}
+
+	defer os.RemoveAll(work)
+	err = unzipLicense(file, work)
 	if err != nil {
 		return nil, err
 	}
 
-	dir, name := getLicenseDirAndName(file)
-	dat, err := os.Open(filepath.Join(dir, fmt.Sprintf("%s.dat", name)))
+	stem, err := licenseMemberStem(work)
+	if err != nil {
+		log.Errorf("licenses: %v(%s)", err, filepath.Base(file))
+		return nil, err
+	}
+
+	dat, err := os.Open(stem + ".dat")
 	if err != nil {
 		return nil, err
 	}
@@ -378,14 +389,13 @@ func parseLicenseDat(file string) (*licenses.License, error) {
 	setLicenseDat(dat, license)
 	setLicenseDatStatus(
 		license,
-		checkImportLicense(file, *license),
+		checkImportLicense(stem, *license),
 	)
 
 	return license, nil
 }
 
-func unzipLicense(license string) error {
-	dir, _ := getLicenseDirAndName(license)
+func unzipLicense(license string, dir string) error {
 	err := zip.DecompressFromTo(license, dir)
 	if err != nil {
 		log.Errorf("licenses: failed to unzip license(%v)", err)
@@ -395,14 +405,33 @@ func unzipLicense(license string) error {
 	return nil
 }
 
-func checkImportLicense(file string, license licenses.License) error {
-	dir, file := getLicenseDirAndName(file)
+// licenseMemberStem returns the shared path prefix of the archive's .dat/.sig
+// pair. The member names need not match the uploaded filename.
+func licenseMemberStem(dir string) (string, error) {
+	dats, err := filepath.Glob(filepath.Join(dir, "*.dat"))
+	if err != nil {
+		return "", err
+	}
+
+	for _, dat := range dats {
+		stem := strings.TrimSuffix(dat, ".dat")
+		_, err := os.Stat(stem + ".sig")
+		if err == nil {
+			return stem, nil
+		}
+	}
+
+	return "", errors.ErrLicenseMalformedArchive
+}
+
+// stem is the member path prefix; hex_config license_check appends .dat/.sig.
+func checkImportLicense(stem string, license licenses.License) error {
 	product := "def"
 	if license.Product.Name == licenses.CubeCMP {
 		product = "cmp"
 	}
 
-	_, err := exec.Command("hex_config", "license_check", product, filepath.Join(dir, file)).Output()
+	_, err := exec.Command("hex_config", "license_check", product, stem).Output()
 	return checkLicenseErr(err)
 }
 

--- a/internal/cubecos/license_verify_test.go
+++ b/internal/cubecos/license_verify_test.go
@@ -1,0 +1,121 @@
+package cubecos
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeLicense builds a .license archive at dir/<filename> whose members carry
+// memberStem, which need not match filename.
+func writeLicense(t *testing.T, dir, filename, memberStem, dat string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, filename)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for ext, body := range map[string]string{"dat": dat, "sig": "signature-bytes"} {
+		w, err := zw.Create(memberStem + "." + ext)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return path
+}
+
+const testDat = "license.name=NYCU ADFP3.0\n" +
+	"license.type=enterprise\n" +
+	"issue.hardware=GRRYSF4,DVRYSF4\n" +
+	"product=CubeCOS\n"
+
+// Member names need not match the uploaded filename.
+func TestParseLicenseDatIgnoresUploadedFilename(t *testing.T) {
+	dir := t.TempDir()
+	path := writeLicense(t, dir, "nycu-adfp3-0 (1).license", "nycu-adfp3-0", testDat)
+
+	license, err := parseLicenseDat(path)
+	if err != nil {
+		t.Fatalf("parseLicenseDat: %v", err)
+	}
+	if license.Name != "NYCU ADFP3.0" {
+		t.Errorf("Name = %q, want %q", license.Name, "NYCU ADFP3.0")
+	}
+	if license.Issue.Hardware != "GRRYSF4,DVRYSF4" {
+		t.Errorf("Hardware = %q", license.Issue.Hardware)
+	}
+}
+
+// A stale pair beside the upload must not be picked up.
+func TestParseLicenseDatIgnoresStaleMembers(t *testing.T) {
+	dir := t.TempDir()
+	for _, ext := range []string{"dat", "sig"} {
+		stale := filepath.Join(dir, "someone-elses."+ext)
+		if err := os.WriteFile(stale, []byte("license.name=someone else\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	path := writeLicense(t, dir, "mine.license", "mine", testDat)
+	license, err := parseLicenseDat(path)
+	if err != nil {
+		t.Fatalf("parseLicenseDat: %v", err)
+	}
+	if license.Name != "NYCU ADFP3.0" {
+		t.Errorf("Name = %q, want the uploaded license, not the stale pair", license.Name)
+	}
+}
+
+// An archive without a .dat/.sig pair is genuinely malformed.
+func TestParseLicenseDatRejectsArchiveWithoutPair(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.license")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("readme.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte("not a license"))
+	zw.Close()
+	f.Close()
+
+	if _, err := parseLicenseDat(path); err == nil {
+		t.Fatal("parseLicenseDat accepted an archive with no .dat/.sig pair")
+	}
+}
+
+// parseLicenseDat must not leave extracted members behind.
+func TestParseLicenseDatCleansUpMembers(t *testing.T) {
+	dir := t.TempDir()
+	path := writeLicense(t, dir, "tidy.license", "tidy", testDat)
+
+	if _, err := parseLicenseDat(path); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "tidy.license" {
+			t.Errorf("left behind %q in the verify dir", e.Name())
+		}
+	}
+}

--- a/internal/definition/v1/errors/errors.go
+++ b/internal/definition/v1/errors/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrLicenseInvalidHardware       = errors.New("license's hardware serial is not matched with the current system")
 	ErrLicenseInvalidSignature      = errors.New("license's signature is invalid")
 	ErrLicenseSystemCompromised     = errors.New("license system is compromised")
+	ErrLicenseMalformedArchive      = errors.New("license archive holds no .dat/.sig pair")
 	ErrSdkExecutionFailure          = errors.New("sdk execution error")
 	ErrUnknownSettingType           = errors.New("unknown setting type")
 	ErrInvalidListenAddress         = errors.New("invalid listen address")


### PR DESCRIPTION
### What type of PR is this?

/kind bug

<br/>

### Which issue(s) this PR fixes?

Fixes #643

<br/>

### What this PR does?

Verify opened `<uploaded filename>.dat` inside the extracted archive. The `.dat`/`.sig` members carry their own stem and need not match the file's name, so any rename — by an operator, a mail client, or a browser saving a duplicate as `x (1).license` — made a valid, correctly signed license fail with the UI's generic "Invalid files." before the dialog ever appeared. Hit by NYCU on 2026-08-27.

- Locate the pair **by extension**, matching `license_import_extract` in `sdk_license.sh` (cubecos `3ae09672`). `hex` was fixed there, but the API's verify runs first, so the UI failed regardless of the SDK.
- Extract into a **per-request temp dir** and remove it afterwards. `/tmp/license_verify` is shared between uploads and was never cleaned — a lab cluster was holding members from three different licenses at once — so an extension lookup in that shared directory could have verified a *stale* license. That hazard is pinned by a test.
- `checkImportLicense` now takes the member stem, which is what `hex_config license_check` appends `.dat`/`.sig` to.
- New `ErrLicenseMalformedArchive` so an archive with no pair reads as malformed rather than as a missing file.

No API surface change, so `api/docs.json` is untouched.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

No API surface change; `api/docs.json` unchanged.

<br/>

2). make sure the api works properly

`internal/cubecos/license_verify_test.go` — 4 tests. Verified they catch the bug: with the fix reverted, `TestParseLicenseDatIgnoresUploadedFilename` and `TestParseLicenseDatCleansUpMembers` fail; all 4 pass with it.

```
=== RUN   TestParseLicenseDatIgnoresUploadedFilename   --- PASS
=== RUN   TestParseLicenseDatIgnoresStaleMembers       --- PASS
=== RUN   TestParseLicenseDatRejectsArchiveWithoutPair --- PASS
=== RUN   TestParseLicenseDatCleansUpMembers           --- PASS
ok  github.com/bigstack-oss/cube-cos-api/internal/cubecos
```

`go vet ./...` clean; `./internal/apis/...` and `./internal/cubecos/` green.

Reproduced end-to-end before the fix on a release-build cluster (cube42, 3.1.10) with the real customer license — same bytes, only the filename differing:

| uploaded as | result |
|---|---|
| `nycu-adfp3-0 (1).license` | "Invalid files." — `open …/nycu-adfp3-0 (1).dat: no such file or directory` |
| `nycu-adfp3-0.license` | verify dialog renders correctly |

**Not yet re-verified on a live cluster with this fix deployed** — worth a hot-swap check before merge.
