### PR TITLE
fix(upload): stop uploads from chmod'ing the destination directory

### DIFF
--- a/.github/workflows/fast-forward-merge.yaml
+++ b/.github/workflows/fast-forward-merge.yaml
@@ -5,20 +5,33 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   merge:
+    permissions:
+      contents: write  # for Git to git push
     if: ${{ github.event.label.name == 'done' && github.event.pull_request.mergeable == true }}
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Check Out PR Target Branch
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0 # fetches all history for all branches and tags
       - name: Merge
         env: 
           TOPIC_BRANCH: ${{ github.head_ref }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
-          git pull origin $TOPIC_BRANCH
-          git checkout $TOPIC_BRANCH
-          git checkout @{-1}
+          git fetch origin $TOPIC_BRANCH
+          git checkout $BASE_BRANCH
           git branch
-          git merge --ff-only $TOPIC_BRANCH
-          git push
+          git merge --ff-only origin/$TOPIC_BRANCH
+          git push origin $BASE_BRANCH

--- a/internal/apis/v1/handlers/integrations/file.go
+++ b/internal/apis/v1/handlers/integrations/file.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/storages"
+	"github.com/bigstack-oss/cube-cos-api/internal/upload"
 	log "go-micro.dev/v5/logger"
 	"gopkg.in/yaml.v3"
 )
@@ -15,7 +16,7 @@ func (h *helper) loadStorageModel() error {
 		return err
 	}
 
-	err = h.c.SaveUploadedFile(list, storages.TmpUploadedStorageModel)
+	err = upload.Save(list, storages.TmpUploadedStorageModel)
 	if err != nil {
 		log.Errorf("storages(%s): failed to save storage model(%v)", h.reqId, err)
 		return err
@@ -40,7 +41,7 @@ func (h *helper) loadStorageModelList() error {
 		return err
 	}
 
-	err = h.c.SaveUploadedFile(list, storages.TmpUploadedStorageModelList)
+	err = upload.Save(list, storages.TmpUploadedStorageModelList)
 	if err != nil {
 		log.Errorf("storages(%s): failed to save storage models(%v)", h.reqId, err)
 		return err

--- a/internal/apis/v1/handlers/licenses/helper.go
+++ b/internal/apis/v1/handlers/licenses/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/pages"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/status"
+	"github.com/bigstack-oss/cube-cos-api/internal/upload"
 	"github.com/gin-gonic/gin"
 	log "go-micro.dev/v5/logger"
 )
@@ -59,7 +60,7 @@ func (h *helper) storeVerifyLicense() (string, error) {
 		return "", err
 	}
 
-	err = h.c.SaveUploadedFile(license, filePath)
+	err = upload.Save(license, filePath)
 	if err != nil {
 		log.Errorf("licenses(%s): failed to save license file: %v", h.reqId, err)
 		return "", err
@@ -81,7 +82,7 @@ func (h *helper) storeImportLicense() (string, error) {
 		return "", err
 	}
 
-	err = h.c.SaveUploadedFile(license, filePath)
+	err = upload.Save(license, filePath)
 	if err != nil {
 		log.Errorf("licenses(%s): failed to save license file: %v", h.reqId, err)
 		return "", err

--- a/internal/apis/v1/handlers/licenses/license.go
+++ b/internal/apis/v1/handlers/licenses/license.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bigstack-oss/cube-cos-api/internal/cubecos"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/licenses"
 	"github.com/bigstack-oss/cube-cos-api/internal/definition/v1/nodes"
+	"github.com/bigstack-oss/cube-cos-api/internal/upload"
 	log "go-micro.dev/v5/logger"
 )
 
@@ -100,7 +101,7 @@ func (h *helper) importLocal(license *multipart.FileHeader) error {
 		return err
 	}
 
-	err = h.c.SaveUploadedFile(license, filePath)
+	err = upload.Save(license, filePath)
 	if err != nil {
 		log.Errorf("licenses(%s): failed to save license file: %v", h.reqId, err)
 		return err

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -1,0 +1,31 @@
+package upload
+
+import (
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+)
+
+// Save stores an uploaded file without changing the mode of the destination
+// directory. gin's SaveUploadedFile chmods filepath.Dir(dst) on every save.
+func Save(file *multipart.FileHeader, dst string) error {
+	src, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return err
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, src)
+	return err
+}

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1,0 +1,97 @@
+package upload
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// gin >= v1.12 chmods the destination's parent directory on every save.
+func TestSaveKeepsDirMode(t *testing.T) {
+	dir := t.TempDir()
+	want := os.FileMode(0o777) | os.ModeSticky
+	if err := os.Chmod(dir, want); err != nil {
+		t.Fatal(err)
+	}
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	fw, err := w.CreateFormFile("file", "storage-model.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte("backends: []\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest("POST", "/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	c.Request = req
+
+	fh, err := c.FormFile("file")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(dir, "storage-model.yaml")
+	if err := Save(fh, dst); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("uploaded file not written: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode() & (os.ModePerm | os.ModeSticky); got != want {
+		t.Fatalf("upload changed the destination directory mode: got %v, want %v", got, want)
+	}
+}
+
+// A directory Save creates must not be world-accessible.
+func TestSaveCreatesDirNotWorldReadable(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cos-storages")
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	fw, err := w.CreateFormFile("file", "storage-model.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte("backends: []\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest("POST", "/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	c.Request = req
+
+	fh, err := c.FormFile("file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(fh, filepath.Join(dir, "storage-model.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got&0o007 != 0 {
+		t.Fatalf("created directory is world-accessible: %04o", got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

gin v1.12.0 changed `SaveUploadedFile` to chmod the destination's **parent directory**:

```go
var mode os.FileMode = 0o750
dir := filepath.Dir(dst)
os.MkdirAll(dir, mode)
os.Chmod(dir, mode)     // added in v1.12; v1.10 did not do this
```

We save storage-model uploads straight into `/tmp`, so `POST …/integrations/storages/models`
ran `chmod 0750 /tmp` as root — and the handler re-uploads the file to the peer control nodes,
so the whole control plane flipped in one request. `mysql` could then no longer create on-disk
temp tables (`Can't create/write to file '/tmp/#sql-temptable-….MAI' (Errcode: 13)`), and every
OpenStack call needing one returned 500, surfacing misleadingly as
`Cell 00000000-…-000000000000 is not responding`. License uploads did the same to `/var/support`.

`upload.Save` writes the file itself — open, `MkdirAll`, `os.Create`, `io.Copy` — the way the image
and volume handlers in this repo already do. It never chmods anything: `MkdirAll` leaves an existing
directory untouched, and the `0750` applies only when it has to create the directory. Used at all five
gin call sites (2 storage-model, 3 license).

Going through gin with an explicit `perm` was the first approach, but gin's chmod is unconditional —
`perm` only chooses which mode it forces — so it still rewrites the directory's permissions, and it
needs a mode to guess with when the directory doesn't exist. Writing the file directly removes the
question entirely.

`internal/upload/upload_test.go` pins both properties: an existing directory's mode is unchanged (this
test fails against the gin call path, `trwxrwxrwx` → `-rwxr-x---`), and a directory we create is not
world-accessible.

#### Which issue(s) this PR fixes

bigstack-oss/cubecos#1393 (cross-repo, so it will not auto-close — please close it by hand on merge)

#### Special notes for your reviewer

> Note

- Based on `release_3.1.10`; 3.1.0 shipped gin v1.10.0 and is unaffected, 3.1.10 and 3.1.20 both
  ship v1.12.0. Confirmed on the affected cluster by diffing the two firmware slots:
  `strings /usr/local/bin/cube-cos-api | grep -oE 'gin-gonic/gin@v[0-9.]+'` → `v1.10.0` on the
  3.1.0 slot, `v1.12.0` on the 3.1.10 slot.
- The image/volume upload paths are *not* affected — those handlers have their own
  `SaveUploadedFile` built on `os.Create` + `io.Copy` and never call gin's.
- No upload paths are changed. An earlier revision also moved the storage-model constants under
  `/tmp/cos-storages/`; that was dropped as unnecessary once nothing chmods the directory, and two of
  the four constants it touched (`TmpUploadedStorage`, `TmpUploadedStorageList`) turn out to be unused.
- Once this is released, `core/api/Makefile` in cubecos needs its RPM URL bumped to the new tag for
  the fix to reach the image.

#### Additional documentation

```docs

```
